### PR TITLE
Update README.md for dev to build streamdown first

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Streamdown is built as a monorepo with:
 # Install dependencies
 pnpm install
 
+# Build the streamdown package
+pnpm --filter streamdown build
+
 # Run development server
 pnpm dev
 


### PR DESCRIPTION
Adds the step to build the streamdown package first, since otherwise it won't find the module in the workspace.