### PR TITLE
fix: parseincompletemarkdown lists emphasis character block issue

### DIFF
--- a/.changeset/good-maps-sneeze.md
+++ b/.changeset/good-maps-sneeze.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+handle lists with emphasis character blocks

--- a/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
+++ b/packages/streamdown/__tests__/parse-incomplete-markdown.test.ts
@@ -862,5 +862,31 @@ describe("parseIncompleteMarkdown", () => {
       expect(parseIncompleteMarkdown("**&lt;tag&gt;")).toBe("**&lt;tag&gt;**");
       expect(parseIncompleteMarkdown("`&amp;")).toBe("`&amp;`");
     });
+
+    it("should handle lists with emphasis character blocks (issue #97)", () => {
+      // Lists with just emphasis markers should not be auto-completed
+      expect(parseIncompleteMarkdown("- __")).toBe("- __");
+      expect(parseIncompleteMarkdown("- **")).toBe("- **");
+      expect(parseIncompleteMarkdown("- __\n- **")).toBe("- __\n- **");
+      expect(parseIncompleteMarkdown("\n- __\n- **")).toBe("\n- __\n- **");
+      
+      // Multiple list items with emphasis markers
+      expect(parseIncompleteMarkdown("* __\n* **")).toBe("* __\n* **");
+      expect(parseIncompleteMarkdown("+ __\n+ **")).toBe("+ __\n+ **");
+      
+      // List items with emphasis markers and text should still complete
+      expect(parseIncompleteMarkdown("- __ text after")).toBe("- __ text after__");
+      expect(parseIncompleteMarkdown("- ** text after")).toBe("- ** text after**");
+      
+      // Mixed list items
+      expect(parseIncompleteMarkdown("- __\n- Normal item\n- **")).toBe("- __\n- Normal item\n- **");
+      
+      // Lists with other emphasis markers
+      expect(parseIncompleteMarkdown("- ***")).toBe("- ***");
+      expect(parseIncompleteMarkdown("- *")).toBe("- *");
+      expect(parseIncompleteMarkdown("- _")).toBe("- _");
+      expect(parseIncompleteMarkdown("- ~~")).toBe("- ~~");
+      expect(parseIncompleteMarkdown("- `")).toBe("- `");
+    });
   });
 });

--- a/packages/streamdown/lib/parse-incomplete-markdown.ts
+++ b/packages/streamdown/lib/parse-incomplete-markdown.ts
@@ -54,6 +54,25 @@ const handleIncompleteBold = (text: string): string => {
       return text;
     }
     
+    // Check if the bold marker is in a list item context
+    // Find the position of the matched bold marker
+    const markerIndex = text.lastIndexOf(boldMatch[1]);
+    const beforeMarker = text.substring(0, markerIndex);
+    const lastNewlineBeforeMarker = beforeMarker.lastIndexOf('\n');
+    const lineStart = lastNewlineBeforeMarker === -1 ? 0 : lastNewlineBeforeMarker + 1;
+    const lineBeforeMarker = text.substring(lineStart, markerIndex);
+    
+    // Check if this line is a list item with just the bold marker
+    if (/^[\s]*[-*+][\s]+$/.test(lineBeforeMarker)) {
+      // This is a list item with just emphasis markers
+      // Check if content after marker spans multiple lines
+      const hasNewlineInContent = contentAfterMarker.includes('\n');
+      if (hasNewlineInContent) {
+        // Don't complete if the content spans to another line
+        return text;
+      }
+    }
+    
     const asteriskPairs = (text.match(/\*\*/g) || []).length;
     if (asteriskPairs % 2 === 1) {
       return `${text}**`;
@@ -74,6 +93,25 @@ const handleIncompleteDoubleUnderscoreItalic = (text: string): string => {
     const contentAfterMarker = italicMatch[2];
     if (!contentAfterMarker || /^[\s_~*`]*$/.test(contentAfterMarker)) {
       return text;
+    }
+    
+    // Check if the underscore marker is in a list item context
+    // Find the position of the matched underscore marker
+    const markerIndex = text.lastIndexOf(italicMatch[1]);
+    const beforeMarker = text.substring(0, markerIndex);
+    const lastNewlineBeforeMarker = beforeMarker.lastIndexOf('\n');
+    const lineStart = lastNewlineBeforeMarker === -1 ? 0 : lastNewlineBeforeMarker + 1;
+    const lineBeforeMarker = text.substring(lineStart, markerIndex);
+    
+    // Check if this line is a list item with just the underscore marker
+    if (/^[\s]*[-*+][\s]+$/.test(lineBeforeMarker)) {
+      // This is a list item with just emphasis markers
+      // Check if content after marker spans multiple lines
+      const hasNewlineInContent = contentAfterMarker.includes('\n');
+      if (hasNewlineInContent) {
+        // Don't complete if the content spans to another line
+        return text;
+      }
     }
     
     const underscorePairs = (text.match(/__/g) || []).length;


### PR DESCRIPTION
This pull request improves the handling of incomplete emphasis markers in Markdown lists within the `streamdown` package. It ensures that list items containing only emphasis markers (like `- **` or `- __`) are not auto-completed, while still correctly completing emphasis markers when there is text after them. The changes also add comprehensive tests to cover these scenarios.

**Markdown emphasis handling improvements:**

* Updated `handleIncompleteBold` and `handleIncompleteDoubleUnderscoreItalic` in `parse-incomplete-markdown.ts` to detect when a list item contains only emphasis markers and prevent auto-completing them, unless there is text after the marker. [[1]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR57-R75) [[2]](diffhunk://#diff-a1a3b395a6fe03aa7d5cea872451f417d31a4217a38f9a70a52d226a65a1fa8cR98-R116)

**Testing enhancements:**

* Added new test cases in `parse-incomplete-markdown.test.ts` to verify correct behavior for lists with emphasis character blocks, including edge cases and mixed content.

**Documentation:**

* Added a changeset describing the patch and the new handling of lists with emphasis character blocks.