### PR TITLE
Add `normalizeHtmlIndentation` prop to prevent indented HTML tags fro…

### DIFF
--- a/.changeset/normalize-html-indentation.md
+++ b/.changeset/normalize-html-indentation.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Add `normalizeHtmlIndentation` prop to prevent indented HTML tags from being treated as code blocks

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -30,6 +30,12 @@ Streamdown can be configured to suit your needs. This guide will walk you throug
       description: "Configure which Markdown completions remend should perform",
       type: "RemendOptions",
     },
+    normalizeHtmlIndentation: {
+      description:
+        'Normalize indentation in HTML blocks to prevent 4+ space indents from being treated as code blocks',
+      type: 'boolean',
+      default: 'false',
+    },
     isAnimating: {
       description:
         "Indicates if content is currently streaming (disables copy buttons)",

--- a/packages/streamdown/__tests__/normalize-html-indentation.test.tsx
+++ b/packages/streamdown/__tests__/normalize-html-indentation.test.tsx
@@ -1,0 +1,293 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { normalizeHtmlIndentation, Streamdown } from "../index";
+
+describe("normalizeHtmlIndentation utility function", () => {
+  it("should return empty string unchanged", () => {
+    expect(normalizeHtmlIndentation("")).toBe("");
+  });
+
+  it("should return non-HTML content unchanged", () => {
+    const markdown = "# Hello World\n\nThis is a paragraph.";
+    expect(normalizeHtmlIndentation(markdown)).toBe(markdown);
+  });
+
+  it("should return indented code blocks unchanged when not starting with HTML", () => {
+    const codeBlock = "    const x = 1;\n    const y = 2;";
+    expect(normalizeHtmlIndentation(codeBlock)).toBe(codeBlock);
+  });
+
+  it("should normalize indented HTML tags within HTML blocks", () => {
+    const input = `<div>
+    <span>Hello</span>
+</div>`;
+    const expected = `<div>
+<span>Hello</span>
+</div>`;
+    expect(normalizeHtmlIndentation(input)).toBe(expected);
+  });
+
+  it("should handle deeply nested HTML with various indentation levels", () => {
+    const input = `<div class="wrapper">
+    <div class="inner">
+      <h4>Title</h4>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+      </ul>
+    </div>
+
+    <div class="another">
+      <h4>Another Title</h4>
+    </div>
+</div>`;
+
+    const result = normalizeHtmlIndentation(input);
+
+    // All HTML tags should not have 4+ spaces before them
+    expect(result).not.toMatch(/\n {4,}<\w/);
+    // Content should still be preserved
+    expect(result).toContain("Title");
+    expect(result).toContain("Another Title");
+    expect(result).toContain("Item 1");
+  });
+
+  it("should preserve text content indentation inside pre tags", () => {
+    const input = `<pre>
+    code with spaces
+</pre>`;
+    // Only HTML tags get dedented, not text content
+    const result = normalizeHtmlIndentation(input);
+    expect(result).toContain("    code with spaces");
+  });
+
+  it("should handle HTML starting with whitespace", () => {
+    const input = "  <div>content</div>";
+    expect(normalizeHtmlIndentation(input)).toBe("  <div>content</div>");
+  });
+
+  it("should handle self-closing tags", () => {
+    const input = `<div>
+    <img src="test.jpg" />
+    <br />
+</div>`;
+    const result = normalizeHtmlIndentation(input);
+    expect(result).toContain('<img src="test.jpg" />');
+    expect(result).toContain("<br />");
+  });
+
+  it("should handle HTML comments", () => {
+    const input = `<div>
+    <!-- comment -->
+    <span>text</span>
+</div>`;
+    const result = normalizeHtmlIndentation(input);
+    expect(result).toContain("<!-- comment -->");
+  });
+
+  it("should handle doctype declarations", () => {
+    const input = `<!DOCTYPE html>
+    <html>
+    <body>
+    </body>
+    </html>`;
+    const result = normalizeHtmlIndentation(input);
+    expect(result).toContain("<!DOCTYPE html>");
+    expect(result).toContain("<html>");
+  });
+
+  it("should not affect markdown code fences", () => {
+    // This starts with markdown, not HTML, so should be unchanged
+    const input = "```html\n    <div>code</div>\n```";
+    expect(normalizeHtmlIndentation(input)).toBe(input);
+  });
+
+  it("should handle mixed content after HTML", () => {
+    const input = `<div>
+    <p>paragraph</p>
+</div>
+
+Some text after.`;
+    const result = normalizeHtmlIndentation(input);
+    expect(result).toContain("<p>paragraph</p>");
+    expect(result).toContain("Some text after.");
+  });
+});
+
+describe("Streamdown with normalizeHtmlIndentation prop", () => {
+  it("should render indented HTML as code block when normalizeHtmlIndentation is false (default)", () => {
+    const content = `<div class="wrapper">
+    <div class="inner">
+      <h4>Title</h4>
+    </div>
+
+    <div class="another">
+      <h4>Another Title</h4>
+    </div>
+</div>`;
+
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    // Without normalization, the second div may be treated as code
+    // due to 4-space indentation after blank line
+    const headings = container.querySelectorAll("h4");
+    // May only find one heading if second block is rendered as code
+    expect(headings.length).toBeLessThanOrEqual(2);
+  });
+
+  it("should render all HTML correctly when normalizeHtmlIndentation is true", () => {
+    const content = `<div class="wrapper">
+    <div class="inner">
+      <h4>Title One</h4>
+    </div>
+
+    <div class="another">
+      <h4>Title Two</h4>
+    </div>
+</div>`;
+
+    const { container } = render(
+      <Streamdown normalizeHtmlIndentation>{content}</Streamdown>
+    );
+
+    const headings = Array.from(container.querySelectorAll("h4")).map(
+      (h) => h.textContent
+    );
+
+    expect(headings).toContain("Title One");
+    expect(headings).toContain("Title Two");
+    // Should not have any code blocks
+    expect(container.querySelectorAll("code").length).toBe(0);
+  });
+
+  it("should handle streaming socket data scenario", () => {
+    // Simulating concatenated socket chunks with indented HTML
+    const content = `<div class="container">
+    <div class="success">
+      <h4>Success Points</h4>
+      <ul>
+        <li><strong>Point 1</strong> - Description</li>
+        <li><strong>Point 2</strong> - Description</li>
+      </ul>
+    </div>
+
+    <div class="failure">
+      <h4>Failure Points</h4>
+      <ul>
+        <li><strong>Issue 1</strong> - Description</li>
+        <li><strong>Issue 2</strong> - Description</li>
+      </ul>
+    </div>
+</div>`;
+
+    const { container } = render(
+      <Streamdown normalizeHtmlIndentation>{content}</Streamdown>
+    );
+
+    const headings = Array.from(container.querySelectorAll("h4")).map(
+      (h) => h.textContent
+    );
+
+    expect(headings).toContain("Success Points");
+    expect(headings).toContain("Failure Points");
+
+    const listItems = container.querySelectorAll("li");
+    expect(listItems.length).toBe(4);
+
+    // Verify no code blocks were created
+    expect(container.querySelectorAll("code").length).toBe(0);
+  });
+
+  it("should not affect non-HTML content when normalizeHtmlIndentation is true", () => {
+    const content = `# Heading
+
+This is a paragraph.
+
+Another paragraph.`;
+
+    const { container } = render(
+      <Streamdown normalizeHtmlIndentation>{content}</Streamdown>
+    );
+
+    // Should have the heading
+    expect(container.querySelector("h1")?.textContent).toBe("Heading");
+
+    // Should have paragraphs
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs.length).toBe(2);
+  });
+
+  it("should handle complex nested HTML with multiple levels", () => {
+    const content = `<article>
+    <header>
+        <h1>Article Title</h1>
+    </header>
+    <section>
+        <h2>Section 1</h2>
+        <p>Content here</p>
+    </section>
+    <section>
+        <h2>Section 2</h2>
+        <p>More content</p>
+    </section>
+    <footer>
+        <p>Footer text</p>
+    </footer>
+</article>`;
+
+    const { container } = render(
+      <Streamdown normalizeHtmlIndentation>{content}</Streamdown>
+    );
+
+    expect(container.querySelector("h1")?.textContent).toBe("Article Title");
+    expect(container.querySelectorAll("h2").length).toBe(2);
+    expect(container.querySelector("footer")).toBeTruthy();
+  });
+});
+
+describe("parse-blocks HTML merging", () => {
+  it("should merge HTML blocks with nested tags correctly", () => {
+    const content = `<div>
+<div>Inner content</div>
+</div>
+
+<p>After</p>`;
+
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    // Should have the outer div with inner content
+    expect(container.textContent).toContain("Inner content");
+    expect(container.textContent).toContain("After");
+  });
+
+  it("should handle self-closing tags without breaking block merging", () => {
+    const content = `<div>
+<br />
+<p>Text after break</p>
+</div>`;
+
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    expect(container.querySelector("br")).toBeTruthy();
+    expect(container.querySelector("p")?.textContent).toBe("Text after break");
+  });
+
+  it("should handle void elements correctly", () => {
+    const content = `<div>
+<br />
+<hr />
+<input type="text" />
+<p>After void elements</p>
+</div>`;
+
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    expect(container.querySelector("br")).toBeTruthy();
+    expect(container.querySelector("hr")).toBeTruthy();
+    expect(container.querySelector("input")).toBeTruthy();
+    expect(container.querySelector("p")?.textContent).toBe(
+      "After void elements"
+    );
+  });
+});
+


### PR DESCRIPTION
The second <div> (after the blank line) gets rendered as a code block instead of HTML.

## Description

<!-- Provide a brief description of the changes in this PR -->
## Description

When rendering AI-generated HTML content with nested tags (e.g., from streaming socket data), indented HTML tags with 4+ leading spaces are incorrectly parsed as code blocks by the Markdown parser.

This occurs because the Markdown specification treats lines starting with 4+ spaces as indented code blocks. While this behavior is correct for Markdown syntax, it causes issues when rendering HTML content that uses indentation for readability.

### Problem Scenario

In streaming scenarios where HTML content is generated incrementally, nested tags are often indented with 4+ spaces for better readability. However, when such content is parsed by Streamdown, the indented HTML tags after blank lines are mistakenly treated as code blocks instead of HTML elements.

### Example

HTML content like this:

<div class="wrapper">
    <div class="success">
      <h4>Title One</h4>
    </div>

    <div class="failure">
      <h4>Title Two</h4>
    </div>
</div>The second `div tag` (after the blank line) gets rendered as a code block instead of HTML.


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues using #issue-number -->

Fixes #
Closes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->

- **New `normalizeHtmlIndentation` prop** - When enabled, removes excessive indentation (4+ spaces) before HTML tags
- **New `normalizeHtmlIndentation()` utility function** - Exported for manual preprocessing
-  **Improved HTML block merging** - Better handling of nested HTML tags with void elements and self-closing tags
- Updated documentation - Added normalizeHtmlIndentation prop to the configuration documentation.


## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

<!-- If applicable, include test coverage information -->
-Added 20 new unit tests in normalize-html-indentation.test.tsx covering:
  Utility function edge cases (empty strings, non-HTML content, various HTML structures)
  Streamdown component behavior with the new prop enabled/disabled
  HTML block merging scenarios with nested tags, void elements, and self-closing tags
-All 541 existing tests continue to pass
-No breaking changes to existing functionality

## Screenshots/Demos

<!-- If applicable, add screenshots or demos to help explain your changes -->

Before (without normalizeHtmlIndentation):
Indented HTML tags after blank lines are rendered as code blocks.
After (with normalizeHtmlIndentation={true}):
All HTML tags are correctly rendered as HTML elements.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [x] I have created a changeset for these changes

## Additional Notes

<!-- Add any additional notes, concerns, or discussion points -->