### PR TITLE
feat: export table action components and utilities

### DIFF
--- a/.changeset/export-table-components.md
+++ b/.changeset/export-table-components.md
@@ -1,0 +1,5 @@
+---
+"streamdown": minor
+---
+
+Export table action components (`TableCopyDropdown`, `TableDownloadButton`, `TableDownloadDropdown`) and utilities (`extractTableDataFromElement`, `tableDataToCSV`, `tableDataToTSV`, `tableDataToMarkdown`, `escapeMarkdownTableCell`, `TableData`), enabling custom table overrides to preserve copy/download interactivity.

--- a/apps/website/content/docs/components.mdx
+++ b/apps/website/content/docs/components.mdx
@@ -149,6 +149,48 @@ Once the code fence closes, the hook returns `false` and your component can rend
 </Streamdown>
 ```
 
+## Preserving Table Interactivity
+
+When overriding the `table` component, the built-in copy and download buttons are lost because custom components fully replace default implementations. To restore them, import the table action components and include them in your custom table:
+
+```tsx title="app/page.tsx"
+import {
+  Streamdown,
+  TableCopyDropdown,
+  TableDownloadDropdown,
+} from "streamdown";
+
+<Streamdown
+  components={{
+    table: ({ children, className }) => (
+      <div data-streamdown="table-wrapper">
+        <div className="flex items-center justify-end gap-1">
+          <TableCopyDropdown />
+          <TableDownloadDropdown />
+        </div>
+        <MyCustomTable className={className}>{children}</MyCustomTable>
+      </div>
+    ),
+  }}
+>
+  {markdown}
+</Streamdown>
+```
+
+<Callout type="warn">
+  The `data-streamdown="table-wrapper"` attribute is required — the copy and download components use it to locate the nearest `<table>` element.
+</Callout>
+
+You can also use the lower-level utilities for custom implementations:
+
+```tsx title="app/page.tsx"
+import {
+  extractTableDataFromElement,
+  tableDataToCSV,
+  tableDataToMarkdown,
+} from "streamdown";
+```
+
 ## Custom HTML Tags
 
 You can render custom HTML tags from AI responses (like `<source>`, `<mention>`, etc.) using the `allowedTags` prop alongside `components`. This is useful when you instruct the AI to output structured data that renders as interactive components.

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -50,6 +50,24 @@ export type {
   MathPlugin,
   PluginConfig,
 } from "./lib/plugin-types";
+export {
+  TableCopyDropdown,
+  type TableCopyDropdownProps,
+} from "./lib/table/copy-dropdown";
+export {
+  TableDownloadButton,
+  type TableDownloadButtonProps,
+  TableDownloadDropdown,
+  type TableDownloadDropdownProps,
+} from "./lib/table/download-dropdown";
+export {
+  escapeMarkdownTableCell,
+  extractTableDataFromElement,
+  type TableData,
+  tableDataToCSV,
+  tableDataToMarkdown,
+  tableDataToTSV,
+} from "./lib/table/utils";
 
 // Patterns for HTML indentation normalization
 // Matches if content starts with an HTML tag (possibly with leading whitespace)

--- a/packages/streamdown/lib/table/copy-dropdown.tsx
+++ b/packages/streamdown/lib/table/copy-dropdown.tsx
@@ -105,7 +105,7 @@ export const TableCopyDropdown = ({
         title="Copy table"
         type="button"
       >
-        {children ?? <Icon size={14} />}
+        {children ?? <Icon height={14} width={14} />}
       </button>
       {isOpen ? (
         <div className="absolute top-full right-0 z-10 mt-1 min-w-[120px] overflow-hidden rounded-md border border-border bg-background shadow-lg">

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -90,7 +90,7 @@ export const TableDownloadButton = ({
       title={`Download table as ${format.toUpperCase()}`}
       type="button"
     >
-      {children ?? <DownloadIcon size={14} />}
+      {children ?? <DownloadIcon height={14} width={14} />}
     </button>
   );
 };
@@ -169,7 +169,7 @@ export const TableDownloadDropdown = ({
         title="Download table"
         type="button"
       >
-        {children ?? <DownloadIcon size={14} />}
+        {children ?? <DownloadIcon height={14} width={14} />}
       </button>
       {isOpen ? (
         <div className="absolute top-full right-0 z-10 mt-1 min-w-[120px] overflow-hidden rounded-md border border-border bg-background shadow-lg">


### PR DESCRIPTION
Closes #422

## Summary

When overriding streamdown's `table` component with custom React components, the built-in copy/download buttons are lost because custom components fully replace default implementations. The table action components (`TableCopyDropdown`, `TableDownloadDropdown`) and their utilities are internal — not exported from the public API.

This PR adds exports to the main entry point so consumers can import these components and wire them into custom table overrides.

## Changes

- **Export table components** from `packages/streamdown/index.tsx`: `TableCopyDropdown`, `TableDownloadButton`, `TableDownloadDropdown` with their prop types
- **Export table utilities**: `extractTableDataFromElement`, `tableDataToCSV`, `tableDataToTSV`, `tableDataToMarkdown`, `escapeMarkdownTableCell`, `TableData`
- **Fix icon type error**: Replace `size={14}` with `width={14} height={14}` on SVG icons in table components (pre-existing type issue exposed by new exports)
- **Add documentation** section in `components.mdx` explaining how to preserve table interactivity with custom overrides
- **Add changeset** for minor version bump

## Test Plan

- [x] `pnpm build` — streamdown package builds successfully with new exports
- [x] `pnpm test` — all 792 tests pass (59 test files)
- [x] `pnpm check` — linting/formatting passes
- [x] Generated `dist/index.d.ts` includes all new type exports