### PR TITLE
Make sitemap.md route static

### DIFF
--- a/apps/website/app/[lang]/sitemap.md/route.ts
+++ b/apps/website/app/[lang]/sitemap.md/route.ts
@@ -1,22 +1,29 @@
 import type { NextRequest } from "next/server";
+import { translations } from "@/geistdocs";
 import { source } from "@/lib/geistdocs/source";
 
 export const revalidate = false;
+export const dynamic = "error";
+
+export const generateStaticParams = async () => {
+  const langs = Object.keys(translations);
+  return langs.map((lang) => ({ lang }));
+};
 
 const DOCS_PREFIX_PATTERN = /^\/docs\/?/;
 const WHITESPACE_PATTERN = /\s+/;
 
-interface PageNode {
-  children: PageNode[];
+type PageNode = {
+  title: string;
   description: string;
-  lastmod?: string;
+  url: string;
+  type?: string;
+  summary?: string;
   prerequisites?: string[];
   product?: string;
-  summary?: string;
-  title: string;
-  type?: string;
-  url: string;
-}
+  lastmod?: string;
+  children: PageNode[];
+};
 
 function buildTree(
   pages: Array<{


### PR DESCRIPTION
## Summary

- Adds `generateStaticParams` and `dynamic = "error"` to the `sitemap.md` route
- Ensures the sitemap is prerendered at build time (SSG) instead of server-rendered on each request
- Cheaper, faster, more resilient

## Test plan

- [ ] Verify build log shows `● /[lang]/sitemap.md` (SSG) instead of `ƒ` (Dynamic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)