### PR TITLE
feat: add table markdown copy and csv/markdown download options

### DIFF
--- a/.changeset/hot-squids-bet.md
+++ b/.changeset/hot-squids-bet.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+feat: add table markdown copy and csv/markdown download options

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -7,6 +7,7 @@ import type { ExtraProps, Options } from "react-markdown";
 import type { BundledLanguage } from "shiki";
 import { CodeBlock, CodeBlockCopyButton } from "./code-block";
 import { Mermaid } from "./mermaid";
+import { TableCopyButton, TableDownloadDropdown } from "./table";
 import { cn } from "./utils";
 
 const LANGUAGE_REGEX = /language-([^\s]+)/;
@@ -202,14 +203,20 @@ export const components: Options["components"] = {
     </h6>
   ),
   table: ({ node, children, className, ...props }) => (
-    <div className="my-4 overflow-x-auto" data-streamdown="table-wrapper">
-      <table
-        className={cn("w-full border-collapse border border-border", className)}
-        data-streamdown="table"
-        {...props}
-      >
-        {children}
-      </table>
+    <div className="my-4 flex flex-col space-y-2" data-streamdown="table-wrapper">
+      <div className="flex items-center justify-end gap-1">
+        <TableCopyButton />
+        <TableDownloadDropdown />
+      </div>
+      <div className="overflow-x-auto">
+        <table
+          className={cn("w-full border-collapse border border-border", className)}
+          data-streamdown="table"
+          {...props}
+        >
+          {children}
+        </table>
+      </div>
     </div>
   ),
   thead: ({ node, children, className, ...props }) => (

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -79,7 +79,8 @@ function tableDataToMarkdown(data: TableData): string {
     while (paddedRow.length < headers.length) {
       paddedRow.push("");
     }
-    markdownRows.push(`| ${paddedRow.join(" | ")} |`);
+    const escapedRow = paddedRow.map(cell => cell.replace(/\|/g, '\\|'));
+    markdownRows.push(`| ${escapedRow.join(" | ")} |`);
   });
 
   return markdownRows.join("\n");

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -228,7 +228,7 @@ export const TableDownloadButton = ({
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `table.${extension}`;
+      a.download = `${filename || 'table'}.${extension}`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -106,7 +106,7 @@ export const TableCopyButton = ({
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef(0);
 
-  const copyTableData = async () => {
+  const copyTableData = async (event: React.MouseEvent<HTMLButtonElement>) => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
       onError?.(new Error("Clipboard API not available"));
       return;
@@ -115,7 +115,7 @@ export const TableCopyButton = ({
     try {
       if (!isCopied) {
         // Find the closest table element
-        const button = document.activeElement as HTMLElement;
+        const button = event.currentTarget;
         const tableWrapper = button.closest('[data-streamdown="table-wrapper"]');
         const tableElement = tableWrapper?.querySelector("table") as HTMLTableElement;
 
@@ -191,10 +191,10 @@ export const TableDownloadButton = ({
   format = "csv",
   filename,
 }: TableDownloadButtonProps) => {
-  const downloadTableData = () => {
+  const downloadTableData = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
       // Find the closest table element
-      const button = document.activeElement as HTMLElement;
+      const button = event.currentTarget;
       const tableWrapper = button.closest('[data-streamdown="table-wrapper"]');
       const tableElement = tableWrapper?.querySelector("table") as HTMLTableElement;
 

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -67,7 +67,8 @@ function tableDataToMarkdown(data: TableData): string {
   const markdownRows: string[] = [];
 
   // Add headers
-  markdownRows.push(`| ${headers.join(" | ")} |`);
+  const escapedHeaders = headers.map(h => h.replace(/\|/g, '\\|'));
+  markdownRows.push(`| ${escapedHeaders.join(" | ")} |`);
 
   // Add separator row
   markdownRows.push(`| ${headers.map(() => "---").join(" | ")} |`);

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -1,0 +1,356 @@
+import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "./utils";
+
+type TableData = {
+  headers: string[];
+  rows: string[][];
+};
+
+function extractTableDataFromElement(tableElement: HTMLElement): TableData {
+  const headers: string[] = [];
+  const rows: string[][] = [];
+
+  // Extract headers
+  const headerCells = tableElement.querySelectorAll("thead th");
+  headerCells.forEach((cell) => {
+    headers.push(cell.textContent?.trim() || "");
+  });
+
+  // Extract rows
+  const bodyRows = tableElement.querySelectorAll("tbody tr");
+  bodyRows.forEach((row) => {
+    const rowData: string[] = [];
+    const cells = row.querySelectorAll("td");
+    cells.forEach((cell) => {
+      rowData.push(cell.textContent?.trim() || "");
+    });
+    rows.push(rowData);
+  });
+
+  return { headers, rows };
+}
+
+function tableDataToCSV(data: TableData): string {
+  const { headers, rows } = data;
+
+  const escapeCSV = (value: string): string => {
+    // If the value contains comma, quote, or newline, wrap in quotes and escape internal quotes
+    if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  };
+
+  const csvRows: string[] = [];
+
+  // Add headers
+  if (headers.length > 0) {
+    csvRows.push(headers.map(escapeCSV).join(","));
+  }
+
+  // Add data rows
+  rows.forEach((row) => {
+    csvRows.push(row.map(escapeCSV).join(","));
+  });
+
+  return csvRows.join("\n");
+}
+
+function tableDataToMarkdown(data: TableData): string {
+  const { headers, rows } = data;
+
+  if (headers.length === 0) {
+    return "";
+  }
+
+  const markdownRows: string[] = [];
+
+  // Add headers
+  markdownRows.push(`| ${headers.join(" | ")} |`);
+
+  // Add separator row
+  markdownRows.push(`| ${headers.map(() => "---").join(" | ")} |`);
+
+  // Add data rows
+  rows.forEach((row) => {
+    // Pad row with empty strings if it's shorter than headers
+    const paddedRow = [...row];
+    while (paddedRow.length < headers.length) {
+      paddedRow.push("");
+    }
+    markdownRows.push(`| ${paddedRow.join(" | ")} |`);
+  });
+
+  return markdownRows.join("\n");
+}
+
+export type TableCopyButtonProps = {
+  children?: React.ReactNode;
+  className?: string;
+  onCopy?: () => void;
+  onError?: (error: Error) => void;
+  timeout?: number;
+  format?: "csv" | "markdown" | "text";
+};
+
+export const TableCopyButton = ({
+  children,
+  className,
+  onCopy,
+  onError,
+  timeout = 2000,
+  format = "markdown",
+}: TableCopyButtonProps) => {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef(0);
+
+  const copyTableData = async () => {
+    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+      onError?.(new Error("Clipboard API not available"));
+      return;
+    }
+
+    try {
+      if (!isCopied) {
+        // Find the closest table element
+        const button = document.activeElement as HTMLElement;
+        const tableWrapper = button.closest('[data-streamdown="table-wrapper"]');
+        const tableElement = tableWrapper?.querySelector("table") as HTMLTableElement;
+
+        if (!tableElement) {
+          onError?.(new Error("Table not found"));
+          return;
+        }
+
+        const tableData = extractTableDataFromElement(tableElement);
+        let content = "";
+
+        switch (format) {
+          case "csv":
+            content = tableDataToCSV(tableData);
+            break;
+          case "markdown":
+            content = tableDataToMarkdown(tableData);
+            break;
+          case "text":
+            content = tableDataToCSV(tableData).replace(/,/g, "\t");
+            break;
+          default:
+            content = tableDataToCSV(tableData);
+        }
+
+        await navigator.clipboard.writeText(content);
+        setIsCopied(true);
+        onCopy?.();
+        timeoutRef.current = window.setTimeout(
+          () => setIsCopied(false),
+          timeout
+        );
+      }
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const Icon = isCopied ? CheckIcon : CopyIcon;
+
+  return (
+    <button
+      className={cn("text-muted-foreground p-1 transition-all", className)}
+      onClick={copyTableData}
+      type="button"
+      title={`Copy table as ${format.toUpperCase()}`}
+    >
+      {children ?? <Icon size={14} />}
+    </button>
+  );
+};
+
+export type TableDownloadButtonProps = {
+  children?: React.ReactNode;
+  className?: string;
+  onDownload?: () => void;
+  onError?: (error: Error) => void;
+  format?: "csv" | "markdown";
+  filename?: string;
+};
+
+export const TableDownloadButton = ({
+  children,
+  className,
+  onDownload,
+  onError,
+  format = "csv",
+  filename,
+}: TableDownloadButtonProps) => {
+  const downloadTableData = () => {
+    try {
+      // Find the closest table element
+      const button = document.activeElement as HTMLElement;
+      const tableWrapper = button.closest('[data-streamdown="table-wrapper"]');
+      const tableElement = tableWrapper?.querySelector("table") as HTMLTableElement;
+
+      if (!tableElement) {
+        onError?.(new Error("Table not found"));
+        return;
+      }
+
+      const tableData = extractTableDataFromElement(tableElement);
+      let content = "";
+      let mimeType = "";
+      let extension = "";
+
+      switch (format) {
+        case "csv":
+          content = tableDataToCSV(tableData);
+          mimeType = "text/csv";
+          extension = "csv";
+          break;
+        case "markdown":
+          content = tableDataToMarkdown(tableData);
+          mimeType = "text/markdown";
+          extension = "md";
+          break;
+        default:
+          content = tableDataToCSV(tableData);
+          mimeType = "text/csv";
+          extension = "csv";
+      }
+
+      const blob = new Blob([content], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `table.${extension}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      onDownload?.();
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  };
+
+  return (
+    <button
+      className={cn("text-muted-foreground p-1 transition-all", className)}
+      onClick={downloadTableData}
+      type="button"
+      title={`Download table as ${format.toUpperCase()}`}
+    >
+      {children ?? <DownloadIcon size={14} />}
+    </button>
+  );
+};
+
+export type TableDownloadDropdownProps = {
+  children?: React.ReactNode;
+  className?: string;
+  onDownload?: (format: 'csv' | 'markdown') => void;
+  onError?: (error: Error) => void;
+};
+
+export const TableDownloadDropdown = ({
+  children,
+  className,
+  onDownload,
+  onError,
+}: TableDownloadDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const downloadTableData = (format: 'csv' | 'markdown') => {
+    try {
+      const tableWrapper = dropdownRef.current?.closest('[data-streamdown="table-wrapper"]');
+      const tableElement = tableWrapper?.querySelector("table") as HTMLTableElement;
+
+      if (!tableElement) {
+        onError?.(new Error("Table not found"));
+        return;
+      }
+
+      const tableData = extractTableDataFromElement(tableElement);
+      let content = "";
+      let mimeType = "";
+
+      switch (format) {
+        case "csv":
+          content = tableDataToCSV(tableData);
+          mimeType = "text/csv";
+          break;
+        case "markdown":
+          content = tableDataToMarkdown(tableData);
+          mimeType = "text/markdown";
+          break;
+      }
+      
+      const blob = new Blob([content], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "table";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      setIsOpen(false);
+      onDownload?.(format);
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <button
+        className={cn("text-muted-foreground p-1 transition-all", className)}
+        onClick={() => setIsOpen(!isOpen)}
+        type="button"
+        title="Download table"
+      >
+        {children ?? <DownloadIcon size={14} />}
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-1 bg-white border border-border rounded-md shadow-lg z-10 min-w-[120px]">
+          <button
+            className="w-full text-left px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
+            onClick={() => downloadTableData('csv')}
+            type="button"
+          >
+            CSV
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
+            onClick={() => downloadTableData('markdown')}
+            type="button"
+          >
+            Markdown
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -297,7 +297,7 @@ export const TableDownloadDropdown = ({
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "table";
+      a.download = `table.${format === 'csv' ? 'csv' : 'md'}`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -166,7 +166,7 @@ export const TableCopyButton = ({
       className={cn("text-muted-foreground p-1 transition-all", className)}
       onClick={copyTableData}
       type="button"
-      title={`Copy table as ${format.toUpperCase()}`}
+      title={`Copy table as ${format}`}
     >
       {children ?? <Icon size={14} />}
     </button>


### PR DESCRIPTION
## Description

• Added copy functionality for tables with markdown format support
• Implemented CSV and Markdown download options via dropdown menu
• Enhanced table wrapper UI with copy and download buttons positioned above tables

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made

• Created new table.tsx component with TableCopyButton and TableDownloadDropdown and related utilities
• Modified table component in components.tsx to include action buttons
• Added table data extraction, CSV conversion, and markdown formatting utilities

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [x] I have created a changeset for these changes

## Demo

<img width="1058" height="906" alt="image" src="https://github.com/user-attachments/assets/761127c2-54aa-4b7d-a01f-cb96bf4ab95c" />

> video ref : https://x.com/milindmishra_/status/1963681330585387054?s=46