### PR TITLE
fix(mermaid): add aria-hidden to decorative SVG icons in toolbar buttons

### DIFF
--- a/.changeset/fix-mermaid-aria-hidden.md
+++ b/.changeset/fix-mermaid-aria-hidden.md
@@ -1,0 +1,13 @@
+---
+'streamdown': patch
+---
+
+fix(mermaid): add aria-hidden to decorative SVG icons in mermaid toolbar buttons
+
+Mermaid toolbar buttons (download, fullscreen, pan/zoom controls) already have
+accessible titles/labels, but the inline SVG icons were exposed to the accessibility
+tree causing "Content with images must be labeled" warnings. Added aria-hidden={true}
+to all decorative icon elements in download-button, fullscreen-button, and pan-zoom
+components.
+
+Fixes #485

--- a/packages/streamdown/lib/mermaid/download-button.tsx
+++ b/packages/streamdown/lib/mermaid/download-button.tsx
@@ -116,7 +116,7 @@ export const MermaidDownloadDropdown = ({
         title={t.downloadDiagram}
         type="button"
       >
-        {children ?? <icons.DownloadIcon size={14} />}
+        {children ?? <icons.DownloadIcon aria-hidden={true} size={14} />}
       </button>
       {isOpen ? (
         <div

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -88,7 +88,7 @@ export const MermaidFullscreenButton = ({
         type="button"
         {...props}
       >
-        <Maximize2Icon size={14} />
+        <Maximize2Icon aria-hidden={true} size={14} />
       </button>
 
       {isFullscreen
@@ -115,7 +115,7 @@ export const MermaidFullscreenButton = ({
                 title={t.exitFullscreen}
                 type="button"
               >
-                <XIcon size={20} />
+                <XIcon aria-hidden={true} size={20} />
               </button>
               {/* biome-ignore lint/a11y/noStaticElementInteractions: "div with role=presentation is used for event propagation control" */}
               <div

--- a/packages/streamdown/lib/mermaid/pan-zoom.tsx
+++ b/packages/streamdown/lib/mermaid/pan-zoom.tsx
@@ -175,7 +175,7 @@ export const PanZoom = ({
             title="Zoom in"
             type="button"
           >
-            <ZoomInIcon size={16} />
+            <ZoomInIcon aria-hidden={true} size={16} />
           </button>
           <button
             className={cn(
@@ -186,7 +186,7 @@ export const PanZoom = ({
             title="Zoom out"
             type="button"
           >
-            <ZoomOutIcon size={16} />
+            <ZoomOutIcon aria-hidden={true} size={16} />
           </button>
           <button
             className={cn(
@@ -196,7 +196,7 @@ export const PanZoom = ({
             title="Reset zoom and pan"
             type="button"
           >
-            <RotateCcwIcon size={16} />
+            <RotateCcwIcon aria-hidden={true} size={16} />
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Mermaid toolbar buttons (download, fullscreen, and pan/zoom controls) already have accessible names via `title` attributes and button labels, but the inline SVG icons were exposed to the accessibility tree, triggering **"Content with images must be labeled"** warnings in Firefox Accessibility Inspector and axe DevTools.

## Changes

Added `aria-hidden={true}` to all decorative icon elements in the mermaid toolbar:

- `MermaidDownloadDropdown`: `DownloadIcon`
- `MermaidFullscreenButton`: `Maximize2Icon`, `XIcon`
- `MermaidPanZoom`: `ZoomInIcon`, `ZoomOutIcon`, `RotateCcwIcon`

Since all buttons already have `title` attributes for screen reader users, the SVGs are purely decorative and should be hidden from the accessibility tree.

## Testing

All 982 existing tests pass (`pnpm test`).

Fixes #485