### PR TITLE
fix(playground-editor): add full height class to ConversationContent

### DIFF
--- a/.changeset/fix-playground-safari-textarea.md
+++ b/.changeset/fix-playground-safari-textarea.md
@@ -1,5 +1,0 @@
----
-"streamdown": patch
----
-
-Fix the playground markdown input layout in Safari 18 by overriding the textarea sizing so it fills the editor pane without relying on `field-sizing: content` support.


### PR DESCRIPTION
## Description

Fix the playground markdown input height in Safari 18 by avoiding `field-sizing: content` for that textarea and letting it fill the left editor pane with local layout overrides only.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes https://github.com/vercel/streamdown/issues/464

## Changes Made

- Added `h-full` to the playground markdown input container so the editor pane has a stable height.
- Overrode the playground textarea to use fixed field sizing instead of `field-sizing: content`.
- Kept the fix scoped to the playground page to avoid changing textarea behavior elsewhere.


## Screenshots/Demos

<img width="3348" height="2016" alt="Safari浏览器 2026-03-13 14 02 39" src="https://github.com/user-attachments/assets/178856d3-bc7a-4896-bed4-1ed709baeb85" />
