### PR TITLE
fix: streaming lists long items break to a new line once the next token / element arrives

### DIFF
--- a/.changeset/rotten-ravens-start.md
+++ b/.changeset/rotten-ravens-start.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+fix: long list items break to a new line

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -86,7 +86,10 @@ const CodeComponent = ({
 export const components: Options['components'] = {
   ol: ({ node, children, className, ...props }) => (
     <ol
-      className={cn('ml-4 list-outside list-decimal', className)}
+      className={cn(
+        'ml-4 list-outside list-decimal whitespace-normal',
+        className
+      )}
       data-streamdown="ordered-list"
       {...props}
     >
@@ -104,7 +107,7 @@ export const components: Options['components'] = {
   ),
   ul: ({ node, children, className, ...props }) => (
     <ul
-      className={cn('ml-4 list-outside list-disc', className)}
+      className={cn('ml-4 list-outside list-disc whitespace-normal', className)}
       data-streamdown="unordered-list"
       {...props}
     >


### PR DESCRIPTION
This pull request addresses a display issue in `streamdown` where long list items were not wrapping correctly and would overflow instead of breaking onto a new line. The fix ensures that both ordered and unordered lists wrap long items as expected.

Styling fixes for list item wrapping:

* Added the `whitespace-normal` CSS class to ordered list (`ol`) elements in `packages/streamdown/lib/components.tsx` to allow long items to break onto a new line.
* Added the `whitespace-normal` CSS class to unordered list (`ul`) elements in `packages/streamdown/lib/components.tsx` for the same purpose.

Changelog update:

* Added a patch changelog entry describing the fix for long list items breaking to a new line in `.changeset/rotten-ravens-start.md`.