### PR TITLE
Add Custom Shiki Theme Support via React Context

### DIFF
--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -101,7 +101,9 @@ export const Streamdown = memo(
       </ShikiThemeContext.Provider>
     );
   },
-  (prevProps, nextProps) => prevProps.children === nextProps.children
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    prevProps.shikiTheme === nextProps.shikiTheme
 );
 Streamdown.displayName = 'Streamdown';
 

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import type { ComponentProps } from 'react';
-import { memo, useId, useMemo } from 'react';
+import { createContext, memo, useId, useMemo } from 'react';
 import ReactMarkdown, { type Options } from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
+import type { BundledTheme } from 'shiki';
 import 'katex/dist/katex.min.css';
 import hardenReactMarkdownImport from 'harden-react-markdown';
 import { components as defaultComponents } from './lib/components';
@@ -30,7 +30,10 @@ const HardenedMarkdown: ReturnType<typeof hardenReactMarkdown> =
 export type StreamdownProps = HardenReactMarkdownProps & {
   parseIncompleteMarkdown?: boolean;
   className?: string;
+  shikiTheme?: BundledTheme;
 };
+
+export const ShikiThemeContext = createContext<BundledTheme>('github-light');
 
 type BlockProps = HardenReactMarkdownProps & {
   content: string;
@@ -63,6 +66,7 @@ export const Streamdown = memo(
     rehypePlugins,
     remarkPlugins,
     className,
+    shikiTheme = 'github-light',
     ...props
   }: StreamdownProps) => {
     // Parse the children to remove incomplete markdown tokens if enabled
@@ -74,25 +78,27 @@ export const Streamdown = memo(
     );
 
     return (
-      <div className={cn('space-y-4', className)} {...props}>
-        {blocks.map((block, index) => (
-          <Block
-            allowedImagePrefixes={allowedImagePrefixes ?? ['*']}
-            allowedLinkPrefixes={allowedLinkPrefixes ?? ['*']}
-            components={{
-              ...defaultComponents,
-              ...components,
-            }}
-            content={block}
-            defaultOrigin={defaultOrigin}
-            // biome-ignore lint/suspicious/noArrayIndexKey: "required"
-            key={`${generatedId}-block_${index}`}
-            rehypePlugins={[rehypeKatex, ...(rehypePlugins ?? [])]}
-            remarkPlugins={[remarkGfm, remarkMath, ...(remarkPlugins ?? [])]}
-            shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
-          />
-        ))}
-      </div>
+      <ShikiThemeContext.Provider value={shikiTheme}>
+        <div className={cn('space-y-4', className)} {...props}>
+          {blocks.map((block, index) => (
+            <Block
+              allowedImagePrefixes={allowedImagePrefixes ?? ['*']}
+              allowedLinkPrefixes={allowedLinkPrefixes ?? ['*']}
+              components={{
+                ...defaultComponents,
+                ...components,
+              }}
+              content={block}
+              defaultOrigin={defaultOrigin}
+              // biome-ignore lint/suspicious/noArrayIndexKey: "required"
+              key={`${generatedId}-block_${index}`}
+              rehypePlugins={[rehypeKatex, ...(rehypePlugins ?? [])]}
+              remarkPlugins={[remarkGfm, remarkMath, ...(remarkPlugins ?? [])]}
+              shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
+            />
+          ))}
+        </div>
+      </ShikiThemeContext.Provider>
     );
   },
   (prevProps, nextProps) => prevProps.children === nextProps.children

--- a/packages/streamdown/lib/code-block.tsx
+++ b/packages/streamdown/lib/code-block.tsx
@@ -9,7 +9,8 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { type BundledLanguage, codeToHtml } from 'shiki';
+import { type BundledLanguage, type BundledTheme, codeToHtml } from 'shiki';
+import { ShikiThemeContext } from '../index';
 import { cn } from './utils';
 
 type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
@@ -25,10 +26,14 @@ const CodeBlockContext = createContext<CodeBlockContextType>({
   code: '',
 });
 
-export async function highlightCode(code: string, language: BundledLanguage) {
+export async function highlightCode(
+  code: string,
+  language: BundledLanguage,
+  theme: BundledTheme
+) {
   return await codeToHtml(code, {
     lang: language,
-    theme: 'github-light',
+    theme,
   });
 }
 
@@ -40,11 +45,12 @@ export const CodeBlock = ({
   ...props
 }: CodeBlockProps) => {
   const [html, setHtml] = useState<string>('');
+  const theme = useContext(ShikiThemeContext);
 
   useEffect(() => {
     let isMounted = true;
 
-    highlightCode(code, language).then((result) => {
+    highlightCode(code, language, theme).then((result) => {
       if (isMounted) {
         setHtml(result);
       }
@@ -53,7 +59,7 @@ export const CodeBlock = ({
     return () => {
       isMounted = false;
     };
-  }, [code, language]);
+  }, [code, language, theme]);
 
   return (
     <CodeBlockContext.Provider value={{ code }}>


### PR DESCRIPTION
Thank you for this great library! I tried it out right away and it feels very natural.

This PR introduces the ability to specify custom Shiki themes for syntax highlighting through React Context, enabling seamless integration with applications using dark mode or other custom color schemes.

### Problem
The library currently hard-codes the `github-light` theme for syntax highlighting, which creates a visual inconsistency when integrated into applications with dark mode interfaces. In our use case at [Giselle](https://giselles.ai/), the light theme clashes with our dark mode design system.

### Solution
Implemented a React Context-based approach that allows consumers to specify custom Shiki themes via the `shikiTheme` prop while maintaining backward compatibility with the default `github-light` theme.

### Implementation Details

#### Changes Made
- **Added `ShikiThemeContext`**: Created a new context with `github-light` as the default theme
- **Added `shikiTheme` prop**: New optional prop on `StreamdownProps` to specify the desired theme
- **Updated `CodeBlock` component**: Modified to consume theme from context instead of hard-coded value
- **Updated `highlightCode` function**: Now accepts theme as a parameter for dynamic highlighting

#### Code Changes
- `packages/streamdown/index.tsx`: 
  - Added `ShikiThemeContext` creation and provider
  - Added `shikiTheme` prop to `StreamdownProps`
  - Wrapped component tree with `ShikiThemeContext.Provider`
- `packages/streamdown/lib/code-block.tsx`:
  - Modified `highlightCode` to accept theme parameter
  - Updated `CodeBlock` to use context theme

### Usage Example
```jsx
import { Streamdown } from 'streamdown';

// Using with dark theme
function CustomApp() {
  return (
    <Streamdown shikiTheme="github-dark">
      {markdownContent}
    </Streamdown>
  );
}

// Default behavior (no changes needed)
function DefaultApp() {
  return (
    <Streamdown>
      {markdownContent}
    </Streamdown>
  );
}
```

### Demo

https://github.com/user-attachments/assets/55146f44-7d90-4bc8-a9dc-96469a1ccaa2


### Supported Themes
All Shiki bundled themes are supported, including but not limited to:
- `github-light` (default)
- `github-dark`
- `github-dark-dimmed`
- `dracula`
- `nord`
- `monokai`
- `one-dark-pro`
- And many more...
