### PR TITLE
fix: regression displaying multiple language code blocks

### DIFF
--- a/.changeset/petite-steaks-sit.md
+++ b/.changeset/petite-steaks-sit.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Support multiple simultaneous code blocks with different languages


### PR DESCRIPTION
This pull request enhances the `streamdown` package by adding support for rendering multiple simultaneous code blocks, each with different languages and themes. The main change is a refactor of the code block highlighting logic to allow for independent management of language and theme combinations, ensuring that multiple code blocks can be displayed correctly at the same time. Comprehensive tests have been added to verify these capabilities.

**Code block rendering and highlighting improvements:**

* Refactored the code block highlighter logic by replacing the global cache with a new `HighlighterManager` class. This class tracks loaded languages and themes, allowing multiple code blocks with different languages to be rendered simultaneously without interference. (`packages/streamdown/lib/code-block.tsx`)
* Exported a singleton instance of `HighlighterManager` and updated the `highlightCode` function to use it, ensuring consistent and isolated highlighting for each code block. (`packages/streamdown/lib/code-block.tsx`)

**Testing enhancements:**

* Added new test cases to verify that multiple code blocks with different languages, multiple instances of the same language, and rapid sequential rendering of different languages all work as expected. (`packages/streamdown/__tests__/code-block.test.tsx`)
* Updated test imports to include `ShikiThemeContext`, supporting theme context in tests for code blocks. (`packages/streamdown/__tests__/code-block.test.tsx`)

**Documentation and release notes:**

* Added a changeset describing the patch, noting support for multiple simultaneous code blocks with different languages. (`.changeset/petite-steaks-sit.md`)