### PR TITLE
V1.2 misc fixes

### DIFF
--- a/.changeset/khaki-facts-fly.md
+++ b/.changeset/khaki-facts-fly.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+misc fixes and improvements

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -72,8 +72,8 @@ Block.displayName = "Block";
 export const Streamdown = memo(
   ({
     children,
-    allowedImagePrefixes,
-    allowedLinkPrefixes,
+    allowedImagePrefixes = ["*"],
+    allowedLinkPrefixes = ["*"],
     defaultOrigin,
     parseIncompleteMarkdown: shouldParseIncompleteMarkdown = true,
     components,
@@ -100,8 +100,8 @@ export const Streamdown = memo(
         <div className={cn("space-y-4", className)} {...props}>
           {blocks.map((block, index) => (
             <Block
-              allowedImagePrefixes={allowedImagePrefixes ?? ["*"]}
-              allowedLinkPrefixes={allowedLinkPrefixes ?? ["*"]}
+              allowedImagePrefixes={allowedImagePrefixes}
+              allowedLinkPrefixes={allowedLinkPrefixes}
               components={{
                 ...defaultComponents,
                 ...components,

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -8,6 +8,8 @@ import remarkMath from "remark-math";
 import type { BundledTheme } from "shiki";
 import "katex/dist/katex.min.css";
 import hardenReactMarkdownImport from "harden-react-markdown";
+import type { Options as RemarkGfmOptions } from "remark-gfm";
+import type { Options as RemarkMathOptions } from "remark-math";
 import { components as defaultComponents } from "./lib/components";
 import { parseMarkdownIntoBlocks } from "./lib/parse-blocks";
 import { parseIncompleteMarkdown } from "./lib/parse-incomplete-markdown";
@@ -43,6 +45,12 @@ type BlockProps = HardenReactMarkdownProps & {
   content: string;
   shouldParseIncompleteMarkdown: boolean;
 };
+
+const remarkMathOptions: RemarkMathOptions = {
+  singleDollarTextMath: false,
+};
+
+const remarkGfmOptions: RemarkGfmOptions = {};
 
 const Block = memo(
   ({ content, shouldParseIncompleteMarkdown, ...props }: BlockProps) => {
@@ -104,8 +112,8 @@ export const Streamdown = memo(
               key={`${generatedId}-block_${index}`}
               rehypePlugins={[rehypeKatexPlugin, ...(rehypePlugins ?? [])]}
               remarkPlugins={[
-                remarkGfm,
-                [remarkMath, { singleDollarTextMath: false }],
+                [remarkGfm, remarkGfmOptions],
+                [remarkMath, remarkMathOptions],
                 ...(remarkPlugins ?? []),
               ]}
               shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}

--- a/packages/streamdown/lib/code-block.tsx
+++ b/packages/streamdown/lib/code-block.tsx
@@ -10,7 +10,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { save } from "save-file";
 import {
   type BundledLanguage,
   type BundledTheme,
@@ -18,7 +17,7 @@ import {
 } from "shiki";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import { ShikiThemeContext } from "../index";
-import { cn } from "./utils";
+import { cn, save } from "./utils";
 
 const PRE_TAG_REGEX = /<pre(\s|>)/;
 
@@ -571,10 +570,11 @@ export const CodeBlockDownloadButton = ({
       ? languageExtensionMap[language]
       : "txt";
   const filename = `file.${extension}`;
+  const mimeType = "text/plain";
 
-  const downloadCode = async () => {
+  const downloadCode = () => {
     try {
-      await save(code, filename);
+      save(filename, code, mimeType);
       onDownload?.();
     } catch (error) {
       onError?.(error as Error);

--- a/packages/streamdown/lib/image.tsx
+++ b/packages/streamdown/lib/image.tsx
@@ -1,9 +1,5 @@
 import { DownloadIcon } from "lucide-react";
-import {
-  type DetailedHTMLProps,
-  type ImgHTMLAttributes,
-  useState,
-} from "react";
+import type { DetailedHTMLProps, ImgHTMLAttributes } from "react";
 import type { ExtraProps } from "react-markdown";
 import { cn } from "./utils";
 
@@ -15,10 +11,10 @@ export const ImageComponent = ({
   ...props
 }: DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> &
   ExtraProps) => {
-  const [isHovered, setIsHovered] = useState(false);
-
   const downloadImage = async () => {
-    if (!src) return;
+    if (!src) {
+      return;
+    }
 
     try {
       const response = await fetch(src);
@@ -68,13 +64,17 @@ export const ImageComponent = ({
     }
   };
 
+  if (!src) {
+    return null;
+  }
+
   return (
     <div
       className="group relative my-4 inline-block"
       data-streamdown="image-wrapper"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
+      {/** biome-ignore lint/nursery/useImageSize: "unknown size" */}
+      {/** biome-ignore lint/performance/noImgElement: "streamdown is framework-agnostic" */}
       <img
         alt={alt}
         className={cn("max-w-full rounded-lg", className)}
@@ -82,13 +82,11 @@ export const ImageComponent = ({
         src={src}
         {...props}
       />
-      {isHovered && (
-        <div className="pointer-events-none absolute inset-0 rounded-lg bg-black/10" />
-      )}
+      <div className="pointer-events-none absolute inset-0 hidden rounded-lg bg-black/10 group-hover:block" />
       <button
         className={cn(
           "absolute right-2 bottom-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-border bg-background/90 shadow-sm backdrop-blur-sm transition-all duration-200 hover:bg-background",
-          isHovered ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+          "opacity-0 group-hover:opacity-100"
         )}
         onClick={downloadImage}
         title="Download image"

--- a/packages/streamdown/lib/image.tsx
+++ b/packages/streamdown/lib/image.tsx
@@ -3,14 +3,19 @@ import type { DetailedHTMLProps, ImgHTMLAttributes } from "react";
 import type { ExtraProps } from "react-markdown";
 import { cn } from "./utils";
 
+type ImageComponentProps = DetailedHTMLProps<
+  ImgHTMLAttributes<HTMLImageElement>,
+  HTMLImageElement
+> &
+  ExtraProps;
+
 export const ImageComponent = ({
   node,
   className,
   src,
   alt,
   ...props
-}: DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> &
-  ExtraProps) => {
+}: ImageComponentProps) => {
   const downloadImage = async () => {
     if (!src) {
       return;

--- a/packages/streamdown/lib/image.tsx
+++ b/packages/streamdown/lib/image.tsx
@@ -1,7 +1,7 @@
 import { DownloadIcon } from "lucide-react";
 import type { DetailedHTMLProps, ImgHTMLAttributes } from "react";
 import type { ExtraProps } from "react-markdown";
-import { cn } from "./utils";
+import { cn, save } from "./utils";
 
 type ImageComponentProps = DetailedHTMLProps<
   ImgHTMLAttributes<HTMLImageElement>,
@@ -24,7 +24,6 @@ export const ImageComponent = ({
     try {
       const response = await fetch(src);
       const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
 
       // Extract filename from URL or use alt text with proper extension
       const urlPath = new URL(src, window.location.origin).pathname;
@@ -34,6 +33,7 @@ export const ImageComponent = ({
         originalFilename.split(".").pop()?.length! <= 4;
 
       let filename = "";
+
       if (hasExtension) {
         filename = originalFilename;
       } else {
@@ -57,13 +57,7 @@ export const ImageComponent = ({
         filename = `${baseName.replace(/\.[^/.]+$/, "")}.${extension}`;
       }
 
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
+      save(filename, blob, blob.type);
     } catch (error) {
       console.error("Failed to download image:", error);
     }

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import save from "save-file";
 import { cn } from "./utils";
 
 type TableData = {
@@ -291,27 +292,14 @@ export const TableDownloadDropdown = ({
       }
 
       const tableData = extractTableDataFromElement(tableElement);
-      let content = "";
-      let mimeType = "";
+      const content =
+        format === "csv"
+          ? tableDataToCSV(tableData)
+          : tableDataToMarkdown(tableData);
+      const extension = format === "csv" ? "csv" : "md";
+      const filename = `table.${extension}`;
 
-      if (format === "csv") {
-        content = tableDataToCSV(tableData);
-        mimeType = "text/csv";
-      } else if (format === "markdown") {
-        content = tableDataToMarkdown(tableData);
-        mimeType = "text/markdown";
-      }
-
-      const blob = new Blob([content], { type: mimeType });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `table.${format === "csv" ? "csv" : "md"}`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-
+      save(content, filename);
       setIsOpen(false);
       onDownload?.(format);
     } catch (error) {

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -294,15 +294,12 @@ export const TableDownloadDropdown = ({
       let content = "";
       let mimeType = "";
 
-      switch (format) {
-        case "csv":
-          content = tableDataToCSV(tableData);
-          mimeType = "text/csv";
-          break;
-        case "markdown":
-          content = tableDataToMarkdown(tableData);
-          mimeType = "text/markdown";
-          break;
+      if (format === "csv") {
+        content = tableDataToCSV(tableData);
+        mimeType = "text/csv";
+      } else if (format === "markdown") {
+        content = tableDataToMarkdown(tableData);
+        mimeType = "text/markdown";
       }
 
       const blob = new Blob([content], { type: mimeType });

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -14,20 +14,20 @@ function extractTableDataFromElement(tableElement: HTMLElement): TableData {
 
   // Extract headers
   const headerCells = tableElement.querySelectorAll("thead th");
-  headerCells.forEach((cell) => {
+  for (const cell of headerCells) {
     headers.push(cell.textContent?.trim() || "");
-  });
+  }
 
   // Extract rows
   const bodyRows = tableElement.querySelectorAll("tbody tr");
-  bodyRows.forEach((row) => {
+  for (const row of bodyRows) {
     const rowData: string[] = [];
     const cells = row.querySelectorAll("td");
-    cells.forEach((cell) => {
+    for (const cell of cells) {
       rowData.push(cell.textContent?.trim() || "");
-    });
+    }
     rows.push(rowData);
-  });
+  }
 
   return { headers, rows };
 }
@@ -51,9 +51,9 @@ function tableDataToCSV(data: TableData): string {
   }
 
   // Add data rows
-  rows.forEach((row) => {
+  for (const row of rows) {
     csvRows.push(row.map(escapeCSV).join(","));
-  });
+  }
 
   return csvRows.join("\n");
 }
@@ -75,7 +75,7 @@ function tableDataToMarkdown(data: TableData): string {
   markdownRows.push(`| ${headers.map(() => "---").join(" | ")} |`);
 
   // Add data rows
-  rows.forEach((row) => {
+  for (const row of rows) {
     // Pad row with empty strings if it's shorter than headers
     const paddedRow = [...row];
     while (paddedRow.length < headers.length) {
@@ -83,7 +83,7 @@ function tableDataToMarkdown(data: TableData): string {
     }
     const escapedRow = paddedRow.map((cell) => cell.replace(/\|/g, "\\|"));
     markdownRows.push(`| ${escapedRow.join(" | ")} |`);
-  });
+  }
 
   return markdownRows.join("\n");
 }

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -1,7 +1,6 @@
 import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import save from "save-file";
-import { cn } from "./utils";
+import { cn, save } from "./utils";
 
 type TableData = {
   headers: string[];
@@ -298,8 +297,9 @@ export const TableDownloadDropdown = ({
           : tableDataToMarkdown(tableData);
       const extension = format === "csv" ? "csv" : "md";
       const filename = `table.${extension}`;
+      const mimeType = format === "csv" ? "text/csv" : "text/markdown";
 
-      save(content, filename);
+      save(filename, content, mimeType);
       setIsOpen(false);
       onDownload?.(format);
     } catch (error) {

--- a/packages/streamdown/lib/utils.ts
+++ b/packages/streamdown/lib/utils.ts
@@ -3,8 +3,8 @@ import { twMerge } from 'tailwind-merge';
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-export const save = (filename: string, content: string, mimeType: string) => {
-  const blob = new Blob([content], { type: mimeType });
+export const save = (filename: string, content: string | Blob, mimeType: string) => {
+  const blob = typeof content === 'string' ? new Blob([content], { type: mimeType }) : content;
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/packages/streamdown/lib/utils.ts
+++ b/packages/streamdown/lib/utils.ts
@@ -2,3 +2,15 @@ import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export const save = (filename: string, content: string, mimeType: string) => {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};

--- a/packages/streamdown/package.json
+++ b/packages/streamdown/package.json
@@ -58,7 +58,6 @@
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "save-file": "^2.3.1",
     "shiki": "^3.12.2",
     "tailwind-merge": "^3.3.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,9 +232,6 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
-      save-file:
-        specifier: ^2.3.1
-        version: 2.3.1
       shiki:
         specifier: ^3.12.2
         version: 3.12.2
@@ -2253,9 +2250,6 @@ packages:
   ast-v8-to-istanbul@0.3.4:
     resolution: {integrity: sha512-cxrAnZNLBnQwBPByK4CeDaw5sWZtMilJE/Q3iDA0aamgaIVNDF9T6K2/8DfYDZEejZ2jNnDrG9m8MY72HFd0KA==}
 
-  atob-lite@2.0.0:
-    resolution: {integrity: sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==}
-
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2654,10 +2648,6 @@ packages:
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
-  dtype@2.0.0:
-    resolution: {integrity: sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==}
-    engines: {node: '>= 0.8.0'}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -2762,9 +2752,6 @@ packages:
       picomatch:
         optional: true
 
-  file-saver@2.0.5:
-    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2775,9 +2762,6 @@ packages:
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
-
-  flatten-vertex-data@1.0.2:
-    resolution: {integrity: sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2947,21 +2931,6 @@ packages:
 
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
-
-  is-base64@0.1.0:
-    resolution: {integrity: sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg==}
-
-  is-blob@1.0.0:
-    resolution: {integrity: sha512-QIZDHQZpRfMEZwSTD7egdNZS7H/awVW9FZ3yJv+gg1z8d8GPXEs76QWL67fZs2BoBqp2dGtamTJpEYFJHmD73g==}
-    engines: {node: '>=0.10.0'}
-
-  is-blob@2.1.0:
-    resolution: {integrity: sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==}
-    engines: {node: '>=6'}
-
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -3385,9 +3354,6 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3395,10 +3361,6 @@ packages:
   minizlib@3.0.2:
     resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
     engines: {node: '>= 18'}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -3821,9 +3783,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  save-file@2.3.1:
-    resolution: {integrity: sha512-VOD2Ojb1/kuj0XbvSXzZ5xr4rRSZD8f+HzKWGztXNp93gBQDj3njFt9HMhmLtnwd7q0BjJkzLXqd8M2+PFS1qg==}
-
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -3861,10 +3820,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-mime@0.1.0:
-    resolution: {integrity: sha512-2EoTElzj77w0hV4lW6nWdA+MR+81hviMBhEc/ppUi0+Q311EFCvwKrGS7dcxqvGRKnUdbAyqPJtBQbRYgmtmvQ==}
-    engines: {'0': node >= 0.2.0}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -3905,9 +3860,6 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
-
-  string-to-arraybuffer@1.0.2:
-    resolution: {integrity: sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4045,9 +3997,6 @@ packages:
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
-
-  to-array-buffer@3.2.0:
-    resolution: {integrity: sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4393,10 +4342,6 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
-
-  write@1.0.3:
-    resolution: {integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==}
-    engines: {node: '>=4'}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -6351,7 +6296,7 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))':
+  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.3.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
@@ -6436,8 +6381,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
       estree-walker: 3.0.3
       js-tokens: 9.0.1
-
-  atob-lite@2.0.0: {}
 
   bail@2.0.2: {}
 
@@ -6842,8 +6785,6 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dtype@2.0.0: {}
-
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.201: {}
@@ -6949,8 +6890,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  file-saver@2.0.5: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -6965,10 +6904,6 @@ snapshots:
       magic-string: 0.30.17
       mlly: 1.7.4
       rollup: 4.46.2
-
-  flatten-vertex-data@1.0.2:
-    dependencies:
-      dtype: 2.0.0
 
   foreground-child@3.3.1:
     dependencies:
@@ -7191,14 +7126,6 @@ snapshots:
 
   is-arrayish@0.3.2:
     optional: true
-
-  is-base64@0.1.0: {}
-
-  is-blob@1.0.0: {}
-
-  is-blob@2.1.0: {}
-
-  is-buffer@2.0.5: {}
 
   is-decimal@2.0.1: {}
 
@@ -7838,17 +7765,11 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  minimist@1.2.8: {}
-
   minipass@7.1.2: {}
 
   minizlib@3.0.2:
     dependencies:
       minipass: 7.1.2
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
 
   mkdirp@3.0.1: {}
 
@@ -8384,15 +8305,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  save-file@2.3.1:
-    dependencies:
-      file-saver: 2.0.5
-      is-blob: 1.0.0
-      is-buffer: 2.0.5
-      simple-mime: 0.1.0
-      to-array-buffer: 3.2.0
-      write: 1.0.3
-
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -8454,8 +8366,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-mime@0.1.0: {}
-
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -8488,11 +8398,6 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
-
-  string-to-arraybuffer@1.0.2:
-    dependencies:
-      atob-lite: 2.0.0
-      is-base64: 0.1.0
 
   string-width@4.2.3:
     dependencies:
@@ -8623,12 +8528,6 @@ snapshots:
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
-
-  to-array-buffer@3.2.0:
-    dependencies:
-      flatten-vertex-data: 1.0.2
-      is-blob: 2.1.0
-      string-to-arraybuffer: 1.0.2
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8926,7 +8825,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))
+      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.3.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9029,10 +8928,6 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-
-  write@1.0.3:
-    dependencies:
-      mkdirp: 0.5.6
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
This pull request refactors the download functionality for code blocks, tables, and images in the `streamdown` package by removing the `save-file` dependency and introducing a new in-house `save` utility. The changes improve consistency and maintainability, and also update several code paths to use more idiomatic JavaScript. Minor improvements are made to markdown parsing options and default props.

**Download functionality refactor:**

* Removed the `save-file` dependency from the project and replaced it with a custom `save` function in `packages/streamdown/lib/utils.ts`, which handles file downloads for strings and blobs. All usages of external file-saving utilities have been updated to use this new function. [[1]](diffhunk://#diff-e28fa88c8a33d0288d7a3349f213ee694f986cd5edc738879d80f4209a155b63R5-R16) [[2]](diffhunk://#diff-86a9aefecfb78a273608892690a311585ac1c02df67409622e6a3ae6e337cac2L61) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL235-L237) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3824-L3826)
* Updated code blocks (`packages/streamdown/lib/code-block.tsx`), image downloads (`packages/streamdown/lib/image.tsx`), and table downloads (`packages/streamdown/lib/table.tsx`) to use the new `save` function, simplifying the download logic and ensuring consistent behavior across file types. [[1]](diffhunk://#diff-b900d575a73c911c1ad702296e8116492c24cf5137ea12ba0b93012edb074c63L13-R20) [[2]](diffhunk://#diff-b900d575a73c911c1ad702296e8116492c24cf5137ea12ba0b93012edb074c63R573-R577) [[3]](diffhunk://#diff-f247833b40da3f812e058456b3cbbaef6bcb2ba6ab58fd21e5e0a65d2f73ba9cL2-L26) [[4]](diffhunk://#diff-f247833b40da3f812e058456b3cbbaef6bcb2ba6ab58fd21e5e0a65d2f73ba9cL59-R88) [[5]](diffhunk://#diff-d6f2fa01caede83273202ec5468ebbce24f7cd95a8900a5249ba78396e2f3ad8L3-R3) [[6]](diffhunk://#diff-d6f2fa01caede83273202ec5468ebbce24f7cd95a8900a5249ba78396e2f3ad8L294-R302)

**Code quality and performance improvements:**

* Replaced array `.forEach()` loops with `for...of` loops in table parsing and CSV/Markdown generation for better performance and readability. [[1]](diffhunk://#diff-d6f2fa01caede83273202ec5468ebbce24f7cd95a8900a5249ba78396e2f3ad8L16-R29) [[2]](diffhunk://#diff-d6f2fa01caede83273202ec5468ebbce24f7cd95a8900a5249ba78396e2f3ad8L53-R55) [[3]](diffhunk://#diff-d6f2fa01caede83273202ec5468ebbce24f7cd95a8900a5249ba78396e2f3ad8L77-R85)

**Other enhancements:**

* Added and used explicit types for markdown plugin options and updated how remark plugins are configured, improving type safety and clarity. [[1]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cR11-R12) [[2]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cR49-R54) [[3]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cL107-R116)
* Set default values for `allowedImagePrefixes` and `allowedLinkPrefixes` props in the `Streamdown` component, ensuring more predictable behavior. [[1]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cL67-R76) [[2]](diffhunk://#diff-d8701d382009863aa1bca03e8a9a95406137e84cb7247599b0143a033c94836cL95-R104)

**Dependency cleanup:**

* Removed unused dependencies from `pnpm-lock.yaml` and `package.json`, reducing package bloat. [[1]](diffhunk://#diff-86a9aefecfb78a273608892690a311585ac1c02df67409622e6a3ae6e337cac2L61) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2256-L2258) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2657-L2660) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2765-L2767) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2779-L2781) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2951-L2965) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3388-L3390) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3399-L3402) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3865-L3868) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3909-L3911)