### PR TITLE
feat: add meta prop to custom renderer props

### DIFF
--- a/.changeset/custom-renderer-meta.md
+++ b/.changeset/custom-renderer-meta.md
@@ -1,0 +1,6 @@
+---
+"streamdown": minor
+---
+
+Add meta prop to custom renderer props to expose code fence metastring
+

--- a/add_tests.py
+++ b/add_tests.py
@@ -1,0 +1,54 @@
+content = open('packages/streamdown/__tests__/custom-renderer.test.tsx').read()
+
+# The triple backtick strings - use chr(96)*3 to avoid issues
+bt = chr(96) * 3
+
+addition = f"""
+  it("passes meta prop to custom renderer when metastring is present", async () => {{
+    const MetaRenderer = ({{ meta }}: CustomRendererProps) => (
+      <div data-meta={{meta ?? ""}} data-testid="meta-renderer" />
+    );
+    const {{ container }} = render(
+      <Streamdown
+        plugins={{{{
+          renderers: [{{ language: "rust", component: MetaRenderer }}],
+        }}}}
+      >
+        {{'{bt}rust {{1}} title="foo"\\nlet x = 1;\\n{bt}'}}
+      </Streamdown>
+    );
+
+    await waitFor(() => {{
+      const el = container.querySelector('[data-testid="meta-renderer"]');
+      expect(el?.getAttribute("data-meta")).toBe('{{1}} title="foo"');
+    }});
+  }});
+
+  it("passes undefined meta when no metastring present", async () => {{
+    const MetaRenderer = ({{ meta }}: CustomRendererProps) => (
+      <div
+        data-has-meta={{meta !== undefined ? "true" : "false"}}
+        data-testid="meta-renderer"
+      />
+    );
+    const {{ container }} = render(
+      <Streamdown
+        plugins={{{{
+          renderers: [{{ language: "rust", component: MetaRenderer }}],
+        }}}}
+      >
+        {{"{bt}rust\\nlet x = 1;\\n{bt}"}}
+      </Streamdown>
+    );
+
+    await waitFor(() => {{
+      const el = container.querySelector('[data-testid="meta-renderer"]');
+      expect(el?.getAttribute("data-has-meta")).toBe("false");
+    }});
+  }});
+"""
+
+idx = content.rfind('});')
+new_content = content[:idx] + addition + content[idx:]
+open('packages/streamdown/__tests__/custom-renderer.test.tsx', 'w').write(new_content)
+print('done')

--- a/packages/streamdown/__tests__/custom-renderer.test.tsx
+++ b/packages/streamdown/__tests__/custom-renderer.test.tsx
@@ -7,11 +7,13 @@ const VegaRenderer = ({
   code,
   language,
   isIncomplete,
+  meta,
 }: CustomRendererProps) => (
   <div
     data-code={code}
     data-incomplete={isIncomplete}
     data-language={language}
+    data-meta={meta}
     data-testid="vega-renderer"
   >
     Vega Chart: {code}
@@ -128,6 +130,42 @@ describe("Custom Renderers", () => {
         '[data-testid="vega-renderer"]'
       );
       expect(renderers.length).toBe(2);
+    });
+  });
+
+  it("passes meta prop when metastring is present", async () => {
+    const { container } = render(
+      <Streamdown
+        plugins={{
+          renderers: [{ language: "vega-lite", component: VegaRenderer }],
+        }}
+      >
+        {"```vega-lite startLine=5\ntest-code\n```"}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      const renderer = container.querySelector('[data-testid="vega-renderer"]');
+      expect(renderer).toBeTruthy();
+      expect(renderer?.getAttribute("data-meta")).toBe("startLine=5");
+    });
+  });
+
+  it("passes meta as undefined when no metastring is present", async () => {
+    const { container } = render(
+      <Streamdown
+        plugins={{
+          renderers: [{ language: "vega-lite", component: VegaRenderer }],
+        }}
+      >
+        {"```vega-lite\ntest-code\n```"}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      const renderer = container.querySelector('[data-testid="vega-renderer"]');
+      expect(renderer).toBeTruthy();
+      expect(renderer?.getAttribute("data-meta")).toBeNull();
     });
   });
 

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -843,6 +843,7 @@ const CodeComponent = ({
           code={code}
           isIncomplete={isBlockIncomplete}
           language={language}
+          meta={metastring}
         />
       </Suspense>
     );

--- a/packages/streamdown/lib/plugin-types.ts
+++ b/packages/streamdown/lib/plugin-types.ts
@@ -149,6 +149,7 @@ export interface CustomRendererProps {
   code: string;
   isIncomplete: boolean;
   language: string;
+  meta?: string;
 }
 
 export interface CustomRenderer {


### PR DESCRIPTION
Closes #443

## Summary

Exposes the code fence metastring as a `meta` prop in custom renderer callbacks. Previously, custom renderers received `code`, `language`, and `isIncomplete` but not the metastring (the text after the language identifier, e.g. ` ```rust {1} title="foo"` → `meta = '{1} title="foo"'`).

The metastring was already being extracted internally (for `startLine` parsing) — this change simply forwards it to custom renderers.

## Changes

- `lib/plugin-types.ts`: Added `meta?: string` to `CustomRendererProps`
- `lib/components.tsx`: Pass `meta={metastring}` to custom renderer component

## Testing

Added tests verifying `meta` is passed when a metastring is present and is `undefined` when absent.