### PR TITLE
Add /playground to website

### DIFF
--- a/apps/website/app/[lang]/playground/page.tsx
+++ b/apps/website/app/[lang]/playground/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { Streamdown } from "streamdown";
+
+const defaultMarkdown = `# Hello, world
+
+Some **bold**, *italic*, and ~~strikethrough~~ text.
+
+## A list
+
+- First item
+- Second item
+  - Nested
+- Third item
+
+## A table
+
+| Name | Flavor |
+|------|--------|
+| Apple | Sweet |
+| Lemon | Sour |
+
+## Some code
+
+\`\`\`js
+function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+\`\`\`
+
+> A blockquote for good measure.
+`;
+
+const Playground = () => {
+  const [markdown, setMarkdown] = useState(defaultMarkdown);
+  const [mode, setMode] = useState<"static" | "streaming">("static");
+
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="flex shrink-0 items-center justify-between border-b px-6 py-3">
+        <h1 className="text-lg font-semibold tracking-tight">
+          Streamdown Playground
+        </h1>
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-2 text-sm" htmlFor="mode">
+            <span className="text-muted-foreground">Mode:</span>
+            <select
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+              id="mode"
+              onChange={(e) =>
+                setMode(e.target.value as "static" | "streaming")
+              }
+              value={mode}
+            >
+              <option value="static">Static</option>
+              <option value="streaming">Streaming</option>
+            </select>
+          </label>
+          <button
+            className="rounded-md border px-3 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            onClick={() => setMarkdown("")}
+            type="button"
+          >
+            Clear
+          </button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Input Panel */}
+        <div className="flex w-1/2 flex-col border-r">
+          <div className="flex shrink-0 items-center border-b bg-muted/50 px-4 py-2">
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Markdown Input
+            </span>
+          </div>
+          <textarea
+            className="flex-1 resize-none bg-background p-4 font-mono text-sm leading-relaxed focus:outline-none"
+            onChange={(e) => setMarkdown(e.target.value)}
+            placeholder="Type your markdown here..."
+            spellCheck={false}
+            value={markdown}
+          />
+        </div>
+
+        {/* Output Panel */}
+        <div className="flex w-1/2 flex-col">
+          <div className="flex shrink-0 items-center border-b bg-muted/50 px-4 py-2">
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Streamdown Output
+            </span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-6">
+            <div className="mx-auto max-w-prose">
+              <Streamdown mode={mode}>{markdown}</Streamdown>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Playground;

--- a/apps/website/geistdocs.tsx
+++ b/apps/website/geistdocs.tsx
@@ -20,6 +20,10 @@ export const nav = [
     href: "/docs",
   },
   {
+    label: "Playground",
+    href: "/playground",
+  },
+  {
     label: "AI Elements",
     href: "https://ai-sdk.dev/elements",
   },


### PR DESCRIPTION
## Description

Adds an interactive playground page to the website where markdown input can be compared side-by-side with the rendered Streamdown output in real time.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

## Changes Made

- Added `/playground` page with a split-pane layout: markdown textarea on the left, live Streamdown output on the right
- Includes a mode toggle (static/streaming) and a clear button
- Added "Playground" link to the top navigation menu

## Testing

- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

N/A — UI-only addition with no logic changes to the library.

## Screenshots/Demos

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created a changeset (`pnpm changeset`)

## Changeset

- [ ] I have created a changeset for these changes

## Additional Notes

No changeset needed — this only adds a page to the website, no package changes.