### PR TITLE
fix(icons): add aria-hidden attribute to all icon components for accessibility(#485)

### DIFF
--- a/.changeset/fix-icons-aria-hidden.md
+++ b/.changeset/fix-icons-aria-hidden.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Add `aria-hidden="true"` to decorative SVG icon components so screen readers rely on parent button labels instead of unlabeled icons.

--- a/packages/streamdown/lib/icons.tsx
+++ b/packages/streamdown/lib/icons.tsx
@@ -5,6 +5,7 @@ type IconProps = SVGProps<SVGSVGElement>;
 
 export const CheckIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -23,6 +24,7 @@ export const CheckIcon = (props: IconProps) => (
 
 export const CopyIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -41,6 +43,7 @@ export const CopyIcon = (props: IconProps) => (
 
 export const DownloadIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -59,6 +62,7 @@ export const DownloadIcon = (props: IconProps) => (
 
 export const Loader2Icon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -121,6 +125,7 @@ export const Loader2Icon = (props: IconProps) => (
 
 export const Maximize2Icon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -139,6 +144,7 @@ export const Maximize2Icon = (props: IconProps) => (
 
 export const RotateCcwIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -157,6 +163,7 @@ export const RotateCcwIcon = (props: IconProps) => (
 
 export const XIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -175,6 +182,7 @@ export const XIcon = (props: IconProps) => (
 
 export const ExternalLinkIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -193,6 +201,7 @@ export const ExternalLinkIcon = (props: IconProps) => (
 
 export const ZoomInIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"
@@ -211,6 +220,7 @@ export const ZoomInIcon = (props: IconProps) => (
 
 export const ZoomOutIcon = (props: IconProps) => (
   <svg
+    aria-hidden="true"
     color="currentColor"
     height={16}
     strokeLinejoin="round"


### PR DESCRIPTION
## fix(icons): add `aria-hidden` to decorative SVG icons for accessibility

### Problem

Toolbar buttons in the Mermaid integration (and other components) contain inline SVG icons that are exposed to the accessibility tree, triggering the warning: **"Content with images must be labeled"** in accessibility audits (Firefox Accessibility Inspector, axe DevTools). While the parent buttons have `title` attributes providing accessible names, the SVGs themselves lacked proper `aria-hidden` attributes to mark them as decorative.

### Solution

Added `aria-hidden="true"` to all 10 SVG icon components in `packages/streamdown/lib/icons.tsx`:

- `CheckIcon`
- `CopyIcon`
- `DownloadIcon`
- `Loader2Icon`
- `Maximize2Icon`
- `RotateCcwIcon`
- `XIcon`
- `ExternalLinkIcon`
- `ZoomInIcon`
- `ZoomOutIcon`

This hides the decorative SVGs from the accessibility tree. Screen readers will rely on the parent button `title` attributes instead, which already provide meaningful labels (e.g., "Zoom in", "Copy Code", "Download").

### Testing

- Verified with accessibility audit tools that the "Content with images must be labeled" warning is resolved.