### PR TITLE
fix(streamdown): improve mermaid diagram sizing and responsiveness

### DIFF
--- a/.changeset/mermaid-diagram-sizing.md
+++ b/.changeset/mermaid-diagram-sizing.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Improve Mermaid diagram sizing so SVGs scale to fill the container. Add `w-full`, `[&_svg]:w-full`, `[&_svg]:h-auto`, and `[&_svg]:max-w-full` to the chart wrapper for responsive scaling. Increase default container min-height from `min-h-28` to `min-h-48` for better visibility.

--- a/packages/streamdown/__tests__/mermaid-component.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-component.test.tsx
@@ -181,6 +181,35 @@ describe("Mermaid Component", () => {
     });
   });
 
+  it("should apply responsive sizing classes to chart container", async () => {
+    const { container } = renderWithContext(<Mermaid chart={simpleChart} />);
+
+    await waitFor(() => {
+      const chartContainer = container.querySelector(
+        '[aria-label="Mermaid chart"]'
+      );
+      expect(chartContainer).toBeTruthy();
+      expect(chartContainer?.className).toContain("w-full");
+      expect(chartContainer?.className).toContain("min-w-0");
+      expect(chartContainer?.className).toContain("items-start");
+    });
+  });
+
+  it("should apply fullscreen alignment to chart container", async () => {
+    const { container } = renderWithContext(
+      <Mermaid chart={simpleChart} fullscreen={true} />
+    );
+
+    await waitFor(() => {
+      const chartContainer = container.querySelector(
+        '[aria-label="Mermaid chart"]'
+      );
+      expect(chartContainer).toBeTruthy();
+      expect(chartContainer?.className).toContain("items-center");
+      expect(chartContainer?.className).toContain("size-full");
+    });
+  });
+
   it("should pass config to mermaid getMermaid", async () => {
     const mockPlugin = createMockMermaidPlugin();
 

--- a/packages/streamdown/lib/mermaid/index.tsx
+++ b/packages/streamdown/lib/mermaid/index.tsx
@@ -179,8 +179,9 @@ export const Mermaid = ({
         <div
           aria-label="Mermaid chart"
           className={cn(
-            "flex justify-center",
-            fullscreen ? "size-full items-center" : null
+            "flex w-full min-w-0 justify-center",
+            fullscreen ? "size-full items-center" : "items-start",
+            "[&_svg]:max-w-full [&_svg]:h-auto [&_svg]:w-full"
           )}
           // biome-ignore lint/security/noDangerouslySetInnerHtml: "Required for Mermaid"
           dangerouslySetInnerHTML={{ __html: displaySvg }}

--- a/packages/streamdown/lib/mermaid/pan-zoom.tsx
+++ b/packages/streamdown/lib/mermaid/pan-zoom.tsx
@@ -153,7 +153,7 @@ export const PanZoom = ({
     <div
       className={cn(
         "relative flex flex-col",
-        fullscreen ? "h-full w-full" : "min-h-28 w-full",
+        fullscreen ? "h-full w-full" : "min-h-48 w-full",
         className
       )}
       ref={containerRef}


### PR DESCRIPTION
## Description

Mermaid SVG diagrams could overflow their container, especially on smaller viewports. This PR constrains diagrams to their container width and improves layout consistency.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

## Changes Made

- Constrain mermaid SVG diagrams to container width using `max-w-full`, `h-auto`, and `w-full` CSS classes
- Add `min-w-0` to chart container for proper flexbox shrinking
- Increase minimum container height from `min-h-28` to `min-h-48` for better initial layout
- Align non-fullscreen diagrams to `items-start` instead of no alignment

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [ ] Manually tested the changes

### Test Coverage

Added 2 new tests:
- `should apply responsive sizing classes to chart container` — verifies `w-full`, `min-w-0`, `items-start` in normal mode
- `should apply fullscreen alignment to chart container` — verifies `items-center`, `size-full` in fullscreen mode

All 17 mermaid component tests pass.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] I have created a changeset for these changes