### PR TITLE
chore: move unified from devDependencies to dependencies

### DIFF
--- a/.changeset/light-keys-beg.md
+++ b/.changeset/light-keys-beg.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+chore: move unified from devDependencies to dependencies

--- a/packages/streamdown/package.json
+++ b/packages/streamdown/package.json
@@ -46,7 +46,6 @@
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",
     "tsup": "^8.5.0",
-    "unified": "^11.0.5",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
@@ -72,6 +71,7 @@
     "remark-rehype": "^11.1.2",
     "shiki": "^3.12.2",
     "tailwind-merge": "^3.3.1",
+    "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -540,9 +543,6 @@ importers:
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)
-      unified:
-        specifier: ^11.0.5
-        version: 11.0.5
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(tsx@4.20.6)


### PR DESCRIPTION
## Description

Since `unified` has been imported in `markdown.tsx`, it should be listed in dependencies.

This change prevent `unified` bundled into dist, which may cause `CallableInstance` in unified be mangled info `IIFE`, and then be mangled into `null` in app bundle minify.

## Before
in build dist:
```
// unified/callable-instance.js
var an = (function (e) {
    let o = this.constructor.prototype, r = o[e], s = function () {
        return r.apply(s, arguments);
    };
    return Object.setPrototypeOf(s, o), s;
});

// unified/index.js
var So = {}.hasOwnProperty, je = class e extends an {}

// after app minified
class e extends null {}
```