### PR TITLE
docs: add shikiTheme prop to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Streamdown accepts all the same props as react-markdown, plus additional streami
 | `rehypePlugins` | `array` | `[rehypeKatex]` | Rehype plugins to use |
 | `allowedImagePrefixes` | `array` | `['*']` | Allowed image URL prefixes |
 | `allowedLinkPrefixes` | `array` | `['*']` | Allowed link URL prefixes |
+| `shikiTheme` | `BundledTheme` (from Shiki) | `github-light` | The theme to use for code blocks |
 
 ## Architecture
 


### PR DESCRIPTION
It's missing in the README.md