### PR TITLE
docs: add build step to contributing setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,11 @@ Thank you for your interest in contributing to Streamdown! We welcome contributi
    ```bash
    pnpm install
    ```
-4. Run the tests to ensure everything is working:
+4. Build all packages (required before running tests):
+   ```bash
+   pnpm build
+   ```
+5. Run the tests to ensure everything is working:
    ```bash
    pnpm test
    ```


### PR DESCRIPTION
## Description

Adds the missing `pnpm build` step to the setup instructions in CONTRIBUTING.md. Without this step, new contributors will encounter test failures due to unbuilt internal packages (e.g., `remend`).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

N/A - Discovered while following the setup instructions as a new contributor.

## Changes Made

- Added step 4: `pnpm build` (required before running tests)
- Renumbered the test step to step 5

## Testing

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manually tested the changes

Verified that following the updated instructions allows tests to pass successfully.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] N/A - Documentation-only change, no package version bump needed

## Additional Notes

The error that occurs without this step:
```
Error: Failed to resolve entry for package "remend". The package may have incorrect main/module/exports specified in its package.json.
```

This happens because internal packages like `remend` need to be built before the `streamdown` package tests can resolve them.