### PR TITLE
fix(streamdown): render code blocks incrementally during streaming

### DIFF
--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -347,6 +347,10 @@ export const Block = memo(
     if (animatePluginProp) {
       const prevCount = animatePluginProp.getLastRenderCharCount();
       animatePluginProp.setPrevContentLength(prevCount);
+      // When the block has an incomplete code fence, animate code block
+      // content incrementally instead of skipping it. This gives visual
+      // feedback that code is streaming in token-by-token.
+      animatePluginProp.setAnimateCodeBlocks(isIncomplete);
     }
 
     // Note: remend is already applied to the entire markdown before parsing into blocks

--- a/packages/streamdown/lib/animate.ts
+++ b/packages/streamdown/lib/animate.ts
@@ -12,6 +12,12 @@ export interface AnimatePlugin {
   name: "animate";
   rehypePlugin: Pluggable;
   /**
+   * Enable or disable animation inside code/pre blocks.
+   * When true, code block content will be animated incrementally
+   * during streaming (useful for incomplete/unclosed code fences).
+   */
+  setAnimateCodeBlocks: (enabled: boolean) => void;
+  /**
    * Set the number of HAST text characters from a previous render.
    * Characters up to this count will get duration=0ms, preventing
    * re-animation of already-visible content during streaming updates.
@@ -31,6 +37,7 @@ export interface AnimateOptions {
 const WHITESPACE_RE = /\s/;
 const WHITESPACE_ONLY_RE = /^\s+$/;
 const SKIP_TAGS = new Set(["code", "pre", "svg", "math", "annotation"]);
+const SKIP_TAGS_WITHOUT_CODE = new Set(["svg", "math", "annotation"]);
 
 const isElement = (node: unknown): node is Element =>
   typeof node === "object" &&
@@ -38,10 +45,15 @@ const isElement = (node: unknown): node is Element =>
   "type" in node &&
   (node as Element).type === "element";
 
-const hasSkipAncestor = (ancestors: Node[]): boolean =>
-  ancestors.some(
-    (ancestor) => isElement(ancestor) && SKIP_TAGS.has(ancestor.tagName)
+const hasSkipAncestor = (
+  ancestors: Node[],
+  animateCodeBlocks: boolean
+): boolean => {
+  const tags = animateCodeBlocks ? SKIP_TAGS_WITHOUT_CODE : SKIP_TAGS;
+  return ancestors.some(
+    (ancestor) => isElement(ancestor) && tags.has(ancestor.tagName)
   );
+};
 
 const splitByWord = (text: string): string[] => {
   const parts: string[] = [];
@@ -126,6 +138,7 @@ interface AnimateConfig {
  * object that setPrevContentLength / getLastRenderCharCount mutate.
  */
 interface AnimateRenderState {
+  animateCodeBlocks: boolean;
   lastRenderCharCount: number;
   prevContentLength: number;
 }
@@ -143,7 +156,7 @@ const processTextNode = (
     return;
   }
 
-  if (hasSkipAncestor(ancestors)) {
+  if (hasSkipAncestor(ancestors, renderState.animateCodeBlocks)) {
     return SKIP;
   }
 
@@ -203,6 +216,7 @@ export function createAnimatePlugin(options?: AnimateOptions): AnimatePlugin {
   // Mutable render state — the rehype closure and the plugin API methods
   // both reference this same object.
   const renderState: AnimateRenderState = {
+    animateCodeBlocks: false,
     prevContentLength: 0,
     lastRenderCharCount: 0,
   };
@@ -230,6 +244,9 @@ export function createAnimatePlugin(options?: AnimateOptions): AnimatePlugin {
     name: "animate",
     type: "animate",
     rehypePlugin: rehypeAnimate,
+    setAnimateCodeBlocks(enabled: boolean) {
+      renderState.animateCodeBlocks = enabled;
+    },
     setPrevContentLength(length: number) {
       renderState.prevContentLength = length;
     },


### PR DESCRIPTION
## Summary
- Fixes the animate plugin to include code/pre elements in its animation pass when the code fence is still open (incomplete)
- Adds `setAnimateCodeBlocks` method to `AnimatePlugin` interface so the Block component can toggle code animation per-block
- Once the code fence closes, animation reverts to default behavior (skip code blocks for syntax highlighting compatibility)

## Problem
When using `<Streamdown animated isAnimating>`, prose text streams with word-by-word fade-in animation. But the animate plugin unconditionally skipped all `code` and `pre` elements (via `SKIP_TAGS`), so code block content appeared instantly without any animation. This created a jarring visual discontinuity where code seemed to "buffer" and then dump all at once, while surrounding text streamed smoothly.

## Changes
- `packages/streamdown/lib/animate.ts`: Added `SKIP_TAGS_WITHOUT_CODE` set, made `hasSkipAncestor` state-aware, added `animateCodeBlocks` flag to render state, exposed `setAnimateCodeBlocks` on the plugin API
- `packages/streamdown/index.tsx`: Block component calls `animatePluginProp.setAnimateCodeBlocks(isIncomplete)` to enable code animation for blocks with unclosed fences

## Test plan
- [x] All 982 existing tests pass
- [x] Animate-specific tests pass (32 tests)
- [x] Incomplete code block tests pass (35 tests)
- [x] Biome linter passes with no issues
- [ ] Manual verification: stream a markdown response containing a fenced code block and confirm content appears incrementally with animation

Fixes #473

This contribution was developed with AI assistance (Claude Code).