### PR TITLE
feat: add meta prop to custom renderer props

### DIFF
--- a/.changeset/meta-custom-renderer-prop.md
+++ b/.changeset/meta-custom-renderer-prop.md
@@ -1,0 +1,5 @@
+---
+"streamdown": minor
+---
+
+Add `meta` prop to `CustomRendererProps`. Custom renderers now receive the raw metastring from the code fence (everything after the language identifier, e.g. ` ```rust {1} title="foo" ` → `meta = '{1} title="foo"'`). The prop is optional (`meta?: string`) and is `undefined` when no metastring is present. Existing custom renderers are unaffected.

--- a/packages/streamdown/__tests__/custom-renderer.test.tsx
+++ b/packages/streamdown/__tests__/custom-renderer.test.tsx
@@ -143,4 +143,47 @@ describe("Custom Renderers", () => {
       expect(codeBlock).toBeTruthy();
     });
   });
+
+  it("passes meta prop to custom renderer when metastring is present", async () => {
+    const MetaRenderer = ({ meta }: CustomRendererProps) => (
+      <div data-meta={meta ?? ""} data-testid="meta-renderer" />
+    );
+    const { container } = render(
+      <Streamdown
+        plugins={{
+          renderers: [{ language: "rust", component: MetaRenderer }],
+        }}
+      >
+        {'```rust {1} title="foo"\nlet x = 1;\n```'}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      const el = container.querySelector('[data-testid="meta-renderer"]');
+      expect(el?.getAttribute("data-meta")).toBe('{1} title="foo"');
+    });
+  });
+
+  it("passes undefined meta when no metastring present", async () => {
+    const MetaRenderer = ({ meta }: CustomRendererProps) => (
+      <div
+        data-has-meta={meta !== undefined ? "true" : "false"}
+        data-testid="meta-renderer"
+      />
+    );
+    const { container } = render(
+      <Streamdown
+        plugins={{
+          renderers: [{ language: "rust", component: MetaRenderer }],
+        }}
+      >
+        {"```rust\nlet x = 1;\n```"}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      const el = container.querySelector('[data-testid="meta-renderer"]');
+      expect(el?.getAttribute("data-has-meta")).toBe("false");
+    });
+  });
 });

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -843,6 +843,7 @@ const CodeComponent = ({
           code={code}
           isIncomplete={isBlockIncomplete}
           language={language}
+          meta={metastring}
         />
       </Suspense>
     );

--- a/packages/streamdown/lib/plugin-types.ts
+++ b/packages/streamdown/lib/plugin-types.ts
@@ -149,6 +149,10 @@ export interface CustomRendererProps {
   code: string;
   isIncomplete: boolean;
   language: string;
+  /** Raw metastring from the code fence (everything after the language identifier).
+   * e.g. ```rust {1} title="foo"  →  meta = '{1} title="foo"'
+   * Undefined when no metastring is present. */
+  meta?: string;
 }
 
 export interface CustomRenderer {


### PR DESCRIPTION
Closes #443

Custom renderers now receive the raw metastring from code fences via a new optional `meta` prop. Everything after the language identifier is passed through (e.g. ` ```rust {1} title="foo" ` → `meta = '{1} title="foo"'`).

- Added `meta?: string` to `CustomRendererProps` in `plugin-types.ts`
- Pass `meta={metastring}` to custom renderers in `components.tsx`
- Added tests for meta prop presence and absence
- Minor changeset included

No breaking changes — `meta` is optional and existing renderers are unaffected.