### PR TITLE
fix: codeblock dark mode and background

### DIFF
--- a/.changeset/yellow-webs-follow.md
+++ b/.changeset/yellow-webs-follow.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+fix: codeblock dark mode and background

--- a/apps/website/app/components/footer.tsx
+++ b/apps/website/app/components/footer.tsx
@@ -3,7 +3,7 @@ import { ModeToggle } from '@/components/mode-toggle';
 export const Footer = () => (
   <footer className="px-4 py-8">
     <div className="flex items-center justify-between">
-      <div className="flex-1 text-center text-muted-foreground text-sm">
+      <div className="text-muted-foreground text-sm">
         <p>
           Made with 🖤 and 🤖 by{' '}
           <a

--- a/apps/website/app/components/footer.tsx
+++ b/apps/website/app/components/footer.tsx
@@ -1,27 +1,32 @@
+import { ModeToggle } from '@/components/mode-toggle';
+
 export const Footer = () => (
   <footer className="px-4 py-8">
-    <div className="text-center text-muted-foreground text-sm">
-      <p>
-        Made with 🖤 and 🤖 by{' '}
-        <a
-          className="font-medium text-blue-600 underline"
-          href="https://vercel.com"
-          rel="noopener"
-          target="_blank"
-        >
-          Vercel
-        </a>
-        . View the{' '}
-        <a
-          className="font-medium text-blue-600 underline"
-          href="https://github.com/vercel/streamdown"
-          rel="noopener"
-          target="_blank"
-        >
-          source code
-        </a>
-        .
-      </p>
+    <div className="flex items-center justify-between">
+      <div className="flex-1 text-center text-muted-foreground text-sm">
+        <p>
+          Made with 🖤 and 🤖 by{' '}
+          <a
+            className="font-medium text-blue-600 underline"
+            href="https://vercel.com"
+            rel="noopener"
+            target="_blank"
+          >
+            Vercel
+          </a>
+          . View the{' '}
+          <a
+            className="font-medium text-blue-600 underline"
+            href="https://github.com/vercel/streamdown"
+            rel="noopener"
+            target="_blank"
+          >
+            source code
+          </a>
+          .
+        </p>
+      </div>
+      <ModeToggle />
     </div>
   </footer>
 );

--- a/apps/website/app/components/header.tsx
+++ b/apps/website/app/components/header.tsx
@@ -14,9 +14,9 @@ const Vercel = (props: SVGProps<SVGSVGElement>) => (
 );
 
 export const Header = () => (
-  <div className="sticky top-0 z-10 flex items-center justify-between bg-secondary p-4 backdrop-blur-sm">
+  <div className="sticky top-0 z-10 flex items-center justify-between bg-secondary p-4 backdrop-blur-sm dark:bg-background">
     <div className="mx-auto flex items-center gap-1 sm:mx-0">
-      <a href="https://vercel.com" className="flex items-center gap-1">
+      <a className="flex items-center gap-1" href="https://vercel.com">
         <Vercel className="h-4 w-auto" />
         <span className="font-semibold sm:text-lg">Vercel</span>
       </a>

--- a/apps/website/app/components/props.tsx
+++ b/apps/website/app/components/props.tsx
@@ -58,9 +58,10 @@ const props = [
   },
   {
     name: 'shikiTheme',
-    type: 'BundledTheme (from Shiki)',
-    default: 'github-light',
-    description: 'The theme to use for code blocks.',
+    type: '[BundledTheme, BundledTheme] (from Shiki)',
+    default: '["github-light", "github-dark"]',
+    description:
+      'The themes to use for code blocks. Defaults to ["github-light", "github-dark"].',
   },
 ];
 

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -2,8 +2,8 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
 import type { ReactNode } from 'react';
-import { cn } from '@/lib/utils';
 import { Providers } from '@/components/providers';
+import { cn } from '@/lib/utils';
 
 const geistSans = Geist({
   variable: '--font-sans',

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
+import { Providers } from '@/components/providers';
 
 const geistSans = Geist({
   variable: '--font-sans',
@@ -23,7 +24,7 @@ type RootLayoutProps = {
 };
 
 const RootLayout = ({ children }: RootLayoutProps) => (
-  <html lang="en">
+  <html lang="en" suppressHydrationWarning>
     <body
       className={cn(
         geistSans.variable,
@@ -31,8 +32,10 @@ const RootLayout = ({ children }: RootLayoutProps) => (
         'overflow-x-hidden font-sans antialiased sm:px-4'
       )}
     >
-      {children}
-      <Analytics />
+      <Providers>
+        {children}
+        <Analytics />
+      </Providers>
     </body>
   </html>
 );

--- a/apps/website/components/mode-toggle.tsx
+++ b/apps/website/components/mode-toggle.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export function ModeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      aria-label="Toggle theme"
+    >
+      <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+    </Button>
+  );
+}

--- a/apps/website/components/providers.tsx
+++ b/apps/website/components/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { ThemeProvider } from 'next-themes';
+import type { ReactNode } from 'react';
+
+type ProvidersProps = {
+  children: ReactNode;
+};
+
+export function Providers({ children }: ProvidersProps) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.539.0",
     "motion": "^12.23.12",
     "next": "15.4.6",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -11,7 +11,6 @@ import hardenReactMarkdownImport from 'harden-react-markdown';
 import { components as defaultComponents } from './lib/components';
 import { parseMarkdownIntoBlocks } from './lib/parse-blocks';
 import { parseIncompleteMarkdown } from './lib/parse-incomplete-markdown';
-import { Mermaid } from './lib/mermaid';
 import { cn } from './lib/utils';
 
 type HardenReactMarkdownProps = Options & {
@@ -31,10 +30,13 @@ const HardenedMarkdown: ReturnType<typeof hardenReactMarkdown> =
 export type StreamdownProps = HardenReactMarkdownProps & {
   parseIncompleteMarkdown?: boolean;
   className?: string;
-  shikiTheme?: BundledTheme;
+  shikiTheme?: [BundledTheme, BundledTheme];
 };
 
-export const ShikiThemeContext = createContext<BundledTheme>('github-light');
+export const ShikiThemeContext = createContext<[BundledTheme, BundledTheme]>([
+  'github-light' as BundledTheme,
+  'github-dark' as BundledTheme,
+]);
 
 type BlockProps = HardenReactMarkdownProps & {
   content: string;
@@ -69,7 +71,7 @@ export const Streamdown = memo(
     rehypePlugins,
     remarkPlugins,
     className,
-    shikiTheme = 'github-light',
+    shikiTheme = ['github-light', 'github-dark'],
     ...props
   }: StreamdownProps) => {
     // Parse the children to remove incomplete markdown tokens if enabled
@@ -109,7 +111,3 @@ export const Streamdown = memo(
     prevProps.shikiTheme === nextProps.shikiTheme
 );
 Streamdown.displayName = 'Streamdown';
-
-export { Mermaid };
-export { CodeBlock, CodeBlockCopyButton, CodeBlockRenderButton } from './lib/code-block';
-export default Streamdown;

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -21,6 +21,7 @@ type HardenReactMarkdownProps = Options & {
 
 // Handle both ESM and CJS imports
 const hardenReactMarkdown =
+  // biome-ignore lint/suspicious/noExplicitAny: "this is needed."
   (hardenReactMarkdownImport as any).default || hardenReactMarkdownImport;
 
 // Create a hardened version of ReactMarkdown

--- a/packages/streamdown/lib/code-block.tsx
+++ b/packages/streamdown/lib/code-block.tsx
@@ -27,15 +27,19 @@ const CodeBlockContext = createContext<CodeBlockContextType>({
   code: '',
 });
 
-export async function highlightCode(code: string, language: BundledLanguage) {
+export async function highlightCode(
+  code: string,
+  language: BundledLanguage,
+  themes: [BundledTheme, BundledTheme]
+) {
   return Promise.all([
     await codeToHtml(code, {
       lang: language,
-      theme: 'github-light',
+      theme: themes[0],
     }),
     await codeToHtml(code, {
       lang: language,
-      theme: 'github-dark',
+      theme: themes[1],
     }),
   ]);
 }
@@ -50,20 +54,23 @@ export const CodeBlock = ({
   const [html, setHtml] = useState<string>('');
   const [darkHtml, setDarkHtml] = useState<string>('');
   const mounted = useRef(false);
+  const [lightTheme, darkTheme] = useContext(ShikiThemeContext);
 
   useEffect(() => {
-    highlightCode(code, language).then(([light, dark]) => {
-      if (!mounted.current) {
-        setHtml(light);
-        setDarkHtml(dark);
-        mounted.current = true;
+    highlightCode(code, language, [lightTheme, darkTheme]).then(
+      ([light, dark]) => {
+        if (!mounted.current) {
+          setHtml(light);
+          setDarkHtml(dark);
+          mounted.current = true;
+        }
       }
-    });
+    );
 
     return () => {
       mounted.current = false;
     };
-  }, [code, language]);
+  }, [code, language, lightTheme, darkTheme]);
 
   return (
     <CodeBlockContext.Provider value={{ code }}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       next:
         specifier: 15.4.6
         version: 15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -2690,6 +2693,12 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.4.6:
     resolution: {integrity: sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==}
@@ -6273,6 +6282,11 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next@15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
This pull request adds dark mode support to the website and improves code block rendering for both light and dark themes. It introduces a theme toggle component, updates code block logic to use separate themes for light and dark modes, and refactors context usage to support this. Additionally, it updates dependencies to enable theme switching and improves UI layout in the footer and header.

**Dark Mode and Theming**

* Added the `next-themes` package and a new `Providers` component to enable theme switching across the app. The root layout now wraps content in `Providers` and uses `suppressHydrationWarning` for proper hydration. (`apps/website/app/layout.tsx`, `apps/website/components/providers.tsx`, `apps/website/package.json`, `pnpm-lock.yaml`) [[1]](diffhunk://#diff-82489ac38096caf5a720bc88ef48664164eef40d1ac9db7565782ffa91125e23R5) [[2]](diffhunk://#diff-82489ac38096caf5a720bc88ef48664164eef40d1ac9db7565782ffa91125e23L26-R38) [[3]](diffhunk://#diff-87271504416632c227f1fc926b7c43d5df7b0c76b20cbc674dd37f805d6fac05R1-R16) [[4]](diffhunk://#diff-c8250ff88394f3d8d36cfcd52d176e5fb4ff291f74cefcb0fa6a6386f080cc11R20) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR53-R55) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2697-R2702) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6286-R6290)
* Added a `ModeToggle` button to the footer for switching between light and dark themes. (`apps/website/app/components/footer.tsx`, `apps/website/components/mode-toggle.tsx`) [[1]](diffhunk://#diff-6b1445b052c1d5d4783118d74f9a109163bce65014b4ff35e473a509fad4b11eR1-R6) [[2]](diffhunk://#diff-6b1445b052c1d5d4783118d74f9a109163bce65014b4ff35e473a509fad4b11eR29-R30) [[3]](diffhunk://#diff-b5500e57f118f2b3c88e02df73b157ad6a53bd112c6619b1dc77b857a619feccR1-R31)
* Improved the header background so it adapts to dark mode. (`apps/website/app/components/header.tsx`)

**Code Block Rendering**

* Refactored code block logic to support both light and dark themes by rendering two versions of highlighted code and toggling visibility based on theme. Updated context and props to accept an array of themes. (`packages/streamdown/index.tsx`, `packages/streamdown/lib/code-block.tsx`, `apps/website/components/code-block.tsx`) [[1]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cL34-R40) [[2]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cL72-R75) [[3]](diffhunk://#diff-b900d575a73c911c1ad702296e8116492c24cf5137ea12ba0b93012edb074c63L32-R44) [[4]](diffhunk://#diff-b900d575a73c911c1ad702296e8116492c24cf5137ea12ba0b93012edb074c63L48-R95) [[5]](diffhunk://#diff-3b976a3e9ed5c755067011d8bf5b4c449668123f1329526eaf1bf0b4e5db7138L29-R39) [[6]](diffhunk://#diff-3b976a3e9ed5c755067011d8bf5b4c449668123f1329526eaf1bf0b4e5db7138R50-R87)
* Updated the code block props documentation to reflect the new theme array usage. (`apps/website/app/components/props.tsx`)

**General Improvements**

* Updated the `.changeset` file to document the code block dark mode and background fix. (`.changeset/yellow-webs-follow.md`)

These changes collectively provide a seamless dark mode experience and ensure code blocks are readable in both light and dark themes.