### PR TITLE
feat: add download functionality to code blocks

### DIFF
--- a/.changeset/salty-actors-care.md
+++ b/.changeset/salty-actors-care.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+feat: add download functionality to code blocks

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -5,7 +5,7 @@ import {
 } from "react";
 import type { ExtraProps, Options } from "react-markdown";
 import type { BundledLanguage } from "shiki";
-import { CodeBlock, CodeBlockCopyButton } from "./code-block";
+import { CodeBlock, CodeBlockCopyButton, CodeBlockDownloadButton } from "./code-block";
 import { Mermaid } from "./mermaid";
 import { TableCopyButton, TableDownloadDropdown } from "./table";
 import { cn } from "./utils";
@@ -62,7 +62,8 @@ const CodeComponent = ({
         )}
         data-streamdown="mermaid-block"
       >
-        <div className="flex items-center justify-end">
+        <div className="flex items-center justify-end gap-2">
+          <CodeBlockDownloadButton code={code} />
           <CodeBlockCopyButton code={code} />
         </div>
         <Mermaid chart={code} />
@@ -79,6 +80,7 @@ const CodeComponent = ({
       language={language}
       preClassName="overflow-x-auto font-mono text-xs p-4 bg-muted/40"
     >
+      <CodeBlockDownloadButton />
       <CodeBlockCopyButton />
     </CodeBlock>
   );


### PR DESCRIPTION
## Description

- Added download capability to code blocks alongside existing copy functionality
- Users can now download code snippets as files with a single click
- Implemented for both regular code blocks and Mermaid diagrams

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes

- Added `CodeBlockDownloadButton` component with download icon from Lucide React
- Integrated download buttons in both regular code blocks and Mermaid blocks
- Added proper error handling for download operations
- Updated layout to accommodate both copy and download buttons with consistent spacing

## Implementation Details

- Downloads create a blob with `text/plain` MIME type
- Files are downloaded with a default filename of 'file' (can be customized)
- Graceful fallback with error callbacks for unsupported environments
- Consistent styling with existing copy button design

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [ ] I have created a changeset for these changes

## Demo

<img width="1036" height="1001" alt="image" src="https://github.com/user-attachments/assets/c28401a9-ddd2-492d-a547-48f532f376b6" />
