### PR TITLE
fix(streamdown): move mermaid from devDependencies to dependencies

### DIFF
--- a/packages/streamdown/package.json
+++ b/packages/streamdown/package.json
@@ -49,7 +49,6 @@
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.15",
     "jsdom": "^27.3.0",
-    "mermaid": "^11.12.2",
     "react-markdown": "^10.1.0",
     "rehype-parse": "^9.0.1",
     "rehype-stringify": "^10.0.1",
@@ -75,6 +74,7 @@
     "remend": "workspace:*",
     "tailwind-merge": "^3.4.0",
     "unified": "^11.0.5",
+    "mermaid": "^11.12.2",
     "unist-util-visit": "^5.0.0",
     "unist-util-visit-parents": "^6.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       marked:
         specifier: ^17.0.1
         version: 17.0.1
+      mermaid:
+        specifier: ^11.12.2
+        version: 11.12.2
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.3
@@ -392,9 +395,6 @@ importers:
       jsdom:
         specifier: ^27.3.0
         version: 27.4.0
-      mermaid:
-        specifier: ^11.12.2
-        version: 11.12.2
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## Summary

- Move `mermaid` from `devDependencies` to `dependencies` in the `streamdown` package
- The published type declarations (`dist/index.d.ts`) import `MermaidConfig` from `mermaid`, making it part of the public API
- Without this change, consumers could resolve different `mermaid` versions for `streamdown` and `@streamdown/mermaid`, causing type errors due to incompatible `MermaidConfig` types

## Test plan

- [x] `pnpm build:packages` succeeds
- [x] Verify that consumer projects no longer need `mermaid` overrides to avoid type mismatches