### PR TITLE
add rtl unit tests

### DIFF
--- a/.changeset/upset-eggs-own.md
+++ b/.changeset/upset-eggs-own.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+add rtl unit tests

--- a/packages/streamdown/__tests__/rtl-support.test.tsx
+++ b/packages/streamdown/__tests__/rtl-support.test.tsx
@@ -1,0 +1,142 @@
+import { render } from '@testing-library/react';
+import { Streamdown } from '../index';
+
+describe('RTL (Right-to-Left) Support', () => {
+  it('renders basic RTL text correctly', () => {
+    const rtlContent = 'مرحبا بك في Streamdown';
+    const { container } = render(<Streamdown>{rtlContent}</Streamdown>);
+    
+    expect(container.textContent).toContain('مرحبا بك في Streamdown');
+  });
+
+  it('renders mixed RTL/LTR content in paragraphs', () => {
+    const mixedContent = `
+This is English text.
+
+هذا نص عربي مع **تنسيق غامق** و *مائل*.
+
+Mixed paragraph: Hello مرحبا World عالم.
+    `;
+    
+    const { container } = render(<Streamdown>{mixedContent}</Streamdown>);
+    expect(container.textContent).toContain('هذا نص عربي');
+    expect(container.textContent).toContain('Hello مرحبا World عالم');
+  });
+
+  it('renders RTL content in lists', () => {
+    const rtlList = `
+- عنصر القائمة الأول
+- עברית פריט רשימה
+- Third item in English
+- רابع عنصر بالعربية
+    `;
+    
+    const { container } = render(<Streamdown>{rtlList}</Streamdown>);
+    const listItems = container.querySelectorAll('[data-streamdown="list-item"]');
+    expect(listItems.length).toBe(4);
+    expect(container.textContent).toContain('עברית פריט רשימה');
+  });
+
+  it('renders RTL content in headings', () => {
+    const rtlHeadings = `
+# عنوان رئيسي بالعربية
+
+## כותרת משנה בעברית
+
+### Mixed Heading مختلط
+    `;
+    
+    const { container } = render(<Streamdown>{rtlHeadings}</Streamdown>);
+    const h1 = container.querySelector('[data-streamdown="heading-1"]');
+    const h2 = container.querySelector('[data-streamdown="heading-2"]');
+    const h3 = container.querySelector('[data-streamdown="heading-3"]');
+    
+    expect(h1?.textContent).toBe('عنوان رئيسي بالعربية');
+    expect(h2?.textContent).toBe('כותרת משנה בעברית');
+    expect(h3?.textContent).toBe('Mixed Heading مختلط');
+  });
+
+  it('renders RTL content in tables', () => {
+    const rtlTable = `
+| English | عربي | עברית |
+|---------|------|-------|
+| Hello | مرحبا | שלום |
+| World | عالم | עולם |
+    `;
+    
+    const { container } = render(<Streamdown>{rtlTable}</Streamdown>);
+    const cells = container.querySelectorAll('[data-streamdown="table-cell"]');
+    
+    expect(cells[0]?.textContent).toBe('Hello');
+    expect(cells[1]?.textContent).toBe('مرحبا');
+    expect(cells[2]?.textContent).toBe('שלום');
+  });
+
+  it('renders RTL content in blockquotes', () => {
+    const rtlQuote = `
+> هذا اقتباس بالعربية مع **تنسيق**.
+> 
+> זה ציטוט בעברית.
+    `;
+    
+    const { container } = render(<Streamdown>{rtlQuote}</Streamdown>);
+    const blockquote = container.querySelector('[data-streamdown="blockquote"]');
+    
+    expect(blockquote?.textContent).toContain('هذا اقتباس بالعربية');
+    expect(blockquote?.textContent).toContain('זה ציטוט בעברית');
+  });
+
+  it.skip('renders RTL content in code blocks', () => {
+    // Note: Code blocks use async syntax highlighting
+    // RTL text in code blocks would still work at runtime
+    const rtlCode = `\`\`\`javascript
+// تعليق بالعربية
+const greeting = "مرحبا";
+console.log(greeting);
+\`\`\``;
+    
+    const { container } = render(<Streamdown>{rtlCode}</Streamdown>);
+    // Code blocks render asynchronously with syntax highlighting
+    // RTL text would be preserved in the rendered output
+  });
+
+  it('renders inline code with RTL text', () => {
+    const inlineRtl = 'Use `مرحبا` for greeting in Arabic';
+    
+    const { container } = render(<Streamdown>{inlineRtl}</Streamdown>);
+    const inlineCode = container.querySelector('[data-streamdown="inline-code"]');
+    
+    expect(inlineCode?.textContent).toBe('مرحبا');
+  });
+
+  it('renders links with RTL text', () => {
+    const rtlLink = '[نص الرابط العربي](https://example.com)';
+    
+    const { container } = render(<Streamdown>{rtlLink}</Streamdown>);
+    const link = container.querySelector('[data-streamdown="link"]');
+    
+    expect(link?.textContent).toBe('نص الرابط العربي');
+    expect(link?.getAttribute('href')).toBe('https://example.com/');
+  });
+
+  it('works with dir="rtl" CSS style', () => {
+    const rtlContent = 'هذا نص عربي كامل';
+    
+    const { container } = render(
+      <div dir="rtl">
+        <Streamdown>{rtlContent}</Streamdown>
+      </div>
+    );
+    
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute('dir')).toBe('rtl');
+    expect(container.textContent).toContain('هذا نص عربي كامل');
+  });
+
+  it('preserves bidirectional text ordering', () => {
+    const bidiContent = 'The price is 50 ريال for the العربية edition';
+    
+    const { container } = render(<Streamdown>{bidiContent}</Streamdown>);
+    expect(container.textContent).toBe('The price is 50 ريال for the العربية edition');
+  });
+});

--- a/packages/streamdown/__tests__/rtl-support.test.tsx
+++ b/packages/streamdown/__tests__/rtl-support.test.tsx
@@ -5,7 +5,7 @@ describe('RTL (Right-to-Left) Support', () => {
   it('renders basic RTL text correctly', () => {
     const rtlContent = 'مرحبا بك في Streamdown';
     const { container } = render(<Streamdown>{rtlContent}</Streamdown>);
-    
+
     expect(container.textContent).toContain('مرحبا بك في Streamdown');
   });
 
@@ -17,7 +17,7 @@ This is English text.
 
 Mixed paragraph: Hello مرحبا World عالم.
     `;
-    
+
     const { container } = render(<Streamdown>{mixedContent}</Streamdown>);
     expect(container.textContent).toContain('هذا نص عربي');
     expect(container.textContent).toContain('Hello مرحبا World عالم');
@@ -30,9 +30,11 @@ Mixed paragraph: Hello مرحبا World عالم.
 - Third item in English
 - רابع عنصر بالعربية
     `;
-    
+
     const { container } = render(<Streamdown>{rtlList}</Streamdown>);
-    const listItems = container.querySelectorAll('[data-streamdown="list-item"]');
+    const listItems = container.querySelectorAll(
+      '[data-streamdown="list-item"]'
+    );
     expect(listItems.length).toBe(4);
     expect(container.textContent).toContain('עברית פריט רשימה');
   });
@@ -45,12 +47,12 @@ Mixed paragraph: Hello مرحبا World عالم.
 
 ### Mixed Heading مختلط
     `;
-    
+
     const { container } = render(<Streamdown>{rtlHeadings}</Streamdown>);
     const h1 = container.querySelector('[data-streamdown="heading-1"]');
     const h2 = container.querySelector('[data-streamdown="heading-2"]');
     const h3 = container.querySelector('[data-streamdown="heading-3"]');
-    
+
     expect(h1?.textContent).toBe('عنوان رئيسي بالعربية');
     expect(h2?.textContent).toBe('כותרת משנה בעברית');
     expect(h3?.textContent).toBe('Mixed Heading مختلط');
@@ -63,10 +65,10 @@ Mixed paragraph: Hello مرحبا World عالم.
 | Hello | مرحبا | שלום |
 | World | عالم | עולם |
     `;
-    
+
     const { container } = render(<Streamdown>{rtlTable}</Streamdown>);
     const cells = container.querySelectorAll('[data-streamdown="table-cell"]');
-    
+
     expect(cells[0]?.textContent).toBe('Hello');
     expect(cells[1]?.textContent).toBe('مرحبا');
     expect(cells[2]?.textContent).toBe('שלום');
@@ -78,56 +80,46 @@ Mixed paragraph: Hello مرحبا World عالم.
 > 
 > זה ציטוט בעברית.
     `;
-    
+
     const { container } = render(<Streamdown>{rtlQuote}</Streamdown>);
-    const blockquote = container.querySelector('[data-streamdown="blockquote"]');
-    
+    const blockquote = container.querySelector(
+      '[data-streamdown="blockquote"]'
+    );
+
     expect(blockquote?.textContent).toContain('هذا اقتباس بالعربية');
     expect(blockquote?.textContent).toContain('זה ציטוט בעברית');
   });
 
-  it.skip('renders RTL content in code blocks', () => {
-    // Note: Code blocks use async syntax highlighting
-    // RTL text in code blocks would still work at runtime
-    const rtlCode = `\`\`\`javascript
-// تعليق بالعربية
-const greeting = "مرحبا";
-console.log(greeting);
-\`\`\``;
-    
-    const { container } = render(<Streamdown>{rtlCode}</Streamdown>);
-    // Code blocks render asynchronously with syntax highlighting
-    // RTL text would be preserved in the rendered output
-  });
-
   it('renders inline code with RTL text', () => {
     const inlineRtl = 'Use `مرحبا` for greeting in Arabic';
-    
+
     const { container } = render(<Streamdown>{inlineRtl}</Streamdown>);
-    const inlineCode = container.querySelector('[data-streamdown="inline-code"]');
-    
+    const inlineCode = container.querySelector(
+      '[data-streamdown="inline-code"]'
+    );
+
     expect(inlineCode?.textContent).toBe('مرحبا');
   });
 
   it('renders links with RTL text', () => {
     const rtlLink = '[نص الرابط العربي](https://example.com)';
-    
+
     const { container } = render(<Streamdown>{rtlLink}</Streamdown>);
     const link = container.querySelector('[data-streamdown="link"]');
-    
+
     expect(link?.textContent).toBe('نص الرابط العربي');
     expect(link?.getAttribute('href')).toBe('https://example.com/');
   });
 
   it('works with dir="rtl" CSS style', () => {
     const rtlContent = 'هذا نص عربي كامل';
-    
+
     const { container } = render(
       <div dir="rtl">
         <Streamdown>{rtlContent}</Streamdown>
       </div>
     );
-    
+
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.getAttribute('dir')).toBe('rtl');
     expect(container.textContent).toContain('هذا نص عربي كامل');
@@ -135,8 +127,10 @@ console.log(greeting);
 
   it('preserves bidirectional text ordering', () => {
     const bidiContent = 'The price is 50 ريال for the العربية edition';
-    
+
     const { container } = render(<Streamdown>{bidiContent}</Streamdown>);
-    expect(container.textContent).toBe('The price is 50 ريال for the العربية edition');
+    expect(container.textContent).toBe(
+      'The price is 50 ريال for the العربية edition'
+    );
   });
 });


### PR DESCRIPTION
This pull request adds a comprehensive test suite to ensure that the `Streamdown` component correctly handles right-to-left (RTL) and mixed bidirectional text across various markdown elements. The tests cover basic rendering, mixed content, lists, headings, tables, blockquotes, code blocks, inline code, links, RTL styling, and bidirectional text ordering.

RTL and bidirectional text support tests:

* Added tests for basic RTL text rendering and mixed RTL/LTR content in paragraphs to verify correct display and text ordering.
* Added tests for RTL content in lists, headings, tables, and blockquotes, checking both text presence and semantic structure using relevant data attributes.
* Included tests for RTL content in code blocks (skipped due to async rendering), inline code, and links to ensure correct handling and preservation of RTL text.
* Added a test for rendering with `dir="rtl"` CSS style to confirm proper directionality support in the DOM.
* Verified preservation of bidirectional text ordering in mixed RTL/LTR sentences.