### PR TITLE
fix(streamdown): preserve double newlines in literalTagContent tags

### DIFF
--- a/packages/streamdown/__tests__/allowed-tags.test.tsx
+++ b/packages/streamdown/__tests__/allowed-tags.test.tsx
@@ -338,4 +338,26 @@ describe("literalTagContent prop", () => {
     expect(mention?.querySelector("em")).toBeNull();
     expect(mention?.textContent).toBe("_handle_");
   });
+  it("should render entire content when literalTagContent tag has double newlines", () => {
+    const AiThinking = (props: CustomComponentProps) => (
+      <div data-testid="ai-thinking">{props.children as React.ReactNode}</div>
+    );
+
+    const { container } = render(
+      <Streamdown
+        allowedTags={{ "ai-thinking": [] }}
+        components={{ "ai-thinking": AiThinking }}
+        literalTagContent={["ai-thinking"]}
+        mode="static"
+      >
+        {"<ai-thinking>first part\n\nsecond part</ai-thinking>"}
+      </Streamdown>
+    );
+
+    const el = container.querySelector("[data-testid=\"ai-thinking\"]");
+    expect(el).toBeTruthy();
+    expect(el?.textContent).toContain("first part");
+    expect(el?.textContent).toContain("second part");
+  });
+
 });

--- a/packages/streamdown/__tests__/allowed-tags.test.tsx
+++ b/packages/streamdown/__tests__/allowed-tags.test.tsx
@@ -354,10 +354,9 @@ describe("literalTagContent prop", () => {
       </Streamdown>
     );
 
-    const el = container.querySelector("[data-testid=\"ai-thinking\"]");
+    const el = container.querySelector('[data-testid="ai-thinking"]');
     expect(el).toBeTruthy();
     expect(el?.textContent).toContain("first part");
     expect(el?.textContent).toContain("second part");
   });
-
 });

--- a/packages/streamdown/__tests__/icon-context.test.tsx
+++ b/packages/streamdown/__tests__/icon-context.test.tsx
@@ -80,7 +80,7 @@ describe("IconProvider rerender / shallowEqual coverage", () => {
     const AltCheckIcon = (props: SVGProps<SVGSVGElement>) => (
       <svg data-testid="alt-check" {...props}>
         <title>Alt check</title>
-        <rect width="10" height="10" />
+        <rect height="10" width="10" />
       </svg>
     );
 
@@ -164,13 +164,17 @@ describe("IconProvider rerender / shallowEqual coverage", () => {
 
     // Rerender with different key count → triggers keysA.length !== keysB.length
     rerender(
-      <IconProvider icons={{ CheckIcon: CustomCheckIcon, CopyIcon: AnotherIcon }}>
+      <IconProvider
+        icons={{ CheckIcon: CustomCheckIcon, CopyIcon: AnotherIcon }}
+      >
         <IconConsumer iconName="CopyIcon" />
       </IconProvider>
     );
 
     // CopyIcon is now overridden
-    expect(container.querySelector("[data-testid='rendered-icon']")).toBeTruthy();
+    expect(
+      container.querySelector("[data-testid='rendered-icon']")
+    ).toBeTruthy();
   });
 
   it("preserves memoized value when same icons reference is passed", () => {

--- a/packages/streamdown/__tests__/preprocess-literal-tag-content.test.ts
+++ b/packages/streamdown/__tests__/preprocess-literal-tag-content.test.ts
@@ -66,4 +66,22 @@ describe("preprocessLiteralTagContent", () => {
     const result = preprocessLiteralTagContent(md, ["mention"]);
     expect(result).toBe("<mention>hello world</mention>");
   });
+
+  it("should replace double newlines with HTML entities to prevent paragraph splits", () => {
+    const md = "<ai-thinking>first part\n\nsecond part</ai-thinking>";
+    const result = preprocessLiteralTagContent(md, ["ai-thinking"]);
+    expect(result).toBe("<ai-thinking>first part&#10;&#10;second part</ai-thinking>");
+  });
+
+  it("should handle multiple double newlines within tag content", () => {
+    const md = "<tag>a\n\nb\n\nc</tag>";
+    const result = preprocessLiteralTagContent(md, ["tag"]);
+    expect(result).toBe("<tag>a&#10;&#10;b&#10;&#10;c</tag>");
+  });
+
+  it("should preserve single newlines unchanged", () => {
+    const md = "<tag>line1\nline2</tag>";
+    const result = preprocessLiteralTagContent(md, ["tag"]);
+    expect(result).toBe("<tag>line1\nline2</tag>");
+  });
 });

--- a/packages/streamdown/__tests__/preprocess-literal-tag-content.test.ts
+++ b/packages/streamdown/__tests__/preprocess-literal-tag-content.test.ts
@@ -70,7 +70,9 @@ describe("preprocessLiteralTagContent", () => {
   it("should replace double newlines with HTML entities to prevent paragraph splits", () => {
     const md = "<ai-thinking>first part\n\nsecond part</ai-thinking>";
     const result = preprocessLiteralTagContent(md, ["ai-thinking"]);
-    expect(result).toBe("<ai-thinking>first part&#10;&#10;second part</ai-thinking>");
+    expect(result).toBe(
+      "<ai-thinking>first part&#10;&#10;second part</ai-thinking>"
+    );
   });
 
   it("should handle multiple double newlines within tag content", () => {

--- a/packages/streamdown/__tests__/remaining-coverage.test.tsx
+++ b/packages/streamdown/__tests__/remaining-coverage.test.tsx
@@ -256,7 +256,9 @@ describe("copy-button onError path", () => {
   beforeEach(() => {
     Object.defineProperty(navigator, "clipboard", {
       value: {
-        writeText: vi.fn().mockRejectedValue(new Error("Clipboard write failed")),
+        writeText: vi
+          .fn()
+          .mockRejectedValue(new Error("Clipboard write failed")),
       },
       writable: true,
       configurable: true,
@@ -282,8 +284,10 @@ describe("copy-button onError path", () => {
     const button = container.querySelector("button");
     expect(button).toBeTruthy();
 
-    await act(async () => {
-      fireEvent.click(button!);
+    await act(() => {
+      if (button) {
+        fireEvent.click(button);
+      }
     });
 
     expect(onError).toHaveBeenCalledWith(expect.any(Error));

--- a/packages/streamdown/lib/code-block/index.tsx
+++ b/packages/streamdown/lib/code-block/index.tsx
@@ -40,10 +40,7 @@ export const CodeBlock = ({
 }: CodeBlockProps) => {
   const cn = useCn();
   // Remove trailing newlines to prevent empty line at end of code blocks
-  const trimmedCode = useMemo(
-    () => trimTrailingNewlines(code),
-    [code]
-  );
+  const trimmedCode = useMemo(() => trimTrailingNewlines(code), [code]);
 
   // Memoize the raw fallback tokens to avoid recomputing on every render
   const raw: HighlightResult = useMemo(

--- a/packages/streamdown/lib/preprocess-literal-tag-content.ts
+++ b/packages/streamdown/lib/preprocess-literal-tag-content.ts
@@ -58,8 +58,15 @@ export const preprocessLiteralTagContent = (
 
     result = result.replace(
       pattern,
-      (_match, open: string, content: string, close: string) =>
-        open + escapeMarkdown(content) + close
+      (_match, open: string, content: string, close: string) => {
+        // Escape markdown metacharacters, then replace \n\n with HTML newline
+        // entities so that blank lines inside the tag do not cause the markdown
+        // parser to split the tag's content across separate block tokens.
+        // rehype-raw decodes &#10; back to \n, so the literal text content is
+        // preserved exactly as authored.
+        const escaped = escapeMarkdown(content).replace(/\n\n/g, "&#10;&#10;");
+        return open + escaped + close;
+      }
     );
   }
 


### PR DESCRIPTION
## Problem

When using the `literalTagContent` prop, double newlines (`\n\n`) inside the tag content were incorrectly treated as paragraph separators by the markdown parser, causing content after the first blank line to be excluded from the tag's children.

Fixes #456

## Root Cause

`preprocessLiteralTagContent` escaped markdown metacharacters but did not prevent the markdown parser from treating blank lines as block boundaries. When the Marked lexer encountered a blank line inside the HTML block, it terminated the block early, leaving the remaining content orphaned.

## Fix

After escaping markdown metacharacters, replace `\n\n` with `&#10;&#10;` HTML entities. This prevents the markdown parser from interpreting blank lines as paragraph breaks while preserving the newline characters — `rehype-raw` decodes `&#10;` back to `\n` so the literal text content is preserved exactly as authored.

## Testing

Added unit tests in `preprocess-literal-tag-content.test.ts` and an integration test in `allowed-tags.test.tsx` that verifies content after a double newline is included in the rendered component output.