### PR TITLE
feat: add image download functionality with hover controls

### DIFF
--- a/.changeset/wise-ravens-kick.md
+++ b/.changeset/wise-ravens-kick.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+feat: add image download functionality with hover controls

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -6,6 +6,7 @@ import {
 import type { ExtraProps, Options } from "react-markdown";
 import type { BundledLanguage } from "shiki";
 import { CodeBlock, CodeBlockCopyButton } from "./code-block";
+import { ImageComponent } from "./image";
 import { Mermaid } from "./mermaid";
 import { TableCopyButton, TableDownloadDropdown } from "./table";
 import { cn } from "./utils";
@@ -83,6 +84,7 @@ const CodeComponent = ({
     </CodeBlock>
   );
 };
+
 
 export const components: Options["components"] = {
   ol: ({ node, children, className, ...props }) => (
@@ -277,6 +279,7 @@ export const components: Options["components"] = {
     </blockquote>
   ),
   code: CodeComponent,
+  img: ImageComponent,
   pre: ({ children }) => children,
   sup: ({ node, children, className, ...props }) => (
     <sup

--- a/packages/streamdown/lib/image.tsx
+++ b/packages/streamdown/lib/image.tsx
@@ -1,0 +1,98 @@
+import {
+  type DetailedHTMLProps,
+  useState,
+} from "react";
+import type { ExtraProps } from "react-markdown";
+import { DownloadIcon } from "lucide-react";
+import { cn } from "./utils";
+
+export const ImageComponent = ({
+  node,
+  className,
+  src,
+  alt,
+  ...props
+}: DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> &
+  ExtraProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const downloadImage = async () => {
+    if (!src) return;
+
+    try {
+      const response = await fetch(src);
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      
+      // Extract filename from URL or use alt text with proper extension
+      const urlPath = new URL(src, window.location.origin).pathname;
+      const originalFilename = urlPath.split('/').pop() || '';
+      const hasExtension = originalFilename.includes('.') && originalFilename.split('.').pop()?.length! <= 4;
+      
+      let filename = '';
+      if (hasExtension) {
+        filename = originalFilename;
+      } else {
+        // Determine extension from blob type
+        const mimeType = blob.type;
+        let extension = 'png'; // default
+        
+        if (mimeType.includes('jpeg') || mimeType.includes('jpg')) {
+          extension = 'jpg';
+        } else if (mimeType.includes('png')) {
+          extension = 'png';
+        } else if (mimeType.includes('svg')) {
+          extension = 'svg';
+        } else if (mimeType.includes('gif')) {
+          extension = 'gif';
+        } else if (mimeType.includes('webp')) {
+          extension = 'webp';
+        }
+        
+        const baseName = alt || originalFilename || 'image';
+        filename = `${baseName.replace(/\.[^/.]+$/, '')}.${extension}`;
+      }
+      
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Failed to download image:", error);
+    }
+  };
+
+  return (
+    <div
+      className="group relative my-4 inline-block"
+      data-streamdown="image-wrapper"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <img
+        className={cn("max-w-full rounded-lg", className)}
+        data-streamdown="image"
+        src={src}
+        alt={alt}
+        {...props}
+      />
+      {isHovered && (
+        <div className="absolute inset-0 bg-black/10 rounded-lg pointer-events-none" />
+      )}
+      <button
+        className={cn(
+          "absolute bottom-2 right-2 flex items-center justify-center w-8 h-8 bg-background/90 hover:bg-background border border-border rounded-md shadow-sm transition-all duration-200 cursor-pointer backdrop-blur-sm",
+          isHovered ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+        )}
+        onClick={downloadImage}
+        title="Download image"
+        type="button"
+      >
+        <DownloadIcon size={14} />
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

- Add download functionality for images in markdown rendering
- Implement hover overlay with download button for enhanced UX
- Handle various image formats (PNG, JPEG, SVG, GIF, WebP) with proper filename detection

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes

- Created new `ImageComponent` with download capabilities
- Added hover state management and visual feedback
- Integrated smart filename detection from URL or alt text
- Added proper MIME type handling for file extensions
- Registered image component in markdown renderer

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [x] I have created a changeset for these changes

## Demo
 
<img width="981" height="457" alt="image" src="https://github.com/user-attachments/assets/d6e45b63-cf4a-4365-ac42-57949ae4dfca" />
 