### PR TITLE
fix(remend): don't treat underscores inside HTML tags as emphasis

### DIFF
--- a/packages/remend/__tests__/html-tags.test.ts
+++ b/packages/remend/__tests__/html-tags.test.ts
@@ -62,6 +62,18 @@ describe("incomplete HTML tag stripping", () => {
     expect(remend("<div>Hello</div> <span")).toBe("<div>Hello</div>");
   });
 
+  it("should not add trailing underscore for HTML attributes with underscores", () => {
+    expect(remend('<a target="_blank" href="https://link.com">word</a>')).toBe(
+      '<a target="_blank" href="https://link.com">word</a>'
+    );
+    expect(remend('<a target="_blank">link</a>')).toBe(
+      '<a target="_blank">link</a>'
+    );
+    expect(remend('<iframe src="x" sandbox="allow_scripts">')).toBe(
+      '<iframe src="x" sandbox="allow_scripts">'
+    );
+  });
+
   it("should be disabled when htmlTags option is false", () => {
     expect(remend("Hello <div", { htmlTags: false })).toBe("Hello <div");
   });

--- a/packages/remend/src/emphasis-handlers.ts
+++ b/packages/remend/src/emphasis-handlers.ts
@@ -13,6 +13,7 @@ import {
 import {
   isHorizontalRule,
   isWithinCodeBlock,
+  isWithinHtmlTag,
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
   isWordChar,
@@ -148,6 +149,11 @@ const shouldSkipUnderscore = (
 
   // Skip if within a link or image URL
   if (isWithinLinkOrImageUrl(text, index)) {
+    return true;
+  }
+
+  // Skip if within an HTML tag (e.g. <a target="_blank">)
+  if (isWithinHtmlTag(text, index)) {
     return true;
   }
 

--- a/packages/remend/src/utils.ts
+++ b/packages/remend/src/utils.ts
@@ -145,6 +145,33 @@ export const isWithinLinkOrImageUrl = (
   return false;
 };
 
+// Check if a position is within an HTML tag (between < and >)
+// e.g. <a target="_blank"> — the underscore in _blank is inside the tag
+export const isWithinHtmlTag = (text: string, position: number): boolean => {
+  // Search backwards from position to find < or >
+  for (let i = position - 1; i >= 0; i -= 1) {
+    if (text[i] === ">") {
+      return false; // Found closing > first — we're outside a tag
+    }
+    if (text[i] === "<") {
+      // Found opening < — check it starts a valid tag (followed by letter or /)
+      const nextChar = i + 1 < text.length ? text[i + 1] : "";
+      if (
+        (nextChar >= "a" && nextChar <= "z") ||
+        (nextChar >= "A" && nextChar <= "Z") ||
+        nextChar === "/"
+      ) {
+        return true;
+      }
+      return false;
+    }
+    if (text[i] === "\n") {
+      return false; // Tags don't span lines in this context
+    }
+  }
+  return false;
+};
+
 // Check if a marker sequence appears to be a horizontal rule
 // Horizontal rules must be on their own line with optional leading/trailing whitespace
 // Valid patterns: ---, ***, ___, or longer sequences with optional spaces between markers


### PR DESCRIPTION
## What?

Fix trailing `_` being appended when `remend()` processes HTML tags containing underscores in attribute values (e.g. `target="_blank"`).

## Why?

The emphasis handler counts single underscores to detect unclosed italic markers. It already skips underscores inside markdown links and math blocks, but didn't account for HTML tags. So `<a target="_blank">` was parsed as having an unclosed `_` emphasis, and remend appended a closing `_`.

**Before:**
```
remend('<a target="_blank" href="https://link.com">word</a>')
// → '<a target="_blank" href="https://link.com">word</a>_'
```

**After:**
```
remend('<a target="_blank" href="https://link.com">word</a>')
// → '<a target="_blank" href="https://link.com">word</a>'
```

## How?

1. Added `isWithinHtmlTag(text, position)` utility — searches backwards from the underscore position to check if it's between `<` and `>`.
2. Added the check to `shouldSkipUnderscore()` in `emphasis-handlers.ts`.
3. Added test cases for `target="_blank"` and other HTML attributes with underscores.

All 283 tests pass.

Fixes #385