### PR TITLE
fix: the unterminated long link text is not rendering anything until the full link has completed streaming

### DIFF
--- a/.changeset/yummy-lines-matter.md
+++ b/.changeset/yummy-lines-matter.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+fix: links invisible while streaming

--- a/apps/website/app/components/terminator-parser.tsx
+++ b/apps/website/app/components/terminator-parser.tsx
@@ -1,10 +1,8 @@
 import { Section } from './section';
 
-const markdown = `# This is a showcase of unterminated Markdown blocks
+const markdown = `**This is a very long bold text that keeps going and going without a clear end, so you can see how unterminated bold blocks are handled by the renderer.**
 
-**This is a very long bold text that keeps going and going without a clear end, so you can see how unterminated bold blocks are handled by the renderer, especially when the text wraps across multiple lines and continues even further to really test the limits of the parser**
-
-*Here is an equally lengthy italicized sentence that stretches on and on, never quite reaching a conclusion, so you can observe how unterminated italic blocks behave in a streaming Markdown context, particularly when the content is verbose and spans several lines for demonstration purposes*
+*Here is an equally lengthy italicized sentence that stretches on and on, never quite reaching a conclusion, so you can observe how unterminated italic blocks behave in a streaming Markdown context, particularly when the content is verbose.*
 
 \`This is a long inline code block that should be unterminated and continues for quite a while, including some code-like content such as const foo = "bar"; and more, to see how the parser deals with it when the code block is not properly closed\`
 

--- a/packages/streamdown/__tests__/components.test.tsx
+++ b/packages/streamdown/__tests__/components.test.tsx
@@ -126,6 +126,21 @@ describe('Markdown Components', () => {
       expect(link?.getAttribute('target')).toBe('_blank');
     });
 
+    it('should mark incomplete links with data attribute', () => {
+      const A = components.a!;
+      const { container } = render(
+        <A href="streamdown:incomplete-link" node={null as any}>
+          Incomplete link text
+        </A>
+      );
+      // Should render a normal anchor with data-incomplete attribute
+      const link = container.querySelector('a[data-streamdown="link"]');
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute('data-incomplete')).toBe('true');
+      expect(link?.getAttribute('href')).toBe('streamdown:incomplete-link');
+      expect(link?.textContent).toBe('Incomplete link text');
+    });
+
     it('should render blockquote with correct classes', () => {
       const Blockquote = components.blockquote!;
       const { container } = render(

--- a/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
+++ b/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
@@ -20,11 +20,11 @@ describe('parseIncompleteMarkdown', () => {
   });
 
   describe('link handling', () => {
-    it('should remove incomplete links', () => {
+    it('should preserve incomplete links with special marker', () => {
       expect(parseIncompleteMarkdown('Text with [incomplete link')).toBe(
-        'Text with '
+        'Text with [incomplete link](streamdown:incomplete-link)'
       );
-      expect(parseIncompleteMarkdown('Text [partial')).toBe('Text ');
+      expect(parseIncompleteMarkdown('Text [partial')).toBe('Text [partial](streamdown:incomplete-link)');
     });
 
     it('should keep complete links unchanged', () => {
@@ -269,9 +269,9 @@ describe('parseIncompleteMarkdown', () => {
       expect(parseIncompleteMarkdown(text)).toBe(text);
     });
 
-    it('should prioritize link/image removal over formatting completion', () => {
+    it('should prioritize link/image preservation over formatting completion', () => {
       expect(parseIncompleteMarkdown('Text with [link and **bold')).toBe(
-        'Text with '
+        'Text with [link and **bold](streamdown:incomplete-link)'
       );
     });
 
@@ -464,7 +464,7 @@ describe('parseIncompleteMarkdown', () => {
     });
 
     it('should handle partial link at chunk boundary', () => {
-      expect(parseIncompleteMarkdown('Check out [this lin')).toBe('Check out ');
+      expect(parseIncompleteMarkdown('Check out [this lin')).toBe('Check out [this lin](streamdown:incomplete-link)');
       // Links with partial URLs are kept as-is since they might be complete
       expect(parseIncompleteMarkdown('Visit [our site](https://exa')).toBe(
         'Visit [our site](https://exa'

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -127,18 +127,23 @@ export const components: Options['components'] = {
       {children}
     </span>
   ),
-  a: ({ node, children, className, href, ...props }) => (
-    <a
-      className={cn('font-medium text-primary underline', className)}
-      data-streamdown="link"
-      href={href}
-      rel="noreferrer"
-      target="_blank"
-      {...props}
-    >
-      {children}
-    </a>
-  ),
+  a: ({ node, children, className, href, ...props }) => {
+    const isIncomplete = href === 'streamdown:incomplete-link';
+
+    return (
+      <a
+        className={cn('font-medium text-primary underline', className)}
+        data-incomplete={isIncomplete}
+        data-streamdown="link"
+        href={href}
+        rel="noreferrer"
+        target="_blank"
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
   h1: ({ node, children, className, ...props }) => (
     <h1
       className={cn('mt-6 mb-2 font-semibold text-3xl', className)}


### PR DESCRIPTION
This pull request improves how incomplete Markdown links are handled during streaming in the `streamdown` package and its website integration. Instead of removing incomplete links, the parser now preserves them using a special placeholder URL and marks them for styling, which makes links visible while streaming. Related tests and rendering logic have been updated to reflect this new behavior.

**Improvements to incomplete link handling:**

* Incomplete Markdown links are now preserved with a placeholder URL (`streamdown:incomplete-link`) rather than being removed, allowing them to be visible during streaming.
* The link rendering component in `components.tsx` sets a `data-incomplete` attribute when rendering these placeholder links, enabling custom styling or behavior for incomplete links. [[1]](diffhunk://#diff-fd2382635b3d84a8d463dfbd2acea58b1cb68ff1e4d00c5fb07648388ae2e89aL130-R136) [[2]](diffhunk://#diff-fd2382635b3d84a8d463dfbd2acea58b1cb68ff1e4d00c5fb07648388ae2e89aL141-R146)

**Updates to tests and documentation:**

* Unit tests in `parse-incomplete-markdown.test.ts` have been updated to expect the new incomplete link behavior, verifying that links are preserved and marked correctly. [[1]](diffhunk://#diff-40baaa3cf5438f5bf3e4819b51ac62574d7af8ba8ff6d4368af5c89e64c8afa8L23-R27) [[2]](diffhunk://#diff-40baaa3cf5438f5bf3e4819b51ac62574d7af8ba8ff6d4368af5c89e64c8afa8L272-R274) [[3]](diffhunk://#diff-40baaa3cf5438f5bf3e4819b51ac62574d7af8ba8ff6d4368af5c89e64c8afa8L467-R467)
* A new test in `components.test.tsx` checks that rendered incomplete links have the correct attributes and content.
* The changeset file documents this patch and its purpose: making links visible while streaming.

**Other codebase improvements:**

* Minor formatting and code style adjustments for clarity and consistency in parsing logic. [[1]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cL88-R100) [[2]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cL230-R246) [[3]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cL301-R318) [[4]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cL312-L320) [[5]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cL371-R388)