### PR TITLE
Release based deploys

### DIFF
--- a/.changeset/sour-grapes-admire.md
+++ b/.changeset/sour-grapes-admire.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+enable release-based web deploys

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Deploy to Vercel
+        if: steps.changesets.outputs.published == 'true'
+        run: npx vercel --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces release-based deployment for the web application using Vercel. The changes ensure that deployments are triggered only after a successful release, improving deployment reliability and aligning production updates with published releases.

Deployment workflow enhancements:

* Updated `.github/workflows/release.yml` to add a step that deploys to Vercel after a release is published, using organization and project secrets for authentication.
* Added `vercel.json` configuration to explicitly disable automatic deployments from the `main` branch, ensuring deployments are controlled via the release workflow.

Release process update:

* Added a changeset (`.changeset/sour-grapes-admire.md`) describing the enablement of release-based web deploys for the `streamdown` package.