### PR TITLE
docs: clarify that custom components replace default styles

### DIFF
--- a/apps/website/content/docs/components.mdx
+++ b/apps/website/content/docs/components.mdx
@@ -59,9 +59,36 @@ You can override any of the following standard HTML components:
 Custom components receive all the props that the default components would receive, including:
 
 - `children` - The content to render
-- `className` - CSS class names (if applicable)
+- `className` - CSS class names from the Markdown AST (if applicable)
 - `node` - The Markdown AST node (for advanced use cases)
 - Element-specific props (e.g., `href` for links, `src` for images)
+
+<Callout type="warn">
+  Custom components **fully replace** the default implementations, including their built-in Tailwind styles. The `className` prop only contains classes from the Markdown AST (e.g., `language-js` on code elements) — it does **not** include the default styles that Streamdown normally applies.
+  
+  If you need to preserve the default appearance, you must re-apply the styles yourself. See the [Styling](/docs/styling) documentation for the default classes, or use [CSS selectors with `data-streamdown` attributes](/docs/styling#global-css-targeting) instead of component overrides when you only need visual changes.
+</Callout>
+
+For example, the default `h2` component applies `mt-6 mb-2 font-semibold text-2xl`. When you override it, those styles are lost unless you include them:
+
+```tsx title="app/page.tsx"
+<Streamdown
+  components={{
+    // ❌ Loses default spacing and font styles
+    h2: ({ children }) => (
+      <h2 className="text-blue-500">{children}</h2>
+    ),
+    // ✅ Preserves default styles alongside custom ones
+    h2: ({ children, className }) => (
+      <h2 className={`mt-6 mb-2 font-semibold text-2xl text-blue-500 ${className ?? ''}`}>
+        {children}
+      </h2>
+    ),
+  }}
+>
+  {markdown}
+</Streamdown>
+```
 
 ```tsx title="app/page.tsx"
 <Streamdown


### PR DESCRIPTION
## Description

Clarify in the Components documentation that custom components fully replace the default implementations, including their built-in Tailwind styles. The `className` prop only contains classes from the Markdown AST (e.g., `language-js` on code elements), not the default styles that Streamdown normally applies.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #394

## Changes Made

- Added a warning callout in the "Component Props" section explaining that custom components lose default styles
- Added a before/after code example showing how to preserve default `h2` styles when overriding
- Clarified the `className` prop description to say "from the Markdown AST"
- Referenced the Styling docs and `data-streamdown` CSS selectors as alternatives

## Testing

- [x] All existing tests pass (docs-only change)
- [ ] Added new tests for the changes — N/A (documentation only)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have created a changeset (`pnpm changeset`) — N/A (docs only, no package changes)