### PR TITLE
feat: add GitHub-style admonition (GFM Alerts) support

### DIFF
--- a/.changeset/add-admonition-support.md
+++ b/.changeset/add-admonition-support.md
@@ -1,0 +1,5 @@
+---
+"streamdown": minor
+---
+
+Add GitHub-style admonition (GFM Alerts) support with `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, and `> [!CAUTION]` syntax. Includes built-in icons, colored styles, and full customization via components, icons, and translations props.

--- a/.changeset/extract-remark-gfm-admonition.md
+++ b/.changeset/extract-remark-gfm-admonition.md
@@ -1,0 +1,6 @@
+---
+"remark-gfm-admonition": minor
+"streamdown": patch
+---
+
+Extract admonition remark plugin into standalone `remark-gfm-admonition` package with GitHub-compatible HTML output. Streamdown now consumes this package internally.

--- a/apps/website/app/[lang]/playground/components/playground-editor.tsx
+++ b/apps/website/app/[lang]/playground/components/playground-editor.tsx
@@ -68,6 +68,25 @@ Visit [Streamdown on GitHub](https://github.com/haydenbleasel/streamdown) or pas
 
 ---
 
+## Admonitions
+
+> [!NOTE]
+> Highlights information that users should take into account.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
+
+> [!CAUTION]
+> Negative potential consequences of an action.
+
+---
+
 ## Lists
 
 ### Unordered Lists

--- a/apps/website/content/docs/admonitions.mdx
+++ b/apps/website/content/docs/admonitions.mdx
@@ -1,0 +1,169 @@
+---
+title: Admonitions
+description: Render GitHub-style alert callouts with built-in icons, colors, and full customization.
+type: guide
+summary: Display note, tip, important, warning, and caution callout boxes from standard GFM alert syntax.
+prerequisites:
+  - /docs/getting-started
+related:
+  - /docs/gfm
+  - /docs/components
+  - /docs/internationalization
+  - /docs/styling
+---
+
+Admonitions are callout boxes that highlight important information using GitHub-style alert syntax. Streamdown renders them with distinct icons, colors, and titles for each type.
+
+## Syntax
+
+Use the `> [!TYPE]` blockquote syntax from GitHub Flavored Markdown:
+
+```markdown
+> [!NOTE]
+> Useful background information.
+
+> [!TIP]
+> Helpful advice for getting the most out of a feature.
+
+> [!IMPORTANT]
+> Key details you need to know.
+
+> [!WARNING]
+> Potential issues to watch out for.
+
+> [!CAUTION]
+> Negative consequences of an action.
+```
+
+## Supported types
+
+Streamdown supports all five GFM alert types:
+
+| Type | Purpose |
+|------|---------|
+| `NOTE` | Background context or supplementary information |
+| `TIP` | Helpful suggestions and best practices |
+| `IMPORTANT` | Critical details the reader must not miss |
+| `WARNING` | Potential problems or things to watch for |
+| `CAUTION` | Actions that could cause data loss or breaking changes |
+
+Each type renders with a unique icon and color scheme that matches GitHub's visual styling.
+
+## Multi-line content
+
+Admonitions support rich Markdown content inside them, including bold, code, links, and lists:
+
+```markdown
+> [!TIP]
+> You can use **bold text**, `inline code`, and [links](https://example.com) inside admonitions.
+>
+> - Lists work too
+> - Including nested content
+```
+
+## Customizing the component
+
+Override the default admonition rendering by passing a custom component:
+
+```tsx title="app/page.tsx"
+const MyAdmonition = ({ children, "data-admonition-type": type, ...props }) => (
+  <div className={`my-admonition my-admonition-${type}`} {...props}>
+    {children}
+  </div>
+);
+
+<Streamdown components={{ admonition: MyAdmonition }}>
+  {markdown}
+</Streamdown>
+```
+
+The component receives `data-admonition-type` as a prop with the lowercase type string (`"note"`, `"tip"`, `"important"`, `"warning"`, or `"caution"`).
+
+<Callout type="warn">
+  Custom components **fully replace** the default implementation, including the built-in icon, title bar, and styles. See the [Components](/docs/components) documentation for details on component overrides.
+</Callout>
+
+## Customizing icons
+
+Replace individual admonition icons through the `icons` prop:
+
+```tsx title="app/page.tsx"
+import { InfoIcon } from "lucide-react";
+
+<Streamdown icons={{ AdmonitionNoteIcon: InfoIcon }}>
+  {markdown}
+</Streamdown>
+```
+
+Available icon keys:
+
+- `AdmonitionNoteIcon`
+- `AdmonitionTipIcon`
+- `AdmonitionImportantIcon`
+- `AdmonitionWarningIcon`
+- `AdmonitionCautionIcon`
+
+## Customizing title text (i18n)
+
+Override the title text displayed in admonition headers using the `translations` prop:
+
+```tsx title="app/page.tsx"
+<Streamdown
+  translations={{
+    admonitionNote: "Nota",
+    admonitionTip: "Consejo",
+    admonitionImportant: "Importante",
+    admonitionWarning: "Advertencia",
+    admonitionCaution: "Precaucion",
+  }}
+>
+  {markdown}
+</Streamdown>
+```
+
+See the [Internationalization](/docs/internationalization) documentation for the full list of translation keys.
+
+## Styling with CSS
+
+Target admonitions using `data-streamdown` and `data-admonition-type` attribute selectors:
+
+```css title="styles/streamdown.css"
+/* Style all admonitions */
+[data-streamdown="admonition"] {
+  border-radius: 0.5rem;
+}
+
+/* Style a specific type */
+[data-streamdown="admonition"][data-admonition-type="note"] {
+  background-color: #dbeafe;
+  border-left: 4px solid #3b82f6;
+}
+
+/* Style the title bar */
+[data-streamdown="admonition-title"] {
+  font-weight: 600;
+}
+
+/* Style the content area */
+[data-streamdown="admonition-content"] {
+  padding: 0.75rem 1rem;
+}
+```
+
+See the [Styling](/docs/styling) documentation for more on CSS customization.
+
+## Disabling admonitions
+
+To disable admonition rendering, provide custom `remarkPlugins` that exclude the admonition plugin:
+
+```tsx title="app/page.tsx"
+import { Streamdown, defaultRemarkPlugins } from "streamdown";
+
+const { admonition, ...remainingPlugins } = defaultRemarkPlugins;
+
+<Streamdown remarkPlugins={Object.values(remainingPlugins)}>
+  {markdown}
+</Streamdown>
+```
+
+With admonitions disabled, `> [!NOTE]` blocks render as standard blockquotes.

--- a/apps/website/content/docs/components.mdx
+++ b/apps/website/content/docs/components.mdx
@@ -50,6 +50,7 @@ You can override any of the following standard HTML components:
 - **Links**: `a`
 - **Code**: `code`, `pre`
 - **Quotes**: `blockquote`
+- **Admonitions**: `admonition`
 - **Tables**: `table`, `thead`, `tbody`, `tr`, `th`, `td`
 - **Media**: `img`
 - **Other**: `hr`, `sup`, `sub`, `section`

--- a/apps/website/content/docs/gfm.mdx
+++ b/apps/website/content/docs/gfm.mdx
@@ -246,3 +246,7 @@ import { Streamdown, defaultRemarkPlugins } from "streamdown";
   {markdown}
 </Streamdown>
 ```
+
+## Admonitions (GFM Alerts)
+
+Streamdown also supports GitHub-style alert callouts using the `> [!TYPE]` syntax. See the [Admonitions](/docs/admonitions) page for details.

--- a/apps/website/content/docs/internationalization.mdx
+++ b/apps/website/content/docs/internationalization.mdx
@@ -31,6 +31,38 @@ Pass a partial translations object to replace specific labels:
 
 ## Available translation keys
 
+### Admonition
+
+<TypeTable
+  type={{
+    admonitionCaution: {
+      description: "Title text for caution admonitions",
+      type: "string",
+      default: '"Caution"',
+    },
+    admonitionImportant: {
+      description: "Title text for important admonitions",
+      type: "string",
+      default: '"Important"',
+    },
+    admonitionNote: {
+      description: "Title text for note admonitions",
+      type: "string",
+      default: '"Note"',
+    },
+    admonitionTip: {
+      description: "Title text for tip admonitions",
+      type: "string",
+      default: '"Tip"',
+    },
+    admonitionWarning: {
+      description: "Title text for warning admonitions",
+      type: "string",
+      default: '"Warning"',
+    },
+  }}
+/>
+
 ### Code block
 
 <TypeTable
@@ -248,6 +280,6 @@ import type { StreamdownTranslations } from "streamdown";
 import { defaultTranslations, useTranslations } from "streamdown";
 ```
 
-- `StreamdownTranslations` — interface with all 37 translation keys
+- `StreamdownTranslations` — interface with all 42 translation keys
 - `defaultTranslations` — the built-in English defaults
 - `useTranslations()` — React hook returning the active translations object

--- a/packages/remark-gfm-admonition/__tests__/index.test.ts
+++ b/packages/remark-gfm-admonition/__tests__/index.test.ts
@@ -1,0 +1,108 @@
+import rehypeStringify from "rehype-stringify";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import remarkGfmAdmonition from "../index";
+
+function processMarkdown(md: string): string {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfmAdmonition)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .processSync(md)
+    .toString();
+}
+
+describe("remarkGfmAdmonition", () => {
+  it("should transform [!NOTE] blockquote to github-compatible HTML", () => {
+    const result = processMarkdown("> [!NOTE]\n> This is a note.");
+    expect(result).toContain('class="markdown-alert markdown-alert-note"');
+    expect(result).toContain('class="markdown-alert-title"');
+    expect(result).toContain("Note");
+    expect(result).toContain("This is a note.");
+  });
+
+  it("should support all 5 admonition types", () => {
+    const types = [
+      { input: "NOTE", title: "Note", cls: "markdown-alert-note" },
+      { input: "TIP", title: "Tip", cls: "markdown-alert-tip" },
+      {
+        input: "IMPORTANT",
+        title: "Important",
+        cls: "markdown-alert-important",
+      },
+      { input: "WARNING", title: "Warning", cls: "markdown-alert-warning" },
+      { input: "CAUTION", title: "Caution", cls: "markdown-alert-caution" },
+    ];
+
+    for (const { input, title, cls } of types) {
+      const result = processMarkdown(`> [!${input}]\n> Content`);
+      expect(result).toContain(cls);
+      expect(result).toContain(title);
+    }
+  });
+
+  it("should preserve normal blockquotes", () => {
+    const result = processMarkdown("> This is a normal quote.");
+    expect(result).not.toContain("markdown-alert");
+    expect(result).toContain("<blockquote>");
+  });
+
+  it("should be case insensitive", () => {
+    for (const variant of ["[!note]", "[!Note]", "[!NOTE]"]) {
+      const result = processMarkdown(`> ${variant}\n> Content`);
+      expect(result).toContain("markdown-alert-note");
+    }
+  });
+
+  it("should leave invalid types as normal blockquotes", () => {
+    const result = processMarkdown("> [!INVALID]\n> Content");
+    expect(result).not.toContain("markdown-alert");
+    expect(result).toContain("<blockquote>");
+  });
+
+  it("should handle empty body", () => {
+    const result = processMarkdown("> [!NOTE]");
+    expect(result).toContain("markdown-alert-note");
+    expect(result).toContain("Note");
+  });
+
+  it("should preserve inline text after marker", () => {
+    const result = processMarkdown("> [!NOTE] Some inline text");
+    expect(result).toContain("markdown-alert-note");
+    expect(result).toContain("Some inline text");
+  });
+
+  it("should handle multi-line content", () => {
+    const result = processMarkdown("> [!NOTE]\n> Line 1\n> Line 2");
+    expect(result).toContain("Line 1");
+    expect(result).toContain("Line 2");
+  });
+
+  it("should use div wrapper, not blockquote", () => {
+    const result = processMarkdown("> [!NOTE]\n> Content");
+    expect(result).not.toContain("<blockquote>");
+    expect(result).toContain("<div");
+  });
+
+  it("should render title as first child paragraph", () => {
+    const result = processMarkdown("> [!WARNING]\n> Be careful!");
+    const titleIndex = result.indexOf("markdown-alert-title");
+    const contentIndex = result.indexOf("Be careful!");
+    expect(titleIndex).toBeLessThan(contentIndex);
+  });
+
+  it("should not treat marker on non-first line as admonition", () => {
+    const result = processMarkdown("> Some text\n> [!NOTE]");
+    expect(result).not.toContain("markdown-alert");
+    expect(result).toContain("<blockquote>");
+  });
+
+  it("should transform nested blockquote with marker", () => {
+    const result = processMarkdown("> > [!NOTE]\n> > Nested note");
+    expect(result).toContain("markdown-alert-note");
+    expect(result).toContain("Nested note");
+  });
+});

--- a/packages/remark-gfm-admonition/index.ts
+++ b/packages/remark-gfm-admonition/index.ts
@@ -18,6 +18,10 @@ const ADMONITION_TYPES = new Set([
 
 const ADMONITION_REGEX = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n?/i;
 
+function toTitleCase(type: string): string {
+  return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();
+}
+
 function detectAdmonitionType(node: MdastNode): string | undefined {
   const firstChild = node.children?.[0];
   if (!firstChild || firstChild.type !== "paragraph") {
@@ -65,7 +69,18 @@ function stripMarker(node: MdastNode): void {
   }
 }
 
-export const remarkAdmonition: Plugin = () => (tree) => {
+function createTitleNode(type: string): MdastNode {
+  return {
+    type: "paragraph",
+    children: [{ type: "text", value: toTitleCase(type) }],
+    data: {
+      hName: "p",
+      hProperties: { class: "markdown-alert-title" },
+    },
+  };
+}
+
+const remarkGfmAdmonition: Plugin = () => (tree) => {
   visit(tree, "blockquote", (node: MdastNode) => {
     const type = detectAdmonitionType(node);
     if (!type) {
@@ -74,12 +89,19 @@ export const remarkAdmonition: Plugin = () => (tree) => {
 
     stripMarker(node);
 
+    // Inject title paragraph as first child
+    const titleNode = createTitleNode(type);
+    node.children = node.children ?? [];
+    node.children.unshift(titleNode);
+
+    // Transform blockquote to div with GitHub-compatible classes
     node.data = node.data ?? {};
-    node.data.hName = "admonition";
+    node.data.hName = "div";
     node.data.hProperties = {
-      ...((node.data.hProperties as Record<string, unknown>) ?? {}),
-      "data-admonition-type": type,
-      dataAdmonitionType: type,
+      class: `markdown-alert markdown-alert-${type}`,
     };
   });
 };
+
+export default remarkGfmAdmonition;
+export { remarkGfmAdmonition };

--- a/packages/remark-gfm-admonition/package.json
+++ b/packages/remark-gfm-admonition/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "remark-gfm-admonition",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Remark plugin to support GitHub-flavored admonition blockquotes",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:coverage": "vitest --coverage run"
+  },
+  "dependencies": {
+    "unist-util-visit": "^5.0.0"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.15",
+    "rehype-stringify": "^10.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "^11.0.5",
+    "vitest": "^4.0.15"
+  },
+  "author": "Hayden Bleasel <hayden.bleasel@vercel.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/streamdown.git",
+    "directory": "packages/remark-gfm-admonition"
+  }
+}

--- a/packages/remark-gfm-admonition/tsconfig.json
+++ b/packages/remark-gfm-admonition/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "build", "dist"]
+}

--- a/packages/remark-gfm-admonition/tsup.config.ts
+++ b/packages/remark-gfm-admonition/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  dts: true,
+  entry: ["index.ts"],
+  format: ["esm"],
+  minify: true,
+  outDir: "dist",
+  sourcemap: false,
+  treeshake: true,
+  platform: "browser",
+});

--- a/packages/remark-gfm-admonition/vitest.config.ts
+++ b/packages/remark-gfm-admonition/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/packages/streamdown/__tests__/admonition.test.tsx
+++ b/packages/streamdown/__tests__/admonition.test.tsx
@@ -122,3 +122,60 @@ describe("admonition - remark plugin", () => {
     expect(admonition?.getAttribute("data-admonition-type")).toBe("warning");
   });
 });
+
+describe("admonition - component features", () => {
+  it("should render the title text from translations", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!NOTE]\n> Content"}
+      </Streamdown>
+    );
+
+    const title = container.querySelector('[data-streamdown="admonition-title"]');
+    expect(title?.textContent).toContain("Note");
+  });
+
+  it("should render an icon in the title", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!NOTE]\n> Content"}
+      </Streamdown>
+    );
+
+    const title = container.querySelector('[data-streamdown="admonition-title"]');
+    const svg = title?.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+
+  it("should support custom translations", () => {
+    const { container } = render(
+      <Streamdown mode="static" translations={{ admonitionNote: "Nota" }}>
+        {"> [!NOTE]\n> Content"}
+      </Streamdown>
+    );
+
+    const title = container.querySelector('[data-streamdown="admonition-title"]');
+    expect(title?.textContent).toContain("Nota");
+  });
+
+  it("should support component override", () => {
+    const CustomAdmonition = (props: Record<string, unknown>) => (
+      <div data-testid="custom-admonition">
+        {props.children as React.ReactNode}
+      </div>
+    );
+
+    const { container } = render(
+      <Streamdown components={{ admonition: CustomAdmonition }} mode="static">
+        {"> [!NOTE]\n> Custom content"}
+      </Streamdown>
+    );
+
+    const custom = container.querySelector('[data-testid="custom-admonition"]');
+    expect(custom).toBeTruthy();
+    expect(custom?.textContent).toContain("Custom content");
+
+    const defaultAdmonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(defaultAdmonition).toBeNull();
+  });
+});

--- a/packages/streamdown/__tests__/admonition.test.tsx
+++ b/packages/streamdown/__tests__/admonition.test.tsx
@@ -124,27 +124,45 @@ describe("admonition - remark plugin", () => {
 });
 
 describe("admonition - component features", () => {
-  it("should render the title text from translations", () => {
-    const { container } = render(
-      <Streamdown mode="static">
-        {"> [!NOTE]\n> Content"}
-      </Streamdown>
-    );
+  it("should render the correct title text for all 5 types", () => {
+    const expectedTitles: Record<string, string> = {
+      NOTE: "Note",
+      TIP: "Tip",
+      IMPORTANT: "Important",
+      WARNING: "Warning",
+      CAUTION: "Caution",
+    };
 
-    const title = container.querySelector('[data-streamdown="admonition-title"]');
-    expect(title?.textContent).toContain("Note");
+    for (const [type, expectedTitle] of Object.entries(expectedTitles)) {
+      const { container } = render(
+        <Streamdown mode="static">
+          {`> [!${type}]\n> Content`}
+        </Streamdown>
+      );
+
+      const title = container.querySelector('[data-streamdown="admonition-title"]');
+      expect(title?.textContent).toContain(expectedTitle);
+    }
   });
 
-  it("should render an icon in the title", () => {
-    const { container } = render(
-      <Streamdown mode="static">
-        {"> [!NOTE]\n> Content"}
-      </Streamdown>
-    );
+  it("should render a distinct icon for each type", () => {
+    const svgContents: string[] = [];
 
-    const title = container.querySelector('[data-streamdown="admonition-title"]');
-    const svg = title?.querySelector("svg");
-    expect(svg).toBeTruthy();
+    for (const type of ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]) {
+      const { container } = render(
+        <Streamdown mode="static">
+          {`> [!${type}]\n> Content`}
+        </Streamdown>
+      );
+
+      const title = container.querySelector('[data-streamdown="admonition-title"]');
+      const svg = title?.querySelector("svg");
+      expect(svg).toBeTruthy();
+      svgContents.push(svg?.innerHTML ?? "");
+    }
+
+    const uniqueSvgs = new Set(svgContents);
+    expect(uniqueSvgs.size).toBe(5);
   });
 
   it("should support custom translations", () => {

--- a/packages/streamdown/__tests__/admonition.test.tsx
+++ b/packages/streamdown/__tests__/admonition.test.tsx
@@ -5,12 +5,12 @@ import { Streamdown } from "../index";
 describe("admonition - remark plugin", () => {
   it("should render > [!NOTE] as an admonition", () => {
     const { container } = render(
-      <Streamdown mode="static">
-        {"> [!NOTE]\n> This is a note."}
-      </Streamdown>
+      <Streamdown mode="static">{"> [!NOTE]\n> This is a note."}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeTruthy();
     expect(admonition?.getAttribute("data-admonition-type")).toBe("note");
     expect(admonition?.textContent).toContain("This is a note.");
@@ -25,34 +25,40 @@ describe("admonition - remark plugin", () => {
         </Streamdown>
       );
 
-      const admonition = container.querySelector('[data-streamdown="admonition"]');
+      const admonition = container.querySelector(
+        '[data-streamdown="admonition"]'
+      );
       expect(admonition).toBeTruthy();
-      expect(admonition?.getAttribute("data-admonition-type")).toBe(type.toLowerCase());
+      expect(admonition?.getAttribute("data-admonition-type")).toBe(
+        type.toLowerCase()
+      );
     }
   });
 
   it("should preserve normal blockquotes", () => {
     const { container } = render(
-      <Streamdown mode="static">
-        {"> This is a normal quote."}
-      </Streamdown>
+      <Streamdown mode="static">{"> This is a normal quote."}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeNull();
 
-    const blockquote = container.querySelector('[data-streamdown="blockquote"]');
+    const blockquote = container.querySelector(
+      '[data-streamdown="blockquote"]'
+    );
     expect(blockquote).toBeTruthy();
   });
 
   it("should handle multi-line content", () => {
     const { container } = render(
-      <Streamdown mode="static">
-        {"> [!NOTE]\n> Line 1\n> Line 2"}
-      </Streamdown>
+      <Streamdown mode="static">{"> [!NOTE]\n> Line 1\n> Line 2"}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeTruthy();
     expect(admonition?.textContent).toContain("Line 1");
     expect(admonition?.textContent).toContain("Line 2");
@@ -60,12 +66,12 @@ describe("admonition - remark plugin", () => {
 
   it("should handle empty body (streaming scenario)", () => {
     const { container } = render(
-      <Streamdown mode="static">
-        {"> [!NOTE]"}
-      </Streamdown>
+      <Streamdown mode="static">{"> [!NOTE]"}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeTruthy();
     expect(admonition?.getAttribute("data-admonition-type")).toBe("note");
   });
@@ -73,12 +79,12 @@ describe("admonition - remark plugin", () => {
   it("should be case insensitive", () => {
     for (const variant of ["[!note]", "[!Note]", "[!NOTE]"]) {
       const { container } = render(
-        <Streamdown mode="static">
-          {`> ${variant}\n> Content`}
-        </Streamdown>
+        <Streamdown mode="static">{`> ${variant}\n> Content`}</Streamdown>
       );
 
-      const admonition = container.querySelector('[data-streamdown="admonition"]');
+      const admonition = container.querySelector(
+        '[data-streamdown="admonition"]'
+      );
       expect(admonition).toBeTruthy();
       expect(admonition?.getAttribute("data-admonition-type")).toBe("note");
     }
@@ -86,38 +92,40 @@ describe("admonition - remark plugin", () => {
 
   it("should leave invalid types as normal blockquotes", () => {
     const { container } = render(
-      <Streamdown mode="static">
-        {"> [!INVALID]\n> Content"}
-      </Streamdown>
+      <Streamdown mode="static">{"> [!INVALID]\n> Content"}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeNull();
 
-    const blockquote = container.querySelector('[data-streamdown="blockquote"]');
+    const blockquote = container.querySelector(
+      '[data-streamdown="blockquote"]'
+    );
     expect(blockquote).toBeTruthy();
   });
 
   it("should preserve inline text after type marker", () => {
     const { container } = render(
-      <Streamdown mode="static">
-        {"> [!NOTE] Some inline text"}
-      </Streamdown>
+      <Streamdown mode="static">{"> [!NOTE] Some inline text"}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeTruthy();
     expect(admonition?.textContent).toContain("Some inline text");
   });
 
   it("should work in streaming mode", () => {
     const { container } = render(
-      <Streamdown mode="streaming">
-        {"> [!WARNING]\n> Be careful!"}
-      </Streamdown>
+      <Streamdown mode="streaming">{"> [!WARNING]\n> Be careful!"}</Streamdown>
     );
 
-    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    const admonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(admonition).toBeTruthy();
     expect(admonition?.getAttribute("data-admonition-type")).toBe("warning");
   });
@@ -135,12 +143,12 @@ describe("admonition - component features", () => {
 
     for (const [type, expectedTitle] of Object.entries(expectedTitles)) {
       const { container } = render(
-        <Streamdown mode="static">
-          {`> [!${type}]\n> Content`}
-        </Streamdown>
+        <Streamdown mode="static">{`> [!${type}]\n> Content`}</Streamdown>
       );
 
-      const title = container.querySelector('[data-streamdown="admonition-title"]');
+      const title = container.querySelector(
+        '[data-streamdown="admonition-title"]'
+      );
       expect(title?.textContent).toContain(expectedTitle);
     }
   });
@@ -150,12 +158,12 @@ describe("admonition - component features", () => {
 
     for (const type of ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]) {
       const { container } = render(
-        <Streamdown mode="static">
-          {`> [!${type}]\n> Content`}
-        </Streamdown>
+        <Streamdown mode="static">{`> [!${type}]\n> Content`}</Streamdown>
       );
 
-      const title = container.querySelector('[data-streamdown="admonition-title"]');
+      const title = container.querySelector(
+        '[data-streamdown="admonition-title"]'
+      );
       const svg = title?.querySelector("svg");
       expect(svg).toBeTruthy();
       svgContents.push(svg?.innerHTML ?? "");
@@ -172,7 +180,9 @@ describe("admonition - component features", () => {
       </Streamdown>
     );
 
-    const title = container.querySelector('[data-streamdown="admonition-title"]');
+    const title = container.querySelector(
+      '[data-streamdown="admonition-title"]'
+    );
     expect(title?.textContent).toContain("Nota");
   });
 
@@ -193,7 +203,9 @@ describe("admonition - component features", () => {
     expect(custom).toBeTruthy();
     expect(custom?.textContent).toContain("Custom content");
 
-    const defaultAdmonition = container.querySelector('[data-streamdown="admonition"]');
+    const defaultAdmonition = container.querySelector(
+      '[data-streamdown="admonition"]'
+    );
     expect(defaultAdmonition).toBeNull();
   });
 });

--- a/packages/streamdown/__tests__/admonition.test.tsx
+++ b/packages/streamdown/__tests__/admonition.test.tsx
@@ -1,0 +1,124 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Streamdown } from "../index";
+
+describe("admonition - remark plugin", () => {
+  it("should render > [!NOTE] as an admonition", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!NOTE]\n> This is a note."}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeTruthy();
+    expect(admonition?.getAttribute("data-admonition-type")).toBe("note");
+    expect(admonition?.textContent).toContain("This is a note.");
+  });
+
+  it("should render all 5 types correctly", () => {
+    const types = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"] as const;
+    for (const type of types) {
+      const { container } = render(
+        <Streamdown mode="static">
+          {`> [!${type}]\n> Content for ${type}.`}
+        </Streamdown>
+      );
+
+      const admonition = container.querySelector('[data-streamdown="admonition"]');
+      expect(admonition).toBeTruthy();
+      expect(admonition?.getAttribute("data-admonition-type")).toBe(type.toLowerCase());
+    }
+  });
+
+  it("should preserve normal blockquotes", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> This is a normal quote."}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeNull();
+
+    const blockquote = container.querySelector('[data-streamdown="blockquote"]');
+    expect(blockquote).toBeTruthy();
+  });
+
+  it("should handle multi-line content", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!NOTE]\n> Line 1\n> Line 2"}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeTruthy();
+    expect(admonition?.textContent).toContain("Line 1");
+    expect(admonition?.textContent).toContain("Line 2");
+  });
+
+  it("should handle empty body (streaming scenario)", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!NOTE]"}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeTruthy();
+    expect(admonition?.getAttribute("data-admonition-type")).toBe("note");
+  });
+
+  it("should be case insensitive", () => {
+    for (const variant of ["[!note]", "[!Note]", "[!NOTE]"]) {
+      const { container } = render(
+        <Streamdown mode="static">
+          {`> ${variant}\n> Content`}
+        </Streamdown>
+      );
+
+      const admonition = container.querySelector('[data-streamdown="admonition"]');
+      expect(admonition).toBeTruthy();
+      expect(admonition?.getAttribute("data-admonition-type")).toBe("note");
+    }
+  });
+
+  it("should leave invalid types as normal blockquotes", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!INVALID]\n> Content"}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeNull();
+
+    const blockquote = container.querySelector('[data-streamdown="blockquote"]');
+    expect(blockquote).toBeTruthy();
+  });
+
+  it("should preserve inline text after type marker", () => {
+    const { container } = render(
+      <Streamdown mode="static">
+        {"> [!NOTE] Some inline text"}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeTruthy();
+    expect(admonition?.textContent).toContain("Some inline text");
+  });
+
+  it("should work in streaming mode", () => {
+    const { container } = render(
+      <Streamdown mode="streaming">
+        {"> [!WARNING]\n> Be careful!"}
+      </Streamdown>
+    );
+
+    const admonition = container.querySelector('[data-streamdown="admonition"]');
+    expect(admonition).toBeTruthy();
+    expect(admonition?.getAttribute("data-admonition-type")).toBe("warning");
+  });
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -18,6 +18,7 @@ import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
+import remarkGfmAdmonition from "remark-gfm-admonition";
 import remend, { type RemendOptions } from "remend";
 import type { Pluggable } from "unified";
 import {
@@ -38,7 +39,7 @@ import { PrefixContext } from "./lib/prefix-context";
 import { preprocessCustomTags } from "./lib/preprocess-custom-tags";
 import { preprocessLiteralTagContent } from "./lib/preprocess-literal-tag-content";
 import { rehypeLiteralTagContent } from "./lib/rehype/literal-tag-content";
-import { remarkAdmonition } from "./lib/remark/admonition";
+import { remarkAdmonitionStreamdown } from "./lib/remark/admonition-streamdown";
 import { remarkCodeMeta } from "./lib/remark/code-meta";
 import {
   defaultTranslations,
@@ -47,13 +48,14 @@ import {
 } from "./lib/translations-context";
 import { createCn } from "./lib/utils";
 
+// biome-ignore lint/performance/noBarrelFile: "required"
+export { default as remarkAdmonition } from "remark-gfm-admonition";
 export type {
   BundledLanguage,
   BundledTheme,
   ThemeRegistrationAny,
 } from "shiki";
 export type { AnimateOptions } from "./lib/animate";
-// biome-ignore lint/performance/noBarrelFile: "required"
 export { createAnimatePlugin } from "./lib/animate";
 export { useIsCodeFenceIncomplete } from "./lib/block-incomplete-context";
 export { CodeBlock } from "./lib/code-block";
@@ -83,7 +85,7 @@ export type {
   PluginConfig,
   ThemeInput,
 } from "./lib/plugin-types";
-export { remarkAdmonition } from "./lib/remark/admonition";
+export { remarkAdmonitionStreamdown } from "./lib/remark/admonition-streamdown";
 export {
   TableCopyDropdown,
   type TableCopyDropdownProps,
@@ -268,7 +270,8 @@ export const defaultRehypePlugins: Record<string, Pluggable> = {
 export const defaultRemarkPlugins: Record<string, Pluggable> = {
   gfm: [remarkGfm, {}],
   codeMeta: remarkCodeMeta,
-  admonition: remarkAdmonition,
+  admonition: remarkGfmAdmonition,
+  admonitionStreamdown: remarkAdmonitionStreamdown,
 } as const;
 
 // Stable plugin arrays for cache efficiency - created once at module level

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -63,9 +63,7 @@ export { CodeBlockDownloadButton } from "./lib/code-block/download-button";
 export { CodeBlockHeader } from "./lib/code-block/header";
 export { CodeBlockSkeleton } from "./lib/code-block/skeleton";
 export { detectTextDirection } from "./lib/detect-direction";
-export { remarkAdmonition } from "./lib/remark/admonition";
 export type { IconMap } from "./lib/icon-context";
-
 export type {
   AllowElement,
   Components,
@@ -85,6 +83,7 @@ export type {
   PluginConfig,
   ThemeInput,
 } from "./lib/plugin-types";
+export { remarkAdmonition } from "./lib/remark/admonition";
 export {
   TableCopyDropdown,
   type TableCopyDropdownProps,

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -38,6 +38,7 @@ import { PrefixContext } from "./lib/prefix-context";
 import { preprocessCustomTags } from "./lib/preprocess-custom-tags";
 import { preprocessLiteralTagContent } from "./lib/preprocess-literal-tag-content";
 import { rehypeLiteralTagContent } from "./lib/rehype/literal-tag-content";
+import { remarkAdmonition } from "./lib/remark/admonition";
 import { remarkCodeMeta } from "./lib/remark/code-meta";
 import {
   defaultTranslations,
@@ -62,6 +63,7 @@ export { CodeBlockDownloadButton } from "./lib/code-block/download-button";
 export { CodeBlockHeader } from "./lib/code-block/header";
 export { CodeBlockSkeleton } from "./lib/code-block/skeleton";
 export { detectTextDirection } from "./lib/detect-direction";
+export { remarkAdmonition } from "./lib/remark/admonition";
 export type { IconMap } from "./lib/icon-context";
 
 export type {
@@ -237,12 +239,14 @@ export type StreamdownProps = Options & {
 
 const defaultSanitizeSchema = {
   ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), "admonition"],
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "tel"],
   },
   attributes: {
     ...defaultSchema.attributes,
+    admonition: ["data-admonition-type", "dataAdmonitionType"],
     code: [...(defaultSchema.attributes?.code ?? []), "metastring"],
   },
 };
@@ -265,6 +269,7 @@ export const defaultRehypePlugins: Record<string, Pluggable> = {
 export const defaultRemarkPlugins: Record<string, Pluggable> = {
   gfm: [remarkGfm, {}],
   codeMeta: remarkCodeMeta,
+  admonition: remarkAdmonition,
 } as const;
 
 // Stable plugin arrays for cache efficiency - created once at module level

--- a/packages/streamdown/lib/admonition.tsx
+++ b/packages/streamdown/lib/admonition.tsx
@@ -1,6 +1,10 @@
 import type { JSX } from "react";
 import { memo } from "react";
+import type { IconMap } from "./icon-context";
+import { useIcons } from "./icon-context";
 import { useCn } from "./prefix-context";
+import type { StreamdownTranslations } from "./translations-context";
+import { useTranslations } from "./translations-context";
 
 interface MarkdownNode {
   position?: {
@@ -47,6 +51,22 @@ const ADMONITION_STYLES: Record<string, { border: string; bg: string; text: stri
 
 const DEFAULT_STYLE = ADMONITION_STYLES.note;
 
+const ICON_MAP: Record<string, keyof IconMap> = {
+  note: "AdmonitionNoteIcon",
+  tip: "AdmonitionTipIcon",
+  important: "AdmonitionImportantIcon",
+  warning: "AdmonitionWarningIcon",
+  caution: "AdmonitionCautionIcon",
+};
+
+const TRANSLATION_MAP: Record<string, keyof StreamdownTranslations> = {
+  note: "admonitionNote",
+  tip: "admonitionTip",
+  important: "admonitionImportant",
+  warning: "admonitionWarning",
+  caution: "admonitionCaution",
+};
+
 export const MemoAdmonition = memo<AdmonitionProps>(
   ({
     children,
@@ -59,6 +79,10 @@ export const MemoAdmonition = memo<AdmonitionProps>(
     const cn = useCn();
     const type = dataAttr ?? dataAdmonitionType ?? "note";
     const style = ADMONITION_STYLES[type] ?? DEFAULT_STYLE;
+    const icons = useIcons();
+    const translations = useTranslations();
+    const IconComponent = icons[ICON_MAP[type] ?? "AdmonitionNoteIcon"];
+    const titleText = translations[TRANSLATION_MAP[type] ?? "admonitionNote"];
 
     return (
       <div
@@ -76,7 +100,8 @@ export const MemoAdmonition = memo<AdmonitionProps>(
           className={cn("mb-2 flex items-center gap-2 font-semibold", style.text)}
           data-streamdown="admonition-title"
         >
-          <span>{type.charAt(0).toUpperCase() + type.slice(1)}</span>
+          <IconComponent height={16} width={16} />
+          <span>{titleText}</span>
         </div>
         <div data-streamdown="admonition-content">
           {children}

--- a/packages/streamdown/lib/admonition.tsx
+++ b/packages/streamdown/lib/admonition.tsx
@@ -1,0 +1,96 @@
+import type { JSX } from "react";
+import { memo } from "react";
+import { useCn } from "./prefix-context";
+
+interface MarkdownNode {
+  position?: {
+    start?: { line?: number; column?: number };
+    end?: { line?: number; column?: number };
+  };
+}
+
+type AdmonitionProps = {
+  children?: React.ReactNode;
+  className?: string;
+  node?: MarkdownNode;
+  "data-admonition-type"?: string;
+  dataAdmonitionType?: string;
+} & JSX.IntrinsicElements["div"];
+
+const ADMONITION_STYLES: Record<string, { border: string; bg: string; text: string }> = {
+  note: {
+    border: "border-blue-500",
+    bg: "bg-blue-500/10",
+    text: "text-blue-600 dark:text-blue-400",
+  },
+  tip: {
+    border: "border-green-500",
+    bg: "bg-green-500/10",
+    text: "text-green-600 dark:text-green-400",
+  },
+  important: {
+    border: "border-purple-500",
+    bg: "bg-purple-500/10",
+    text: "text-purple-600 dark:text-purple-400",
+  },
+  warning: {
+    border: "border-yellow-500",
+    bg: "bg-yellow-500/10",
+    text: "text-yellow-600 dark:text-yellow-400",
+  },
+  caution: {
+    border: "border-red-500",
+    bg: "bg-red-500/10",
+    text: "text-red-600 dark:text-red-400",
+  },
+};
+
+const DEFAULT_STYLE = ADMONITION_STYLES.note;
+
+export const MemoAdmonition = memo<AdmonitionProps>(
+  ({
+    children,
+    className,
+    node,
+    "data-admonition-type": dataAttr,
+    dataAdmonitionType,
+    ...props
+  }) => {
+    const cn = useCn();
+    const type = dataAttr ?? dataAdmonitionType ?? "note";
+    const style = ADMONITION_STYLES[type] ?? DEFAULT_STYLE;
+
+    return (
+      <div
+        className={cn(
+          "my-4 rounded-lg border-l-4 p-4",
+          style.border,
+          style.bg,
+          className
+        )}
+        data-admonition-type={type}
+        data-streamdown="admonition"
+        {...props}
+      >
+        <div
+          className={cn("mb-2 flex items-center gap-2 font-semibold", style.text)}
+          data-streamdown="admonition-title"
+        >
+          <span>{type.charAt(0).toUpperCase() + type.slice(1)}</span>
+        </div>
+        <div data-streamdown="admonition-content">
+          {children}
+        </div>
+      </div>
+    );
+  },
+  (prev, next) =>
+    prev.className === next.className &&
+    prev["data-admonition-type"] === next["data-admonition-type"] &&
+    prev.dataAdmonitionType === next.dataAdmonitionType &&
+    prev.node?.position?.start?.line === next.node?.position?.start?.line &&
+    prev.node?.position?.start?.column === next.node?.position?.start?.column &&
+    prev.node?.position?.end?.line === next.node?.position?.end?.line &&
+    prev.node?.position?.end?.column === next.node?.position?.end?.column
+);
+MemoAdmonition.displayName = "MarkdownAdmonition";

--- a/packages/streamdown/lib/admonition.tsx
+++ b/packages/streamdown/lib/admonition.tsx
@@ -21,7 +21,10 @@ type AdmonitionProps = {
   dataAdmonitionType?: string;
 } & JSX.IntrinsicElements["div"];
 
-const ADMONITION_STYLES: Record<string, { border: string; bg: string; text: string }> = {
+const ADMONITION_STYLES: Record<
+  string,
+  { border: string; bg: string; text: string }
+> = {
   note: {
     border: "border-blue-500",
     bg: "bg-blue-500/10",
@@ -97,15 +100,16 @@ export const MemoAdmonition = memo<AdmonitionProps>(
         {...props}
       >
         <div
-          className={cn("mb-2 flex items-center gap-2 font-semibold", style.text)}
+          className={cn(
+            "mb-2 flex items-center gap-2 font-semibold",
+            style.text
+          )}
           data-streamdown="admonition-title"
         >
           <IconComponent height={16} width={16} />
           <span>{titleText}</span>
         </div>
-        <div data-streamdown="admonition-content">
-          {children}
-        </div>
+        <div data-streamdown="admonition-content">{children}</div>
       </div>
     );
   },

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -20,6 +20,7 @@ import { CodeBlock } from "./code-block";
 import { CodeBlockCopyButton } from "./code-block/copy-button";
 import { CodeBlockDownloadButton } from "./code-block/download-button";
 import { CodeBlockSkeleton } from "./code-block/skeleton";
+import { MemoAdmonition } from "./admonition";
 import { ImageComponent } from "./image";
 import { LinkSafetyModal } from "./link-modal";
 import type { ExtraProps, Options } from "./markdown";
@@ -1035,6 +1036,7 @@ export const components: Options["components"] = {
   tr: MemoTr,
   th: MemoTh,
   td: MemoTd,
+  admonition: MemoAdmonition,
   blockquote: MemoBlockquote,
   code: MemoCode,
   img: MemoImg,

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -15,12 +15,12 @@ import {
 } from "react";
 // BundledLanguage type removed - we now support any language string
 import { type ControlsConfig, StreamdownContext } from "../index";
+import { MemoAdmonition } from "./admonition";
 import { useIsCodeFenceIncomplete } from "./block-incomplete-context";
 import { CodeBlock } from "./code-block";
 import { CodeBlockCopyButton } from "./code-block/copy-button";
 import { CodeBlockDownloadButton } from "./code-block/download-button";
 import { CodeBlockSkeleton } from "./code-block/skeleton";
-import { MemoAdmonition } from "./admonition";
 import { ImageComponent } from "./image";
 import { LinkSafetyModal } from "./link-modal";
 import type { ExtraProps, Options } from "./markdown";

--- a/packages/streamdown/lib/icon-context.tsx
+++ b/packages/streamdown/lib/icon-context.tsx
@@ -2,6 +2,11 @@
 
 import { createContext, type SVGProps, useContext, useRef } from "react";
 import {
+  AdmonitionCautionIcon,
+  AdmonitionImportantIcon,
+  AdmonitionNoteIcon,
+  AdmonitionTipIcon,
+  AdmonitionWarningIcon,
   CheckIcon,
   CopyIcon,
   DownloadIcon,
@@ -19,6 +24,11 @@ export type IconComponent = React.ComponentType<
 >;
 
 export interface IconMap {
+  AdmonitionCautionIcon: IconComponent;
+  AdmonitionImportantIcon: IconComponent;
+  AdmonitionNoteIcon: IconComponent;
+  AdmonitionTipIcon: IconComponent;
+  AdmonitionWarningIcon: IconComponent;
   CheckIcon: IconComponent;
   CopyIcon: IconComponent;
   DownloadIcon: IconComponent;
@@ -32,6 +42,11 @@ export interface IconMap {
 }
 
 export const defaultIcons: IconMap = {
+  AdmonitionCautionIcon,
+  AdmonitionImportantIcon,
+  AdmonitionNoteIcon,
+  AdmonitionTipIcon,
+  AdmonitionWarningIcon,
   CheckIcon,
   CopyIcon,
   DownloadIcon,

--- a/packages/streamdown/lib/icons.tsx
+++ b/packages/streamdown/lib/icons.tsx
@@ -226,3 +226,93 @@ export const ZoomOutIcon = (props: IconProps) => (
     />
   </svg>
 );
+
+export const AdmonitionNoteIcon = (props: IconProps) => (
+  <svg
+    color="currentColor"
+    height={16}
+    strokeLinejoin="round"
+    viewBox="0 0 16 16"
+    width={16}
+    {...props}
+  >
+    <path
+      clipRule="evenodd"
+      d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
+export const AdmonitionTipIcon = (props: IconProps) => (
+  <svg
+    color="currentColor"
+    height={16}
+    strokeLinejoin="round"
+    viewBox="0 0 16 16"
+    width={16}
+    {...props}
+  >
+    <path
+      clipRule="evenodd"
+      d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.256c.255.309.625.756.625 1.44V10a1 1 0 0 0 1 1h2.5a1 1 0 0 0 1-1v-.75c0-.684.37-1.131.625-1.44l.214-.256c.56-.679.984-1.32.984-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM10.5 5.25c0-1.365-1.052-2.25-2.5-2.25S5.5 3.885 5.5 5.25c0 .54.223.85.683 1.407l.171.205c.282.342.766.929.766 1.888h1.76c0-.959.484-1.546.766-1.888l.171-.205c.46-.557.683-.866.683-1.407Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
+export const AdmonitionImportantIcon = (props: IconProps) => (
+  <svg
+    color="currentColor"
+    height={16}
+    strokeLinejoin="round"
+    viewBox="0 0 16 16"
+    width={16}
+    {...props}
+  >
+    <path
+      clipRule="evenodd"
+      d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
+export const AdmonitionWarningIcon = (props: IconProps) => (
+  <svg
+    color="currentColor"
+    height={16}
+    strokeLinejoin="round"
+    viewBox="0 0 16 16"
+    width={16}
+    {...props}
+  >
+    <path
+      clipRule="evenodd"
+      d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
+export const AdmonitionCautionIcon = (props: IconProps) => (
+  <svg
+    color="currentColor"
+    height={16}
+    strokeLinejoin="round"
+    viewBox="0 0 16 16"
+    width={16}
+    {...props}
+  >
+    <path
+      clipRule="evenodd"
+      d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);

--- a/packages/streamdown/lib/remark/admonition-streamdown.ts
+++ b/packages/streamdown/lib/remark/admonition-streamdown.ts
@@ -1,0 +1,53 @@
+import { visit } from "unist-util-visit";
+
+interface MdastNode {
+  children?: MdastNode[];
+  data?: Record<string, unknown>;
+  type: string;
+  value?: string;
+}
+
+/**
+ * Post-processor that runs after remark-gfm-admonition.
+ * Overrides GitHub-compatible div.markdown-alert output to use
+ * Streamdown's custom <admonition> element for React component mapping.
+ */
+export const remarkAdmonitionStreamdown: () => (tree: MdastNode) => void =
+  () => (tree) => {
+    visit(tree, (node: MdastNode) => {
+      const hProperties = node.data?.hProperties as
+        | Record<string, unknown>
+        | undefined;
+      if (!hProperties) {
+        return;
+      }
+
+      const classAttr = hProperties.class;
+      if (
+        typeof classAttr !== "string" ||
+        !classAttr.startsWith("markdown-alert markdown-alert-")
+      ) {
+        return;
+      }
+
+      const type = classAttr.replace("markdown-alert markdown-alert-", "");
+
+      node.data = node.data ?? {};
+      node.data.hName = "admonition";
+      node.data.hProperties = {
+        "data-admonition-type": type,
+        dataAdmonitionType: type,
+      };
+
+      // Remove the injected title paragraph — Streamdown's React component handles titles
+      if (node.children) {
+        const firstChild = node.children[0];
+        const firstChildProps = firstChild?.data?.hProperties as
+          | Record<string, unknown>
+          | undefined;
+        if (firstChildProps?.class === "markdown-alert-title") {
+          node.children.splice(0, 1);
+        }
+      }
+    });
+  };

--- a/packages/streamdown/lib/remark/admonition.ts
+++ b/packages/streamdown/lib/remark/admonition.ts
@@ -1,6 +1,12 @@
-import type { Blockquote, Paragraph, Root, Text } from "mdast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
+
+interface MdastNode {
+  children?: MdastNode[];
+  data?: Record<string, unknown>;
+  type: string;
+  value?: string;
+}
 
 const ADMONITION_TYPES = new Set([
   "note",
@@ -12,20 +18,18 @@ const ADMONITION_TYPES = new Set([
 
 const ADMONITION_REGEX = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n?/i;
 
-function detectAdmonitionType(node: Blockquote): string | undefined {
-  const firstChild = node.children[0];
+function detectAdmonitionType(node: MdastNode): string | undefined {
+  const firstChild = node.children?.[0];
   if (!firstChild || firstChild.type !== "paragraph") {
     return undefined;
   }
 
-  const paragraph = firstChild as Paragraph;
-  const firstInline = paragraph.children[0];
-  if (!firstInline || firstInline.type !== "text") {
+  const firstInline = firstChild.children?.[0];
+  if (!firstInline || firstInline.type !== "text" || !firstInline.value) {
     return undefined;
   }
 
-  const textNode = firstInline as Text;
-  const match = textNode.value.match(ADMONITION_REGEX);
+  const match = firstInline.value.match(ADMONITION_REGEX);
   if (!match) {
     return undefined;
   }
@@ -38,9 +42,13 @@ function detectAdmonitionType(node: Blockquote): string | undefined {
   return type;
 }
 
-function stripMarker(node: Blockquote): void {
-  const paragraph = node.children[0] as Paragraph;
-  const textNode = paragraph.children[0] as Text;
+function stripMarker(node: MdastNode): void {
+  const paragraph = node.children?.[0];
+  const textNode = paragraph?.children?.[0];
+  if (!textNode?.value) {
+    return;
+  }
+
   const match = textNode.value.match(ADMONITION_REGEX);
   if (!match) {
     return;
@@ -50,15 +58,15 @@ function stripMarker(node: Blockquote): void {
 
   if (remaining.length > 0) {
     textNode.value = remaining;
-  } else if (paragraph.children.length > 1) {
+  } else if (paragraph?.children && paragraph.children.length > 1) {
     paragraph.children.splice(0, 1);
-  } else {
+  } else if (node.children) {
     node.children.splice(0, 1);
   }
 }
 
-export const remarkAdmonition: Plugin<[], Root> = () => (tree) => {
-  visit(tree, "blockquote", (node: Blockquote) => {
+export const remarkAdmonition: Plugin = () => (tree) => {
+  visit(tree, "blockquote", (node: MdastNode) => {
     const type = detectAdmonitionType(node);
     if (!type) {
       return;

--- a/packages/streamdown/lib/remark/admonition.ts
+++ b/packages/streamdown/lib/remark/admonition.ts
@@ -1,0 +1,62 @@
+import type { Blockquote, Paragraph, Root, Text } from "mdast";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+const ADMONITION_TYPES = new Set([
+  "note",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+]);
+
+const ADMONITION_REGEX = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n?/i;
+
+export const remarkAdmonition: Plugin<[], Root> = () => (tree) => {
+  visit(tree, "blockquote", (node: Blockquote) => {
+    const firstChild = node.children[0];
+    if (!firstChild || firstChild.type !== "paragraph") {
+      return;
+    }
+
+    const paragraph = firstChild as Paragraph;
+    const firstInline = paragraph.children[0];
+    if (!firstInline || firstInline.type !== "text") {
+      return;
+    }
+
+    const textNode = firstInline as Text;
+    const match = textNode.value.match(ADMONITION_REGEX);
+    if (!match) {
+      return;
+    }
+
+    const type = match[1].toLowerCase();
+    if (!ADMONITION_TYPES.has(type)) {
+      return;
+    }
+
+    // Strip the [!TYPE] marker from the text
+    const remaining = textNode.value.slice(match[0].length);
+
+    if (remaining.length > 0) {
+      // There's text after the marker — keep it
+      textNode.value = remaining;
+    } else if (paragraph.children.length > 1) {
+      // Remove the empty text node, keep other paragraph children
+      paragraph.children.splice(0, 1);
+    } else {
+      // Paragraph only had the marker — remove entire paragraph
+      node.children.splice(0, 1);
+    }
+
+    // Transform blockquote into admonition via remark-rehype hName/hProperties
+    node.data = node.data ?? {};
+    node.data.hName = "admonition";
+    node.data.hProperties = {
+      ...((node.data.hProperties as Record<string, unknown>) ?? {}),
+      "data-admonition-type": type,
+      dataAdmonitionType: type,
+    };
+  });
+};

--- a/packages/streamdown/lib/remark/admonition.ts
+++ b/packages/streamdown/lib/remark/admonition.ts
@@ -12,45 +12,60 @@ const ADMONITION_TYPES = new Set([
 
 const ADMONITION_REGEX = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n?/i;
 
+function detectAdmonitionType(node: Blockquote): string | undefined {
+  const firstChild = node.children[0];
+  if (!firstChild || firstChild.type !== "paragraph") {
+    return undefined;
+  }
+
+  const paragraph = firstChild as Paragraph;
+  const firstInline = paragraph.children[0];
+  if (!firstInline || firstInline.type !== "text") {
+    return undefined;
+  }
+
+  const textNode = firstInline as Text;
+  const match = textNode.value.match(ADMONITION_REGEX);
+  if (!match) {
+    return undefined;
+  }
+
+  const type = match[1].toLowerCase();
+  if (!ADMONITION_TYPES.has(type)) {
+    return undefined;
+  }
+
+  return type;
+}
+
+function stripMarker(node: Blockquote): void {
+  const paragraph = node.children[0] as Paragraph;
+  const textNode = paragraph.children[0] as Text;
+  const match = textNode.value.match(ADMONITION_REGEX);
+  if (!match) {
+    return;
+  }
+
+  const remaining = textNode.value.slice(match[0].length);
+
+  if (remaining.length > 0) {
+    textNode.value = remaining;
+  } else if (paragraph.children.length > 1) {
+    paragraph.children.splice(0, 1);
+  } else {
+    node.children.splice(0, 1);
+  }
+}
+
 export const remarkAdmonition: Plugin<[], Root> = () => (tree) => {
   visit(tree, "blockquote", (node: Blockquote) => {
-    const firstChild = node.children[0];
-    if (!firstChild || firstChild.type !== "paragraph") {
+    const type = detectAdmonitionType(node);
+    if (!type) {
       return;
     }
 
-    const paragraph = firstChild as Paragraph;
-    const firstInline = paragraph.children[0];
-    if (!firstInline || firstInline.type !== "text") {
-      return;
-    }
+    stripMarker(node);
 
-    const textNode = firstInline as Text;
-    const match = textNode.value.match(ADMONITION_REGEX);
-    if (!match) {
-      return;
-    }
-
-    const type = match[1].toLowerCase();
-    if (!ADMONITION_TYPES.has(type)) {
-      return;
-    }
-
-    // Strip the [!TYPE] marker from the text
-    const remaining = textNode.value.slice(match[0].length);
-
-    if (remaining.length > 0) {
-      // There's text after the marker — keep it
-      textNode.value = remaining;
-    } else if (paragraph.children.length > 1) {
-      // Remove the empty text node, keep other paragraph children
-      paragraph.children.splice(0, 1);
-    } else {
-      // Paragraph only had the marker — remove entire paragraph
-      node.children.splice(0, 1);
-    }
-
-    // Transform blockquote into admonition via remark-rehype hName/hProperties
     node.data = node.data ?? {};
     node.data.hName = "admonition";
     node.data.hProperties = {

--- a/packages/streamdown/lib/translations-context.tsx
+++ b/packages/streamdown/lib/translations-context.tsx
@@ -3,6 +3,12 @@
 import { createContext, useContext } from "react";
 
 export interface StreamdownTranslations {
+  // Admonition
+  admonitionCaution: string;
+  admonitionImportant: string;
+  admonitionNote: string;
+  admonitionTip: string;
+  admonitionWarning: string;
   // Link modal
   close: string;
   copied: string;
@@ -40,6 +46,12 @@ export interface StreamdownTranslations {
 }
 
 export const defaultTranslations: StreamdownTranslations = {
+  // Admonition
+  admonitionCaution: "Caution",
+  admonitionImportant: "Important",
+  admonitionNote: "Note",
+  admonitionTip: "Tip",
+  admonitionWarning: "Warning",
   // Code block
   copyCode: "Copy Code",
   downloadFile: "Download file",

--- a/packages/streamdown/package.json
+++ b/packages/streamdown/package.json
@@ -70,6 +70,7 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-gfm-admonition": "workspace:*",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "remend": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,37 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/remark-gfm-admonition:
+    dependencies:
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.0.15
+        version: 4.0.17(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      rehype-stringify:
+        specifier: ^10.0.0
+        version: 10.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.0.0
+        version: 11.1.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      vitest:
+        specifier: ^4.0.15
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/remend:
     devDependencies:
       '@vitest/coverage-v8':
@@ -337,6 +368,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-gfm-admonition:
+        specifier: workspace:*
+        version: link:../remark-gfm-admonition
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0


### PR DESCRIPTION
## Summary

- Add built-in support for GitHub-style admonition blocks (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`)
- Remark plugin transforms blockquotes with `[!TYPE]` markers into styled callout boxes with type-specific icons and colors
- Fully customizable via `components`, `icons`, and `translations` props
- Add admonitions documentation page and update existing docs (components, internationalization, GFM)
- Add admonition examples to the playground

## New files

- `packages/streamdown/lib/remark/admonition.ts` — Remark plugin (AST-level transformation)
- `packages/streamdown/lib/admonition.tsx` — Memoized React component with 5 color themes
- `packages/streamdown/__tests__/admonition.test.tsx` — 13 tests covering plugin + component features
- `apps/website/content/docs/admonitions.mdx` — Documentation page

## Modified files

- `packages/streamdown/lib/icons.tsx` — 5 new SVG icon components
- `packages/streamdown/lib/icon-context.tsx` — Extended IconMap interface
- `packages/streamdown/lib/translations-context.tsx` — 5 new i18n keys
- `packages/streamdown/lib/components.tsx` — Register admonition component
- `packages/streamdown/index.tsx` — Add to default remark plugins + sanitize schema + export
- `apps/website/content/docs/components.mdx` — Add admonition to available components list
- `apps/website/content/docs/internationalization.mdx` — Add admonition translation keys
- `apps/website/content/docs/gfm.mdx` — Cross-link to admonitions page
- `apps/website/app/[lang]/playground/components/playground-editor.tsx` — Add admonition examples

## Test plan

- [x] All 995 tests pass (74 test files)
- [x] Linter clean (`ultracite check`)
- [x] Type check passes (`pnpm check-types`)
- [x] Changeset included (minor bump)

<img width="753" height="552" alt="image" src="https://github.com/user-attachments/assets/7b66711f-0121-4e5a-a63a-66703f2ea004" />

<img width="758" height="541" alt="image" src="https://github.com/user-attachments/assets/92541db6-a52f-4818-a630-85053399351b" />
