### PR TITLE
fix: rendering code blocks throws csp errors using vite build

### DIFF
--- a/.changeset/eighty-regions-make.md
+++ b/.changeset/eighty-regions-make.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+use javascript regex engine for shiki


### PR DESCRIPTION
Modified the Streamdown package to use Shiki's JavaScript engine instead of the WebAssembly engine, which should resolve the CSP errors in production builds.