### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,35 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.STREAMDOWN_APP_ID }}
+          private-key: ${{ secrets.STREAMDOWN_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Setup Git User
+        run: |
+          git config --global user.email "streamdown-bot[bot]@users.noreply.github.com"
+          git config --global user.name "streamdown-bot[bot]"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -24,6 +44,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: pnpm i
@@ -34,6 +55,9 @@ jobs:
         with:
           version: pnpm changeset version
           publish: pnpm changeset publish
+          createGithubReleases: true
+          setupGitUser: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -12,27 +12,43 @@ on:
     paths:
       - '.changeset/*.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   verify-changesets:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.STREAMDOWN_APP_ID }}
+          private-key: ${{ secrets.STREAMDOWN_APP_PRIVATE_KEY }}
+      
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+      
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+      
       - name: get all changed files from .changeset/*.md
         id: changeset-files
         run: |
           echo "changed-files=$(git diff --diff-filter=dr --name-only $BASE_SHA -- '.changeset/*.md' | tr '\n' ' ')" >> $GITHUB_OUTPUT
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      
       - name: Verify changesets
         if: steps.changeset-files.outputs.changed-files != ''
         working-directory: .github/workflows/actions/verify-changesets
         run: |
           node index.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CHANGED_FILES: ${{ steps.changeset-files.outputs.changed-files }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both release and changeset verification to improve security, automation, and permissions management. The main changes involve switching to GitHub App authentication, refining permissions, and ensuring tokens are used correctly for all steps.

**Release workflow improvements:**

* Added explicit permissions for `contents`, `pull-requests`, and `id-token`, and set a timeout for the release job to prevent long-running processes.
* Integrated GitHub App authentication by generating a token using `actions/create-github-app-token@v1`, and updated all relevant steps to use this token for repository access and publishing. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R10-R38) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R58-R62)
* Updated the Node setup step to specify the npm registry URL for publishing.
* Enhanced the changeset publishing step to automatically create GitHub releases and clarified git user setup behavior.

**Changeset verification workflow improvements:**

* Added explicit read permissions for `contents` and `pull-requests`, set a timeout for the job, and switched to GitHub App authentication for secure token generation and usage throughout the workflow.