### PR TITLE
fix: parseincompletemarkdown emphasis character block issue

### DIFF
--- a/.changeset/old-facts-beg.md
+++ b/.changeset/old-facts-beg.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+fix: parseIncompleteMarkdown Emphasis Character Block Issue

--- a/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
+++ b/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
@@ -544,7 +544,7 @@ describe("parseIncompleteMarkdown", () => {
   describe("mixed formatting scenarios", () => {
     it("should handle bold inside italic", () => {
       expect(parseIncompleteMarkdown("*italic with **bold")).toBe(
-        "*italic with **bold***"
+        "*italic with **bold**"
       );
     });
 
@@ -781,16 +781,45 @@ describe("parseIncompleteMarkdown", () => {
   describe("edge cases", () => {
     it("should handle text ending with formatting characters", () => {
       expect(parseIncompleteMarkdown("Text ending with *")).toBe(
-        "Text ending with **"
+        "Text ending with *"
       );
       expect(parseIncompleteMarkdown("Text ending with **")).toBe(
-        "Text ending with ****"
+        "Text ending with **"
       );
     });
 
     it("should handle empty formatting markers", () => {
       expect(parseIncompleteMarkdown("****")).toBe("****");
       expect(parseIncompleteMarkdown("``")).toBe("``");
+    });
+
+    it("should handle standalone emphasis characters (issue #90)", () => {
+      // Standalone markers should not be auto-closed
+      expect(parseIncompleteMarkdown("**")).toBe("**");
+      expect(parseIncompleteMarkdown("__")).toBe("__");
+      expect(parseIncompleteMarkdown("***")).toBe("***");
+      expect(parseIncompleteMarkdown("*")).toBe("*");
+      expect(parseIncompleteMarkdown("_")).toBe("_");
+      expect(parseIncompleteMarkdown("~~")).toBe("~~");
+      expect(parseIncompleteMarkdown("`")).toBe("`");
+      
+      // Multiple standalone markers on the same line
+      expect(parseIncompleteMarkdown("** __")).toBe("** __");
+      expect(parseIncompleteMarkdown("\n** __\n")).toBe("\n** __\n");
+      expect(parseIncompleteMarkdown("* _ ~~ `")).toBe("* _ ~~ `");
+      
+      // Standalone markers with only whitespace
+      expect(parseIncompleteMarkdown("** ")).toBe("** ");
+      expect(parseIncompleteMarkdown(" **")).toBe(" **");
+      expect(parseIncompleteMarkdown("  **  ")).toBe("  **  ");
+      
+      // But markers with actual content should still be closed
+      expect(parseIncompleteMarkdown("**text")).toBe("**text**");
+      expect(parseIncompleteMarkdown("__text")).toBe("__text__");
+      expect(parseIncompleteMarkdown("*text")).toBe("*text*");
+      expect(parseIncompleteMarkdown("_text")).toBe("_text_");
+      expect(parseIncompleteMarkdown("~~text")).toBe("~~text~~");
+      expect(parseIncompleteMarkdown("`text")).toBe("`text`");
     });
 
     it("should handle very long text", () => {
@@ -800,9 +829,9 @@ describe("parseIncompleteMarkdown", () => {
     });
 
     it("should handle text with only formatting characters", () => {
-      expect(parseIncompleteMarkdown("*")).toBe("**");
-      expect(parseIncompleteMarkdown("**")).toBe("****");
-      expect(parseIncompleteMarkdown("`")).toBe("``");
+      expect(parseIncompleteMarkdown("*")).toBe("*");
+      expect(parseIncompleteMarkdown("**")).toBe("**");
+      expect(parseIncompleteMarkdown("`")).toBe("`");
     });
 
     it("should handle escaped characters", () => {
@@ -811,11 +840,11 @@ describe("parseIncompleteMarkdown", () => {
     });
 
     it("should handle markdown at very end of string", () => {
-      expect(parseIncompleteMarkdown("text**")).toBe("text****");
-      expect(parseIncompleteMarkdown("text*")).toBe("text**");
-      expect(parseIncompleteMarkdown("text`")).toBe("text``");
+      expect(parseIncompleteMarkdown("text**")).toBe("text**");
+      expect(parseIncompleteMarkdown("text*")).toBe("text*");
+      expect(parseIncompleteMarkdown("text`")).toBe("text`");
       expect(parseIncompleteMarkdown("text$")).toBe("text$"); // Single dollar not completed
-      expect(parseIncompleteMarkdown("text~~")).toBe("text~~~~");
+      expect(parseIncompleteMarkdown("text~~")).toBe("text~~");
     });
 
     it("should handle whitespace before incomplete markdown", () => {

--- a/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
+++ b/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
@@ -544,7 +544,7 @@ describe("parseIncompleteMarkdown", () => {
   describe("mixed formatting scenarios", () => {
     it("should handle bold inside italic", () => {
       expect(parseIncompleteMarkdown("*italic with **bold")).toBe(
-        "*italic with **bold**"
+        "*italic with **bold***"
       );
     });
 

--- a/packages/streamdown/lib/parse-incomplete-markdown.ts
+++ b/packages/streamdown/lib/parse-incomplete-markdown.ts
@@ -46,6 +46,14 @@ const handleIncompleteBold = (text: string): string => {
   const boldMatch = text.match(boldPattern);
 
   if (boldMatch) {
+    // Don't close if there's no meaningful content after the opening markers
+    // boldMatch[2] contains the content after **
+    // Check if content is only whitespace or other emphasis markers
+    const contentAfterMarker = boldMatch[2];
+    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+      return text;
+    }
+    
     const asteriskPairs = (text.match(/\*\*/g) || []).length;
     if (asteriskPairs % 2 === 1) {
       return `${text}**`;
@@ -60,6 +68,14 @@ const handleIncompleteDoubleUnderscoreItalic = (text: string): string => {
   const italicMatch = text.match(italicPattern);
 
   if (italicMatch) {
+    // Don't close if there's no meaningful content after the opening markers
+    // italicMatch[2] contains the content after __
+    // Check if content is only whitespace or other emphasis markers
+    const contentAfterMarker = italicMatch[2];
+    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+      return text;
+    }
+    
     const underscorePairs = (text.match(/__/g) || []).length;
     if (underscorePairs % 2 === 1) {
       return `${text}__`;
@@ -119,6 +135,23 @@ const handleIncompleteSingleAsteriskItalic = (text: string): string => {
   const singleAsteriskMatch = text.match(singleAsteriskPattern);
 
   if (singleAsteriskMatch) {
+    // Don't close if there's no meaningful content after the opening marker
+    // singleAsteriskMatch[2] contains the content after *
+    const contentAfterMarker = singleAsteriskMatch[2];
+    
+    // Only skip closing if the content is truly empty or contains ONLY whitespace/markers
+    // If there's any actual text content, we should close the marker
+    if (!contentAfterMarker || contentAfterMarker.trim() === '') {
+      return text;
+    }
+    
+    // Check if content contains any non-emphasis characters (actual text)
+    const hasTextContent = /[^\s_~*`]/.test(contentAfterMarker);
+    if (!hasTextContent) {
+      // Content is only whitespace and emphasis markers, don't close
+      return text;
+    }
+    
     const singleAsterisks = countSingleAsterisks(text);
     if (singleAsterisks % 2 === 1) {
       return `${text}*`;
@@ -189,6 +222,14 @@ const handleIncompleteSingleUnderscoreItalic = (text: string): string => {
   const singleUnderscoreMatch = text.match(singleUnderscorePattern);
 
   if (singleUnderscoreMatch) {
+    // Don't close if there's no meaningful content after the opening marker
+    // singleUnderscoreMatch[2] contains the content after _
+    // Check if content is only whitespace or other emphasis markers
+    const contentAfterMarker = singleUnderscoreMatch[2];
+    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+      return text;
+    }
+    
     const singleUnderscores = countSingleUnderscores(text);
     if (singleUnderscores % 2 === 1) {
       return `${text}_`;
@@ -260,6 +301,14 @@ const handleIncompleteInlineCode = (text: string): string => {
   const inlineCodeMatch = text.match(inlineCodePattern);
 
   if (inlineCodeMatch && !insideIncompleteCodeBlock) {
+    // Don't close if there's no meaningful content after the opening marker
+    // inlineCodeMatch[2] contains the content after `
+    // Check if content is only whitespace or other emphasis markers
+    const contentAfterMarker = inlineCodeMatch[2];
+    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+      return text;
+    }
+    
     const singleBacktickCount = countSingleBackticks(text);
     if (singleBacktickCount % 2 === 1) {
       return `${text}\``;
@@ -274,6 +323,14 @@ const handleIncompleteStrikethrough = (text: string): string => {
   const strikethroughMatch = text.match(strikethroughPattern);
 
   if (strikethroughMatch) {
+    // Don't close if there's no meaningful content after the opening markers
+    // strikethroughMatch[2] contains the content after ~~
+    // Check if content is only whitespace or other emphasis markers
+    const contentAfterMarker = strikethroughMatch[2];
+    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+      return text;
+    }
+    
     const tildePairs = (text.match(/~~/g) || []).length;
     if (tildePairs % 2 === 1) {
       return `${text}~~`;
@@ -359,6 +416,14 @@ const handleIncompleteBoldItalic = (text: string): string => {
   const boldItalicMatch = text.match(boldItalicPattern);
 
   if (boldItalicMatch) {
+    // Don't close if there's no meaningful content after the opening markers
+    // boldItalicMatch[2] contains the content after ***
+    // Check if content is only whitespace or other emphasis markers
+    const contentAfterMarker = boldItalicMatch[2];
+    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+      return text;
+    }
+    
     const tripleAsteriskCount = countTripleAsterisks(text);
     if (tripleAsteriskCount % 2 === 1) {
       return `${text}***`;

--- a/packages/streamdown/lib/parse-incomplete-markdown.ts
+++ b/packages/streamdown/lib/parse-incomplete-markdown.ts
@@ -135,20 +135,25 @@ const handleIncompleteSingleAsteriskItalic = (text: string): string => {
   const singleAsteriskMatch = text.match(singleAsteriskPattern);
 
   if (singleAsteriskMatch) {
-    // Don't close if there's no meaningful content after the opening marker
-    // singleAsteriskMatch[2] contains the content after *
-    const contentAfterMarker = singleAsteriskMatch[2];
+    // Find the first single asterisk position (not part of **)
+    let firstSingleAsteriskIndex = -1;
+    for (let i = 0; i < text.length; i++) {
+      if (text[i] === '*' && text[i-1] !== '*' && text[i+1] !== '*') {
+        firstSingleAsteriskIndex = i;
+        break;
+      }
+    }
     
-    // Only skip closing if the content is truly empty or contains ONLY whitespace/markers
-    // If there's any actual text content, we should close the marker
-    if (!contentAfterMarker || contentAfterMarker.trim() === '') {
+    if (firstSingleAsteriskIndex === -1) {
       return text;
     }
     
-    // Check if content contains any non-emphasis characters (actual text)
-    const hasTextContent = /[^\s_~*`]/.test(contentAfterMarker);
-    if (!hasTextContent) {
-      // Content is only whitespace and emphasis markers, don't close
+    // Get content after the first single asterisk
+    const contentAfterFirstAsterisk = text.substring(firstSingleAsteriskIndex + 1);
+    
+    // Check if there's meaningful content after the asterisk
+    // Don't close if content is only whitespace or emphasis markers
+    if (!contentAfterFirstAsterisk || /^[\s_~*`]*$/.test(contentAfterFirstAsterisk)) {
       return text;
     }
     
@@ -222,11 +227,25 @@ const handleIncompleteSingleUnderscoreItalic = (text: string): string => {
   const singleUnderscoreMatch = text.match(singleUnderscorePattern);
 
   if (singleUnderscoreMatch) {
-    // Don't close if there's no meaningful content after the opening marker
-    // singleUnderscoreMatch[2] contains the content after _
-    // Check if content is only whitespace or other emphasis markers
-    const contentAfterMarker = singleUnderscoreMatch[2];
-    if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
+    // Find the first single underscore position (not part of __)
+    let firstSingleUnderscoreIndex = -1;
+    for (let i = 0; i < text.length; i++) {
+      if (text[i] === '_' && text[i-1] !== '_' && text[i+1] !== '_' && !isWithinMathBlock(text, i)) {
+        firstSingleUnderscoreIndex = i;
+        break;
+      }
+    }
+    
+    if (firstSingleUnderscoreIndex === -1) {
+      return text;
+    }
+    
+    // Get content after the first single underscore
+    const contentAfterFirstUnderscore = text.substring(firstSingleUnderscoreIndex + 1);
+    
+    // Check if there's meaningful content after the underscore
+    // Don't close if content is only whitespace or emphasis markers
+    if (!contentAfterFirstUnderscore || /^[\s_~*`]*$/.test(contentAfterFirstUnderscore)) {
       return text;
     }
     


### PR DESCRIPTION
This pull request fixes an issue in the `parseIncompleteMarkdown` function where standalone Markdown emphasis markers (such as `*`, `**`, `_`, `__`, `~~`, and `` ` ``) were incorrectly auto-closed even when they did not have any content after them. The changes ensure that only markers followed by meaningful content are auto-closed, improving the accuracy of Markdown parsing for incomplete input. The test suite is updated to cover these edge cases.

### Markdown emphasis auto-closing improvements

* Updated all emphasis and formatting handlers in `packages/streamdown/lib/parse-incomplete-markdown.ts` to check for meaningful content after the marker before auto-closing. Standalone markers or those followed only by whitespace or other markers are no longer auto-closed. (`handleIncompleteBold`, `handleIncompleteDoubleUnderscoreItalic`, `handleIncompleteSingleAsteriskItalic`, `handleIncompleteSingleUnderscoreItalic`, `handleIncompleteInlineCode`, `handleIncompleteStrikethrough`, `handleIncompleteBoldItalic`) [[1]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR49-R56) [[2]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR71-R78) [[3]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR138-R159) [[4]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR230-R251) [[5]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR323-R330) [[6]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR345-R352) [[7]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR438-R445)

### Test coverage

* Added and updated test cases in `packages/streamdown/__tests__/parse-incomplete-markdown.test.ts` to verify correct handling of standalone emphasis markers and edge cases, ensuring that only markers with actual content are auto-closed. [[1]](diffhunk://#diff-40baaa3cf5438f5bf3e4819b51ac62574d7af8ba8ff6d4368af5c89e64c8afa8L784-R787) [[2]](diffhunk://#diff-40baaa3cf5438f5bf3e4819b51ac62574d7af8ba8ff6d4368af5c89e64c8afa8R796-R834) [[3]](diffhunk://#diff-40baaa3cf5438f5bf3e4819b51ac62574d7af8ba8ff6d4368af5c89e64c8afa8L814-R847)

### Documentation

* Added a changeset entry documenting the fix for the emphasis character block issue in Markdown parsing. (`.changeset/old-facts-beg.md`)