### PR TITLE
feat: add theme support with dark mode for table export dropdown

### DIFF
--- a/.changeset/slimy-bikes-fetch.md
+++ b/.changeset/slimy-bikes-fetch.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+feat: add theme support with dark mode for table export dropdown

--- a/apps/test/app/components/chat.tsx
+++ b/apps/test/app/components/chat.tsx
@@ -35,9 +35,9 @@ export const Chat = ({ models }: ChatProps) => {
   const [model, setModel] = useState(models[0].value);
 
   return (
-    <div className="mx-auto flex h-screen max-w-4xl flex-col divide-y border-x">
+    <div className="mx-auto flex h-screen max-w-4xl flex-col divide-y border-x bg-background">
       <div className="flex flex-1 divide-x overflow-hidden">
-        <div className="flex-1 space-y-4 overflow-y-auto bg-black p-4 text-white">
+        <div className="flex-1 space-y-4 overflow-y-auto bg-muted p-4 text-muted-foreground">
           {messages.map((message) => (
             <div key={message.id}>
               <span className="font-bold">
@@ -80,7 +80,7 @@ export const Chat = ({ models }: ChatProps) => {
             </div>
           ))}
         </div>
-        <div className="flex-1 space-y-4 overflow-y-auto p-4">
+        <div className="flex-1 space-y-4 overflow-y-auto bg-background p-4">
           {messages.map((message) => (
             <div key={message.id}>
               <span className="font-bold">
@@ -121,7 +121,7 @@ export const Chat = ({ models }: ChatProps) => {
         </div>
       </div>
       <form
-        className="grid shrink-0 items-center gap-2 divide-y p-4"
+        className="grid shrink-0 items-center gap-2 divide-y bg-background p-4"
         onSubmit={(e) => {
           e.preventDefault();
           if (input.trim()) {

--- a/apps/test/app/components/providers/theme-provider.tsx
+++ b/apps/test/app/components/providers/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/apps/test/app/components/theme-switcher.tsx
+++ b/apps/test/app/components/theme-switcher.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ThemeSwitcher() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/test/app/layout.tsx
+++ b/apps/test/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "./components/providers/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,8 +27,15 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+        >
+        <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
         {children}
+      </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/test/app/page.tsx
+++ b/apps/test/app/page.tsx
@@ -1,5 +1,6 @@
 import { gateway } from "@ai-sdk/gateway";
 import { Chat } from "./components/chat";
+import { ThemeSwitcher } from "./components/theme-switcher";
 
 export default async function Page() {
   const { models } = await gateway.getAvailableModels();
@@ -10,5 +11,12 @@ export default async function Page() {
       value: model.id,
     }));
 
-  return <Chat models={list} />;
+  return (
+    <div className="relative h-screen">
+      <div className="absolute top-4 right-4 z-10">
+        <ThemeSwitcher />
+      </div>
+      <Chat models={list} />
+    </div>
+  );
 }

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -343,16 +343,16 @@ export const TableDownloadDropdown = ({
         {children ?? <DownloadIcon size={14} />}
       </button>
       {isOpen && (
-        <div className="absolute top-full right-0 z-10 mt-1 min-w-[120px] rounded-md border border-border bg-white shadow-lg">
+        <div className="absolute top-full right-0 z-10 mt-1 min-w-[120px] rounded-md border border-border bg-popover shadow-lg">
           <button
-            className="w-full px-3 py-2 text-left text-sm transition-colors hover:bg-muted/40"
+            className="w-full px-3 py-2 text-left text-sm text-popover-foreground transition-colors hover:bg-muted/40"
             onClick={() => downloadTableData("csv")}
             type="button"
           >
             CSV
           </button>
           <button
-            className="w-full px-3 py-2 text-left text-sm transition-colors hover:bg-muted/40"
+            className="w-full px-3 py-2 text-left text-sm text-popover-foreground transition-colors hover:bg-muted/40"
             onClick={() => downloadTableData("markdown")}
             type="button"
           >

--- a/packages/streamdown/lib/table.tsx
+++ b/packages/streamdown/lib/table.tsx
@@ -343,7 +343,7 @@ export const TableDownloadDropdown = ({
         {children ?? <DownloadIcon size={14} />}
       </button>
       {isOpen && (
-        <div className="absolute top-full right-0 z-10 mt-1 min-w-[120px] rounded-md border border-border bg-popover shadow-lg">
+        <div className="absolute top-full right-0 z-10 mt-1 min-w-[120px] rounded-md border border-border bg-popover text-popover-foreground shadow-lg">
           <button
             className="w-full px-3 py-2 text-left text-sm text-popover-foreground transition-colors hover:bg-muted/40"
             onClick={() => downloadTableData("csv")}


### PR DESCRIPTION
## Description

- Add theme provider and theme switcher component to test app
- Update chat component styling to use theme-aware CSS variables
- Fix table export dropdown styling for dark theme compatibility

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)


## Screenshots/Demos

<!-- If applicable, add screenshots or demos to help explain your changes -->

> before 

<img width="776" height="490" alt="image" src="https://github.com/user-attachments/assets/1ab8a7ec-49e1-411b-af10-bed7e97f6b83" />


> after 

<img width="1427" height="437" alt="image" src="https://github.com/user-attachments/assets/3bfc0a18-1c03-4085-9c44-25e4a2ea0dba" />


## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [ ] I have created a changeset for these changes
