### PR TITLE
fix(custom-tags): restructure inline content with newlines to prevent ATX heading block splitting

### DIFF
--- a/packages/streamdown/__tests__/preprocess-custom-tags.test.ts
+++ b/packages/streamdown/__tests__/preprocess-custom-tags.test.ts
@@ -51,9 +51,23 @@ describe("preprocessCustomTags", () => {
     expect(preprocessCustomTags(md, ["custom"])).toBe(md);
   });
 
-  it("should not modify content without blank lines", () => {
+  it("should not modify content without blank lines (no newline)", () => {
+    // Single-line content without any newlines is fine as inline HTML
     const md = "<custom>Hello World</custom>";
     expect(preprocessCustomTags(md, ["custom"])).toBe(md);
+  });
+
+  it("should restructure inline content with a newline followed by ATX heading", () => {
+    // A heading inside inline content would prematurely terminate the custom tag
+    const md = "<ai-thinking> hi\n # yes</ai-thinking>";
+    const result = preprocessCustomTags(md, ["ai-thinking"]);
+    expect(result).toBe("<ai-thinking>\n hi\n # yes\n</ai-thinking>\n\n");
+  });
+
+  it("should restructure inline content with any newline (prevents block element splitting)", () => {
+    const md = "<custom>hello\nworld</custom>";
+    const result = preprocessCustomTags(md, ["custom"]);
+    expect(result).toBe("<custom>\nhello\nworld\n</custom>\n\n");
   });
 
   it("should not modify tags where content already starts on own line without blank lines", () => {

--- a/packages/streamdown/lib/preprocess-custom-tags.ts
+++ b/packages/streamdown/lib/preprocess-custom-tags.ts
@@ -35,10 +35,16 @@ export const preprocessCustomTags = (
     result = result.replace(
       pattern,
       (_match, open: string, content: string, close: string) => {
-        // Only restructure when content contains blank lines that would
-        // split the HTML block. Tags without blank lines work fine as
-        // inline HTML and don't need restructuring.
-        if (!content.includes("\n\n")) {
+        // Restructure when:
+        // 1. Content has blank lines (\n\n) — these would split the HTML block, or
+        // 2. Content starts inline (not preceded by \n) and contains any newline —
+        //    a newline inside inline content can introduce block-level elements like
+        //    ATX headings (# title) that the parser would treat as a new block,
+        //    prematurely terminating the custom tag scope.
+        const hasBlankLines = content.includes("\n\n");
+        const isInlineContent = !content.startsWith("\n");
+        const hasNewline = content.includes("\n");
+        if (!(hasBlankLines || (isInlineContent && hasNewline))) {
           return open + content + close;
         }
 


### PR DESCRIPTION
## Problem

Custom tags with multiline content are prematurely closed by the CommonMark parser when the content starts inline (on the same line as the opening tag) and contains a newline followed by a block-level element like an ATX heading.

**Minimal reproduction:**
```tsx
const markdown = '<ai-thinking> hi\n # yes</ai-thinking>';
// Expected: Both 'hi' and '# yes' inside the AiThinking component
// Actual: 'hi' inside, '# yes' rendered outside
```

The `marked` Lexer splits this as:
1. `paragraph`: `<ai-thinking> hi\n`
2. `heading`: ` # yes</ai-thinking>`

## Root Cause

`preprocess-custom-tags.ts` only restructures tags to block-level HTML when there are blank lines (`\n\n`) in the content. However, a single newline inside inline content is sufficient to introduce block-starting sequences (ATX headings, thematic breaks, list items, etc.) that break the parser.

Content that already starts on its own line (`\nContent\n`) is correctly parsed as a block-level HTML element by the Lexer — even with headings inside — because the opening tag is on its own line.

## Fix

Extend the restructuring condition to also apply when:
- Content is **inline** (doesn't start with `\n`), **AND**
- Content contains **any newline**

Tags where content already starts on its own line (block-level) are unaffected. Single-line tags without newlines are also unaffected.

Fixes #477
Related: #478 (same root cause)