### PR TITLE
fix: stabilize table column widths during streaming

### DIFF
--- a/.changeset/fixed-table-widths.md
+++ b/.changeset/fixed-table-widths.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Fix table column widths from shifting during streaming by applying a fixed table layout to standard and fullscreen tables.

--- a/packages/streamdown/__tests__/components.test.tsx
+++ b/packages/streamdown/__tests__/components.test.tsx
@@ -433,6 +433,7 @@ describe("Markdown Components", () => {
       const table = tableWrapper?.querySelector("table");
       expect(table).toBeTruthy();
       expect(table?.className).toContain("w-full");
+      expect(table?.className).toContain("table-fixed");
       expect(table?.className).toContain("divide-y");
       expect(table?.className).toContain("divide-border");
     });

--- a/packages/streamdown/__tests__/table-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/table-fullscreen.test.tsx
@@ -136,6 +136,7 @@ describe("TableFullscreenButton", () => {
     );
     const table = overlay?.querySelector('[data-streamdown="table"]');
     expect(table).toBeTruthy();
+    expect(table?.className).toContain("table-fixed");
   });
 
   it("should show copy and download controls in fullscreen", () => {

--- a/packages/streamdown/lib/table/fullscreen-button.tsx
+++ b/packages/streamdown/lib/table/fullscreen-button.tsx
@@ -112,7 +112,7 @@ export const TableFullscreenButton = ({
                 >
                   <table
                     className={cn(
-                      "w-full border-collapse border border-border"
+                      "table-fixed w-full border-collapse border border-border"
                     )}
                     data-streamdown="table"
                   >

--- a/packages/streamdown/lib/table/index.tsx
+++ b/packages/streamdown/lib/table/index.tsx
@@ -53,7 +53,7 @@ export const Table = ({
         )}
       >
         <table
-          className={cn("w-full divide-y divide-border", className)}
+          className={cn("table-fixed w-full divide-y divide-border", className)}
           data-streamdown="table"
           {...props}
         >


### PR DESCRIPTION
## Description

Fix table column width jitter during streaming by applying a fixed table layout to Streamdown tables.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #
Closes #
Related to #

## Changes Made

- Apply `table-fixed` to the standard table renderer so column widths remain stable while table content streams in
- Apply `table-fixed` to the fullscreen table renderer for consistent behavior there as well
- Add regression tests covering both the standard table path and the fullscreen table path
- Add a patch changeset for the fix

## Testing

- [ ] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

Verified locally with:

- `corepack pnpm --filter streamdown exec vitest run __tests__/components.test.tsx __tests__/table-fullscreen.test.tsx`
- `corepack pnpm --filter streamdown build`

## Screenshots/Demos

N/A

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] I have created a changeset for these changes

## Additional Notes

This PR is intentionally scoped to the layout-stability fix only. 
