### PR TITLE
`showControls` to show and hide copy/download buttons

### DIFF
--- a/.changeset/real-coins-lay.md
+++ b/.changeset/real-coins-lay.md
@@ -1,0 +1,5 @@
+---
+"streamdown": minor
+---
+
+Add showControls prop to control copy/download button visibility.

--- a/.changeset/real-coins-lay.md
+++ b/.changeset/real-coins-lay.md
@@ -2,4 +2,4 @@
 "streamdown": minor
 ---
 
-Add showControls prop to control copy/download button visibility.
+Add controls prop to control copy/download button visibility.

--- a/apps/website/app/components/props.tsx
+++ b/apps/website/app/components/props.tsx
@@ -69,6 +69,13 @@ const props = [
     description:
       "Custom configuration for Mermaid diagrams including theme, colors, fonts, and other rendering options. See Mermaid documentation for all available options.",
   },
+  {
+    name: "showControls",
+    type: "boolean | { table?: boolean, code?: boolean, mermaid?: boolean }",
+    default: "true",
+    description:
+      "Control the visibility of copy and download buttons. Can be a boolean to show/hide all controls, or an object to selectively control buttons for tables, code blocks, and Mermaid diagrams.",
+  },
 ];
 
 export const Props = () => (

--- a/apps/website/app/components/props.tsx
+++ b/apps/website/app/components/props.tsx
@@ -70,7 +70,7 @@ const props = [
       "Custom configuration for Mermaid diagrams including theme, colors, fonts, and other rendering options. See Mermaid documentation for all available options.",
   },
   {
-    name: "showControls",
+    name: "controls",
     type: "boolean | { table?: boolean, code?: boolean, mermaid?: boolean }",
     default: "true",
     description:

--- a/packages/streamdown/README.md
+++ b/packages/streamdown/README.md
@@ -166,6 +166,7 @@ Streamdown accepts all the same props as react-markdown, plus additional streami
 | `defaultOrigin` | `string` | - | Default origin to use for relative URLs in links and images |
 | `shikiTheme` | `[BundledTheme, BundledTheme]` | `['github-light', 'github-dark']` | The light and dark themes to use for code blocks |
 | `mermaidConfig` | `MermaidConfig` | - | Custom configuration for Mermaid diagrams (theme, colors, etc.) |
+| `showControls` | `boolean \| { table?: boolean, code?: boolean, mermaid?: boolean }` | `true` | Control visibility of copy/download buttons |
 
 ## Architecture
 

--- a/packages/streamdown/README.md
+++ b/packages/streamdown/README.md
@@ -166,7 +166,7 @@ Streamdown accepts all the same props as react-markdown, plus additional streami
 | `defaultOrigin` | `string` | - | Default origin to use for relative URLs in links and images |
 | `shikiTheme` | `[BundledTheme, BundledTheme]` | `['github-light', 'github-dark']` | The light and dark themes to use for code blocks |
 | `mermaidConfig` | `MermaidConfig` | - | Custom configuration for Mermaid diagrams (theme, colors, etc.) |
-| `showControls` | `boolean \| { table?: boolean, code?: boolean, mermaid?: boolean }` | `true` | Control visibility of copy/download buttons |
+| `controls` | `boolean \| { table?: boolean, code?: boolean, mermaid?: boolean }` | `true` | Control visibility of copy/download buttons |
 
 ## Architecture
 

--- a/packages/streamdown/__tests__/show-controls.test.tsx
+++ b/packages/streamdown/__tests__/show-controls.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Streamdown } from "../index";
 
-describe("showControls prop", () => {
+describe("controls prop", () => {
   const markdownWithTable = `
 | Column 1 | Column 2 |
 |----------|----------|
@@ -24,42 +24,52 @@ graph TD
 
   describe("boolean configuration", () => {
     it("should show all controls by default", () => {
-      const { container } = render(<Streamdown>{markdownWithTable}</Streamdown>);
+      const { container } = render(
+        <Streamdown>{markdownWithTable}</Streamdown>
+      );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const buttons = tableWrapper?.querySelectorAll("button");
 
       expect(buttons?.length).toBeGreaterThan(0);
     });
 
-    it("should show all controls when showControls is true", () => {
+    it("should show all controls when controls is true", () => {
       const { container } = render(
-        <Streamdown showControls={true}>{markdownWithTable}</Streamdown>
+        <Streamdown controls={true}>{markdownWithTable}</Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const buttons = tableWrapper?.querySelectorAll("button");
 
       expect(buttons?.length).toBeGreaterThan(0);
     });
 
-    it("should hide all controls when showControls is false", () => {
+    it("should hide all controls when controls is false", () => {
       const { container } = render(
-        <Streamdown showControls={false}>{markdownWithTable}</Streamdown>
+        <Streamdown controls={false}>{markdownWithTable}</Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const buttons = tableWrapper?.querySelectorAll("button");
 
       expect(buttons?.length).toBe(0);
     });
 
-    it("should hide code block controls when showControls is false", () => {
+    it("should hide code block controls when controls is false", () => {
       const { container } = render(
-        <Streamdown showControls={false}>{markdownWithCode}</Streamdown>
+        <Streamdown controls={false}>{markdownWithCode}</Streamdown>
       );
 
-      const buttons = container.querySelectorAll('[data-code-block-header] button');
+      const buttons = container.querySelectorAll(
+        "[data-code-block-header] button"
+      );
 
       expect(buttons?.length).toBe(0);
     });
@@ -68,12 +78,12 @@ graph TD
   describe("object configuration", () => {
     it("should hide only table controls when table is false", () => {
       const { container } = render(
-        <Streamdown showControls={{ table: false }}>
-          {markdownWithTable}
-        </Streamdown>
+        <Streamdown controls={{ table: false }}>{markdownWithTable}</Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const buttons = tableWrapper?.querySelectorAll("button");
 
       expect(buttons?.length).toBe(0);
@@ -81,12 +91,12 @@ graph TD
 
     it("should show table controls when table is true", () => {
       const { container } = render(
-        <Streamdown showControls={{ table: true }}>
-          {markdownWithTable}
-        </Streamdown>
+        <Streamdown controls={{ table: true }}>{markdownWithTable}</Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const buttons = tableWrapper?.querySelectorAll("button");
 
       expect(buttons?.length).toBeGreaterThan(0);
@@ -94,36 +104,38 @@ graph TD
 
     it("should hide only code controls when code is false", () => {
       const { container } = render(
-        <Streamdown showControls={{ code: false }}>
-          {markdownWithCode}
-        </Streamdown>
+        <Streamdown controls={{ code: false }}>{markdownWithCode}</Streamdown>
       );
 
-      const buttons = container.querySelectorAll('[data-code-block-header] button');
+      const buttons = container.querySelectorAll(
+        "[data-code-block-header] button"
+      );
 
       expect(buttons?.length).toBe(0);
     });
 
     it("should show code controls when code is true", () => {
       const { container } = render(
-        <Streamdown showControls={{ code: true }}>
-          {markdownWithCode}
-        </Streamdown>
+        <Streamdown controls={{ code: true }}>{markdownWithCode}</Streamdown>
       );
 
-      const buttons = container.querySelectorAll('[data-code-block-header] button');
+      const buttons = container.querySelectorAll(
+        "[data-code-block-header] button"
+      );
 
       expect(buttons?.length).toBeGreaterThan(0);
     });
 
     it("should hide only mermaid controls when mermaid is false", () => {
       const { container } = render(
-        <Streamdown showControls={{ mermaid: false }}>
+        <Streamdown controls={{ mermaid: false }}>
           {markdownWithMermaid}
         </Streamdown>
       );
 
-      const mermaidBlock = container.querySelector('[data-streamdown="mermaid-block"]');
+      const mermaidBlock = container.querySelector(
+        '[data-streamdown="mermaid-block"]'
+      );
       const buttons = mermaidBlock?.querySelectorAll("button");
 
       expect(buttons?.length).toBe(0);
@@ -136,16 +148,20 @@ ${markdownWithCode}
       `;
 
       const { container } = render(
-        <Streamdown showControls={{ table: false, code: true }}>
+        <Streamdown controls={{ table: false, code: true }}>
           {combined}
         </Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const tableButtons = tableWrapper?.querySelectorAll("button");
       expect(tableButtons?.length).toBe(0);
 
-      const codeButtons = container.querySelectorAll('[data-code-block-header] button');
+      const codeButtons = container.querySelectorAll(
+        "[data-code-block-header] button"
+      );
       expect(codeButtons?.length).toBeGreaterThan(0);
     });
 
@@ -156,37 +172,38 @@ ${markdownWithCode}
       `;
 
       const { container } = render(
-        <Streamdown showControls={{ table: false }}>
-          {combined}
-        </Streamdown>
+        <Streamdown controls={{ table: false }}>{combined}</Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const tableButtons = tableWrapper?.querySelectorAll("button");
       expect(tableButtons?.length).toBe(0);
 
       // Code controls should still show since not specified
-      const codeButtons = container.querySelectorAll('[data-code-block-header] button');
+      const codeButtons = container.querySelectorAll(
+        "[data-code-block-header] button"
+      );
       expect(codeButtons?.length).toBeGreaterThan(0);
     });
   });
 
   describe("with custom components", () => {
-    it("should respect showControls with custom component overrides", () => {
+    it("should respect controls with custom component overrides", () => {
       const CustomParagraph = ({ children }: any) => (
         <p className="custom-paragraph">{children}</p>
       );
 
       const { container } = render(
-        <Streamdown
-          showControls={false}
-          components={{ p: CustomParagraph }}
-        >
+        <Streamdown components={{ p: CustomParagraph }} controls={false}>
           {markdownWithTable}
         </Streamdown>
       );
 
-      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableWrapper = container.querySelector(
+        '[data-streamdown="table-wrapper"]'
+      );
       const buttons = tableWrapper?.querySelectorAll("button");
 
       expect(buttons?.length).toBe(0);

--- a/packages/streamdown/__tests__/show-controls.test.tsx
+++ b/packages/streamdown/__tests__/show-controls.test.tsx
@@ -1,0 +1,195 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Streamdown } from "../index";
+
+describe("showControls prop", () => {
+  const markdownWithTable = `
+| Column 1 | Column 2 |
+|----------|----------|
+| Data 1   | Data 2   |
+`;
+
+  const markdownWithCode = `
+\`\`\`javascript
+console.log('Hello World');
+\`\`\`
+`;
+
+  const markdownWithMermaid = `
+\`\`\`mermaid
+graph TD
+    A[Start] --> B[End]
+\`\`\`
+`;
+
+  describe("boolean configuration", () => {
+    it("should show all controls by default", () => {
+      const { container } = render(<Streamdown>{markdownWithTable}</Streamdown>);
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const buttons = tableWrapper?.querySelectorAll("button");
+
+      expect(buttons?.length).toBeGreaterThan(0);
+    });
+
+    it("should show all controls when showControls is true", () => {
+      const { container } = render(
+        <Streamdown showControls={true}>{markdownWithTable}</Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const buttons = tableWrapper?.querySelectorAll("button");
+
+      expect(buttons?.length).toBeGreaterThan(0);
+    });
+
+    it("should hide all controls when showControls is false", () => {
+      const { container } = render(
+        <Streamdown showControls={false}>{markdownWithTable}</Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const buttons = tableWrapper?.querySelectorAll("button");
+
+      expect(buttons?.length).toBe(0);
+    });
+
+    it("should hide code block controls when showControls is false", () => {
+      const { container } = render(
+        <Streamdown showControls={false}>{markdownWithCode}</Streamdown>
+      );
+
+      const buttons = container.querySelectorAll('[data-code-block-header] button');
+
+      expect(buttons?.length).toBe(0);
+    });
+  });
+
+  describe("object configuration", () => {
+    it("should hide only table controls when table is false", () => {
+      const { container } = render(
+        <Streamdown showControls={{ table: false }}>
+          {markdownWithTable}
+        </Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const buttons = tableWrapper?.querySelectorAll("button");
+
+      expect(buttons?.length).toBe(0);
+    });
+
+    it("should show table controls when table is true", () => {
+      const { container } = render(
+        <Streamdown showControls={{ table: true }}>
+          {markdownWithTable}
+        </Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const buttons = tableWrapper?.querySelectorAll("button");
+
+      expect(buttons?.length).toBeGreaterThan(0);
+    });
+
+    it("should hide only code controls when code is false", () => {
+      const { container } = render(
+        <Streamdown showControls={{ code: false }}>
+          {markdownWithCode}
+        </Streamdown>
+      );
+
+      const buttons = container.querySelectorAll('[data-code-block-header] button');
+
+      expect(buttons?.length).toBe(0);
+    });
+
+    it("should show code controls when code is true", () => {
+      const { container } = render(
+        <Streamdown showControls={{ code: true }}>
+          {markdownWithCode}
+        </Streamdown>
+      );
+
+      const buttons = container.querySelectorAll('[data-code-block-header] button');
+
+      expect(buttons?.length).toBeGreaterThan(0);
+    });
+
+    it("should hide only mermaid controls when mermaid is false", () => {
+      const { container } = render(
+        <Streamdown showControls={{ mermaid: false }}>
+          {markdownWithMermaid}
+        </Streamdown>
+      );
+
+      const mermaidBlock = container.querySelector('[data-streamdown="mermaid-block"]');
+      const buttons = mermaidBlock?.querySelectorAll("button");
+
+      expect(buttons?.length).toBe(0);
+    });
+
+    it("should allow mixed configuration", () => {
+      const combined = `
+${markdownWithTable}
+${markdownWithCode}
+      `;
+
+      const { container } = render(
+        <Streamdown showControls={{ table: false, code: true }}>
+          {combined}
+        </Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableButtons = tableWrapper?.querySelectorAll("button");
+      expect(tableButtons?.length).toBe(0);
+
+      const codeButtons = container.querySelectorAll('[data-code-block-header] button');
+      expect(codeButtons?.length).toBeGreaterThan(0);
+    });
+
+    it("should default unspecified controls to true", () => {
+      const combined = `
+${markdownWithTable}
+${markdownWithCode}
+      `;
+
+      const { container } = render(
+        <Streamdown showControls={{ table: false }}>
+          {combined}
+        </Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const tableButtons = tableWrapper?.querySelectorAll("button");
+      expect(tableButtons?.length).toBe(0);
+
+      // Code controls should still show since not specified
+      const codeButtons = container.querySelectorAll('[data-code-block-header] button');
+      expect(codeButtons?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("with custom components", () => {
+    it("should respect showControls with custom component overrides", () => {
+      const CustomParagraph = ({ children }: any) => (
+        <p className="custom-paragraph">{children}</p>
+      );
+
+      const { container } = render(
+        <Streamdown
+          showControls={false}
+          components={{ p: CustomParagraph }}
+        >
+          {markdownWithTable}
+        </Streamdown>
+      );
+
+      const tableWrapper = container.querySelector('[data-streamdown="table-wrapper"]');
+      const buttons = tableWrapper?.querySelectorAll("button");
+
+      expect(buttons?.length).toBe(0);
+    });
+  });
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -8,9 +8,9 @@ import remarkMath from "remark-math";
 import type { BundledTheme } from "shiki";
 import "katex/dist/katex.min.css";
 import hardenReactMarkdownImport from "harden-react-markdown";
+import type { MermaidConfig } from "mermaid";
 import type { Options as RemarkGfmOptions } from "remark-gfm";
 import type { Options as RemarkMathOptions } from "remark-math";
-import type { MermaidConfig } from "mermaid";
 import { components as defaultComponents } from "./lib/components";
 import { parseMarkdownIntoBlocks } from "./lib/parse-blocks";
 import { parseIncompleteMarkdown } from "./lib/parse-incomplete-markdown";
@@ -33,18 +33,20 @@ const hardenReactMarkdown =
 const HardenedMarkdown: ReturnType<typeof hardenReactMarkdown> =
   hardenReactMarkdown(ReactMarkdown);
 
-export type ControlsConfig = boolean | {
-  table?: boolean;
-  code?: boolean;
-  mermaid?: boolean;
-};
+export type ControlsConfig =
+  | boolean
+  | {
+      table?: boolean;
+      code?: boolean;
+      mermaid?: boolean;
+    };
 
 export type StreamdownProps = HardenReactMarkdownProps & {
   parseIncompleteMarkdown?: boolean;
   className?: string;
   shikiTheme?: [BundledTheme, BundledTheme];
   mermaidConfig?: MermaidConfig;
-  showControls?: ControlsConfig;
+  controls?: ControlsConfig;
 };
 
 export const ShikiThemeContext = createContext<[BundledTheme, BundledTheme]>([
@@ -52,7 +54,9 @@ export const ShikiThemeContext = createContext<[BundledTheme, BundledTheme]>([
   "github-dark" as BundledTheme,
 ]);
 
-export const MermaidConfigContext = createContext<MermaidConfig | undefined>(undefined);
+export const MermaidConfigContext = createContext<MermaidConfig | undefined>(
+  undefined
+);
 
 export const ControlsContext = createContext<ControlsConfig>(true);
 
@@ -97,7 +101,7 @@ export const Streamdown = memo(
     className,
     shikiTheme = ["github-light", "github-dark"],
     mermaidConfig,
-    showControls = true,
+    controls = true,
     ...props
   }: StreamdownProps) => {
     // Parse the children to remove incomplete markdown tokens if enabled
@@ -115,7 +119,7 @@ export const Streamdown = memo(
     return (
       <ShikiThemeContext.Provider value={shikiTheme}>
         <MermaidConfigContext.Provider value={mermaidConfig}>
-          <ControlsContext.Provider value={showControls}>
+          <ControlsContext.Provider value={controls}>
             <div className={cn("space-y-4", className)} {...props}>
               {blocks.map((block, index) => (
                 <Block

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -33,11 +33,18 @@ const hardenReactMarkdown =
 const HardenedMarkdown: ReturnType<typeof hardenReactMarkdown> =
   hardenReactMarkdown(ReactMarkdown);
 
+export type ControlsConfig = boolean | {
+  table?: boolean;
+  code?: boolean;
+  mermaid?: boolean;
+};
+
 export type StreamdownProps = HardenReactMarkdownProps & {
   parseIncompleteMarkdown?: boolean;
   className?: string;
   shikiTheme?: [BundledTheme, BundledTheme];
   mermaidConfig?: MermaidConfig;
+  showControls?: ControlsConfig;
 };
 
 export const ShikiThemeContext = createContext<[BundledTheme, BundledTheme]>([
@@ -46,6 +53,8 @@ export const ShikiThemeContext = createContext<[BundledTheme, BundledTheme]>([
 ]);
 
 export const MermaidConfigContext = createContext<MermaidConfig | undefined>(undefined);
+
+export const ControlsContext = createContext<ControlsConfig>(true);
 
 type BlockProps = HardenReactMarkdownProps & {
   content: string;
@@ -88,6 +97,7 @@ export const Streamdown = memo(
     className,
     shikiTheme = ["github-light", "github-dark"],
     mermaidConfig,
+    showControls = true,
     ...props
   }: StreamdownProps) => {
     // Parse the children to remove incomplete markdown tokens if enabled
@@ -105,29 +115,31 @@ export const Streamdown = memo(
     return (
       <ShikiThemeContext.Provider value={shikiTheme}>
         <MermaidConfigContext.Provider value={mermaidConfig}>
-          <div className={cn("space-y-4", className)} {...props}>
-            {blocks.map((block, index) => (
-              <Block
-                allowedImagePrefixes={allowedImagePrefixes}
-                allowedLinkPrefixes={allowedLinkPrefixes}
-                components={{
-                  ...defaultComponents,
-                  ...components,
-                }}
-                content={block}
-                defaultOrigin={defaultOrigin}
-                // biome-ignore lint/suspicious/noArrayIndexKey: "required"
-                key={`${generatedId}-block_${index}`}
-                rehypePlugins={[rehypeKatexPlugin, ...(rehypePlugins ?? [])]}
-                remarkPlugins={[
-                  [remarkGfm, remarkGfmOptions],
-                  [remarkMath, remarkMathOptions],
-                  ...(remarkPlugins ?? []),
-                ]}
-                shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
-              />
-            ))}
-          </div>
+          <ControlsContext.Provider value={showControls}>
+            <div className={cn("space-y-4", className)} {...props}>
+              {blocks.map((block, index) => (
+                <Block
+                  allowedImagePrefixes={allowedImagePrefixes}
+                  allowedLinkPrefixes={allowedLinkPrefixes}
+                  components={{
+                    ...defaultComponents,
+                    ...components,
+                  }}
+                  content={block}
+                  defaultOrigin={defaultOrigin}
+                  // biome-ignore lint/suspicious/noArrayIndexKey: "required"
+                  key={`${generatedId}-block_${index}`}
+                  rehypePlugins={[rehypeKatexPlugin, ...(rehypePlugins ?? [])]}
+                  remarkPlugins={[
+                    [remarkGfm, remarkGfmOptions],
+                    [remarkMath, remarkMathOptions],
+                    ...(remarkPlugins ?? []),
+                  ]}
+                  shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
+                />
+              ))}
+            </div>
+          </ControlsContext.Provider>
         </MermaidConfigContext.Provider>
       </ShikiThemeContext.Provider>
     );

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -6,7 +6,7 @@ import {
 } from "react";
 import type { ExtraProps, Options } from "react-markdown";
 import type { BundledLanguage } from "shiki";
-import { MermaidConfigContext, ControlsContext } from "../index";
+import { ControlsContext, MermaidConfigContext } from "../index";
 import {
   CodeBlock,
   CodeBlockCopyButton,
@@ -22,8 +22,11 @@ const LANGUAGE_REGEX = /language-([^\s]+)/;
 const shouldShowControls = (
   config: boolean | { table?: boolean; code?: boolean; mermaid?: boolean },
   type: "table" | "code" | "mermaid"
-): boolean => {
-  if (typeof config === "boolean") return config;
+) => {
+  if (typeof config === "boolean") {
+    return config;
+  }
+
   return config[type] !== false;
 };
 

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -6,7 +6,7 @@ import {
 } from "react";
 import type { ExtraProps, Options } from "react-markdown";
 import type { BundledLanguage } from "shiki";
-import { MermaidConfigContext } from "../index";
+import { MermaidConfigContext, ControlsContext } from "../index";
 import {
   CodeBlock,
   CodeBlockCopyButton,
@@ -18,6 +18,14 @@ import { TableCopyButton, TableDownloadDropdown } from "./table";
 import { cn } from "./utils";
 
 const LANGUAGE_REGEX = /language-([^\s]+)/;
+
+const shouldShowControls = (
+  config: boolean | { table?: boolean; code?: boolean; mermaid?: boolean },
+  type: "table" | "code" | "mermaid"
+): boolean => {
+  if (typeof config === "boolean") return config;
+  return config[type] !== false;
+};
 
 const CodeComponent = ({
   node,
@@ -62,6 +70,9 @@ const CodeComponent = ({
 
   if (language === "mermaid") {
     const mermaidConfig = useContext(MermaidConfigContext);
+    const controlsConfig = useContext(ControlsContext);
+    const showMermaidControls = shouldShowControls(controlsConfig, "mermaid");
+
     return (
       <div
         className={cn(
@@ -70,14 +81,19 @@ const CodeComponent = ({
         )}
         data-streamdown="mermaid-block"
       >
-        <div className="flex items-center justify-end gap-2">
-          <CodeBlockDownloadButton code={code} language={language} />
-          <CodeBlockCopyButton code={code} />
-        </div>
+        {showMermaidControls && (
+          <div className="flex items-center justify-end gap-2">
+            <CodeBlockDownloadButton code={code} language={language} />
+            <CodeBlockCopyButton code={code} />
+          </div>
+        )}
         <Mermaid chart={code} config={mermaidConfig} />
       </div>
     );
   }
+
+  const controlsConfig = useContext(ControlsContext);
+  const showCodeControls = shouldShowControls(controlsConfig, "code");
 
   return (
     <CodeBlock
@@ -88,9 +104,44 @@ const CodeComponent = ({
       language={language}
       preClassName="overflow-x-auto font-mono text-xs p-4 bg-muted/40"
     >
-      <CodeBlockDownloadButton code={code} language={language} />
-      <CodeBlockCopyButton />
+      {showCodeControls && (
+        <>
+          <CodeBlockDownloadButton code={code} language={language} />
+          <CodeBlockCopyButton />
+        </>
+      )}
     </CodeBlock>
+  );
+};
+
+const TableComponent = ({ node, children, className, ...props }: any) => {
+  const controlsConfig = useContext(ControlsContext);
+  const showTableControls = shouldShowControls(controlsConfig, "table");
+
+  return (
+    <div
+      className="my-4 flex flex-col space-y-2"
+      data-streamdown="table-wrapper"
+    >
+      {showTableControls && (
+        <div className="flex items-center justify-end gap-1">
+          <TableCopyButton />
+          <TableDownloadDropdown />
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table
+          className={cn(
+            "w-full border-collapse border border-border",
+            className
+          )}
+          data-streamdown="table"
+          {...props}
+        >
+          {children}
+        </table>
+      </div>
+    </div>
   );
 };
 
@@ -212,29 +263,7 @@ export const components: Options["components"] = {
       {children}
     </h6>
   ),
-  table: ({ node, children, className, ...props }) => (
-    <div
-      className="my-4 flex flex-col space-y-2"
-      data-streamdown="table-wrapper"
-    >
-      <div className="flex items-center justify-end gap-1">
-        <TableCopyButton />
-        <TableDownloadDropdown />
-      </div>
-      <div className="overflow-x-auto">
-        <table
-          className={cn(
-            "w-full border-collapse border border-border",
-            className
-          )}
-          data-streamdown="table"
-          {...props}
-        >
-          {children}
-        </table>
-      </div>
-    </div>
-  ),
+  table: TableComponent,
   thead: ({ node, children, className, ...props }) => (
     <thead
       className={cn("bg-muted/80", className)}

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -38,6 +38,8 @@ const CodeComponent = ({
 }: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> &
   ExtraProps) => {
   const inline = node?.position?.start.line === node?.position?.end.line;
+  const mermaidConfig = useContext(MermaidConfigContext);
+  const controlsConfig = useContext(ControlsContext);
 
   if (inline) {
     return (
@@ -72,8 +74,6 @@ const CodeComponent = ({
   }
 
   if (language === "mermaid") {
-    const mermaidConfig = useContext(MermaidConfigContext);
-    const controlsConfig = useContext(ControlsContext);
     const showMermaidControls = shouldShowControls(controlsConfig, "mermaid");
 
     return (
@@ -95,7 +95,6 @@ const CodeComponent = ({
     );
   }
 
-  const controlsConfig = useContext(ControlsContext);
   const showCodeControls = shouldShowControls(controlsConfig, "code");
 
   return (


### PR DESCRIPTION
## Description

Added a new `showControls` prop to the Streamdown component that allows users to control the visibility of copy and download buttons on tables, code blocks, and Mermaid diagrams. The prop accepts either a boolean (to show/hide all controls globally) or an object for granular control per component type.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #135 

## Changes Made

- Added `ControlsConfig` type and `showControls` prop to `StreamdownProps`
- Created `ControlsContext` to pass control configuration down the component tree
- Updated table, code block, and Mermaid components to conditionally render controls based on configuration
- Added comprehensive test suite with 12 tests covering boolean and object configurations
- Updated documentation in both main README and website props section

## Testing

- [x] All existing tests pass **(except 1 pre-existing flaky Mermaid test)**
- [x] Added new tests for the changes
- [ ] Manually tested the changes

### Test Coverage

Added comprehensive test coverage with 12 new tests covering:
- Boolean configuration (`true`/`false`)
- Object configuration with selective control
- Mixed configurations
- Default behavior
- Compatibility with custom components

## Screenshots/Demos

<!-- If applicable, add screenshots or demos to help explain your changes -->

## Checklist


- [ ] My code follows the project's code style **(I had some issues running the format command)**
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes **(except 1 pre-existing flaky Mermaid test)**
- [x] I have created a changeset (`pnpm changeset`) 

## Changeset

- [x] I have created a changeset for these changes

## Additional Notes

I had some issues running `pnpm format` and `pnpm lint`. It seems like eslint and prettier are not configured correctly?