### PR TITLE
Refactor click outside handler for Shadow DOM compatibility

### DIFF
--- a/packages/streamdown/lib/mermaid/download-button.tsx
+++ b/packages/streamdown/lib/mermaid/download-button.tsx
@@ -79,9 +79,10 @@ export const MermaidDownloadDropdown = ({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const path = event.composedPath();
       if (
         dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
+        !path.includes(dropdownRef.current)
       ) {
         setIsOpen(false);
       }

--- a/packages/streamdown/lib/table/copy-dropdown.tsx
+++ b/packages/streamdown/lib/table/copy-dropdown.tsx
@@ -73,9 +73,10 @@ export const TableCopyDropdown = ({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const path = event.composedPath();
       if (
         dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
+        !path.includes(dropdownRef.current)
       ) {
         setIsOpen(false);
       }

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -145,9 +145,10 @@ export const TableDownloadDropdown = ({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const path = event.composedPath();
       if (
         dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
+        !path.includes(dropdownRef.current)
       ) {
         setIsOpen(false);
       }


### PR DESCRIPTION
The click outside handlers for the table copy, table download, and mermaid download dropdowns have been refactored to use `event.composedPath()` instead of `event.target`. This change resolves the issue where dropdown menu items were not clickable when rendered inside a Shadow DOM.
Fixes #337

