### PR TITLE
Support React 18

### DIFF
--- a/packages/streamdown/package.json
+++ b/packages/streamdown/package.json
@@ -39,7 +39,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "react": "^19.1.1"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
Change peerDependencies to `"react": "^18.0.0 || ^19.0.0"`

Without this, I cannot use the package in a project with React 18:

```
$ npm i
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: streamdown@1.0.11
npm error Found: react@18.3.1
npm error node_modules/react
npm error   react@"^18.3.1" from the root project
npm error   peer react@"^18 || ^19 || ^19.0.0-rc" from @ai-sdk/react@2.0.19
npm error   node_modules/@ai-sdk/react
npm error     @ai-sdk/react@"^2.0.19" from the root project
npm error   119 more (@floating-ui/react-dom, @nostrify/react, ...)
npm error
npm error Could not resolve dependency:
npm error peer react@"^19.1.1" from streamdown@1.0.11
npm error node_modules/streamdown
npm error   streamdown@"^1.0.11" from the root project
npm error
npm error Conflicting peer dependency: react@19.1.1
npm error node_modules/react
npm error   peer react@"^19.1.1" from streamdown@1.0.11
npm error   node_modules/streamdown
npm error     streamdown@"^1.0.11" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /home/alex/.npm/_logs/2025-08-20T21_14_53_950Z-eresolve-report.txt
npm error A complete log of this run can be found in: /home/alex/.npm/_logs/2025-08-20T21_14_53_950Z-debug-0.log
```