### PR TITLE
fix: handleincompletesingleunderscoreitalic is not accounting for the usage inside math equations

### DIFF
--- a/.changeset/cuddly-goats-warn.md
+++ b/.changeset/cuddly-goats-warn.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+fix: handleIncompleteSingleUnderscoreItalic is not accounting for the usage inside math equations

--- a/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
+++ b/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
@@ -626,6 +626,73 @@ describe('parseIncompleteMarkdown', () => {
     });
   });
 
+  describe('math blocks with underscores', () => {
+    it('should not complete underscores within inline math blocks', () => {
+      const text = 'The variable $x_1$ represents the first element';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+      
+      const text2 = 'Formula: $a_b + c_d = e_f$';
+      expect(parseIncompleteMarkdown(text2)).toBe(text2);
+    });
+
+    it('should not complete underscores within block math', () => {
+      const text = '$$x_1 + y_2 = z_3$$';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+      
+      const text2 = '$$\na_1 + b_2\nc_3 + d_4\n$$';
+      expect(parseIncompleteMarkdown(text2)).toBe(text2);
+    });
+
+    it('should not add underscore when math block has incomplete underscore', () => {
+      // Incomplete math blocks get completed by handleIncompleteInlineKatex
+      // The underscore inside should not be treated as italic
+      const text = 'Math expression $x_';
+      expect(parseIncompleteMarkdown(text)).toBe('Math expression $x_$');
+      
+      const text2 = '$$formula_';
+      expect(parseIncompleteMarkdown(text2)).toBe('$$formula_$$');
+    });
+
+    it('should handle underscores outside math blocks normally', () => {
+      const text = 'Text with _italic_ and math $x_1$';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+      
+      const text2 = '_italic text_ followed by $a_b$';
+      expect(parseIncompleteMarkdown(text2)).toBe(text2);
+    });
+
+    it('should complete italic underscore outside math but not inside', () => {
+      const text = 'Start _italic with $x_1$';
+      expect(parseIncompleteMarkdown(text)).toBe('Start _italic with $x_1$_');
+    });
+
+    it('should handle complex math expressions with multiple underscores', () => {
+      const text = '$x_1 + x_2 + x_3 = y_1$';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+      
+      const text2 = '$$\\sum_{i=1}^{n} x_i = \\prod_{j=1}^{m} y_j$$';
+      expect(parseIncompleteMarkdown(text2)).toBe(text2);
+    });
+
+    it('should handle escaped dollar signs correctly', () => {
+      const text = 'Price is \\$50 and _this is italic_';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+      
+      const text2 = 'Cost \\$100 with _incomplete';
+      expect(parseIncompleteMarkdown(text2)).toBe('Cost \\$100 with _incomplete_');
+    });
+
+    it('should handle mixed inline and block math', () => {
+      const text = 'Inline $x_1$ and block $$y_2$$ math';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+    });
+
+    it('should not interfere with complete math blocks when adding underscores outside', () => {
+      const text = '_italic start $x_1$ italic end_';
+      expect(parseIncompleteMarkdown(text)).toBe(text);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle text ending with formatting characters', () => {
       expect(parseIncompleteMarkdown('Text ending with *')).toBe(

--- a/packages/streamdown/lib/parse-incomplete-markdown.ts
+++ b/packages/streamdown/lib/parse-incomplete-markdown.ts
@@ -81,7 +81,36 @@ const handleIncompleteSingleAsteriskItalic = (text: string): string => {
   return text;
 };
 
-// Counts single underscores that are not part of double underscores and not escaped
+// Check if a position is within a math block (between $ or $$)
+const isWithinMathBlock = (text: string, position: number): boolean => {
+  // Count dollar signs before this position
+  let inInlineMath = false;
+  let inBlockMath = false;
+  
+  for (let i = 0; i < text.length && i < position; i++) {
+    // Skip escaped dollar signs
+    if (text[i] === '\\' && text[i + 1] === '$') {
+      i++; // Skip the next character
+      continue;
+    }
+    
+    if (text[i] === '$') {
+      // Check for block math ($$)
+      if (text[i + 1] === '$') {
+        inBlockMath = !inBlockMath;
+        i++; // Skip the second $
+        inInlineMath = false; // Block math takes precedence
+      } else if (!inBlockMath) {
+        // Only toggle inline math if not in block math
+        inInlineMath = !inInlineMath;
+      }
+    }
+  }
+  
+  return inInlineMath || inBlockMath;
+};
+
+// Counts single underscores that are not part of double underscores, not escaped, and not in math blocks
 const countSingleUnderscores = (text: string): number => {
   return text.split('').reduce((acc, char, index) => {
     if (char === '_') {
@@ -89,6 +118,10 @@ const countSingleUnderscores = (text: string): number => {
       const nextChar = text[index + 1];
       // Skip if escaped with backslash
       if (prevChar === '\\') {
+        return acc;
+      }
+      // Skip if within math block
+      if (isWithinMathBlock(text, index)) {
         return acc;
       }
       if (prevChar !== '_' && nextChar !== '_') {


### PR DESCRIPTION
This pull request addresses a bug in the markdown parser related to handling single underscores used for italics when they appear inside math equations. The core improvement ensures that underscores inside math blocks (delimited by `$... or `$...$`) are not incorrectly interpreted as markdown italics, while underscores outside math blocks continue to be handled as before. Comprehensive tests have been added to verify correct behavior for various edge cases in math and markdown parsing.

**Bug fix for markdown parsing in math blocks:**

* Updated the logic in `countSingleUnderscores` within `parse-incomplete-markdown.ts` to skip underscores that are inside math blocks, using a new helper function `isWithinMathBlock`. This prevents underscores inside `$... or `$...$` from being treated as markdown italics. [[1]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cL84-R113) [[2]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR123-R126)
* Added the helper function `isWithinMathBlock` to detect whether a character position is inside an inline or block math region, correctly handling escaped dollar signs and precedence between inline and block math.

**Expanded test coverage:**

* Added a new test suite in `parse-incomplete-markdown.test.ts` to verify that underscores inside math blocks are not completed as italics, while underscores outside math blocks are handled normally. The tests cover inline math, block math, incomplete math blocks, mixed content, and escaped dollar signs.

**Documentation and changelog:**

* Added a changeset entry documenting the patch fix for handling incomplete single underscore italics inside math equations.