### PR TITLE
fix: prioritize shikiTheme prop over code plugin default theme

### DIFF
--- a/.changeset/fix-shiki-theme-priority.md
+++ b/.changeset/fix-shiki-theme-priority.md
@@ -2,6 +2,10 @@
 "streamdown": patch
 ---
 
-Fix: `shikiTheme` prop now takes priority over the code plugin's default theme.
+Fix: `shikiTheme` prop priority chain is now fully reachable.
 
-Previously, the nullish coalescing order was incorrect, causing the code plugin's `getThemes()` to override the explicitly passed `shikiTheme` prop. The order has been swapped so the prop takes precedence.
+Previously, `shikiTheme` had a default value in the props destructuring (`= defaultShikiTheme`), making the `plugins?.code?.getThemes()` fallback unreachable in both orderings. The fix removes the destructuring default and moves it to the end of the nullish coalescing chain, so all three levels are reachable:
+
+1. Explicit `shikiTheme` prop (highest priority)
+2. Code plugin's `getThemes()` (second priority)
+3. Built-in `defaultShikiTheme` (final fallback)

--- a/.changeset/fix-shiki-theme-priority.md
+++ b/.changeset/fix-shiki-theme-priority.md
@@ -1,0 +1,7 @@
+---
+"streamdown": patch
+---
+
+Fix: `shikiTheme` prop now takes priority over the code plugin's default theme.
+
+Previously, the nullish coalescing order was incorrect, causing the code plugin's `getThemes()` to override the explicitly passed `shikiTheme` prop. The order has been swapped so the prop takes precedence.

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -609,7 +609,7 @@ export const Streamdown = memo(
     // Combined context value - single object reduces React tree overhead
     const contextValue = useMemo<StreamdownContextType>(
       () => ({
-        shikiTheme: plugins?.code?.getThemes() ?? shikiTheme,
+        shikiTheme: shikiTheme ?? plugins?.code?.getThemes(),
         controls,
         isAnimating,
         lineNumbers,

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -438,7 +438,7 @@ export const Streamdown = memo(
     rehypePlugins = defaultRehypePluginsArray,
     remarkPlugins = defaultRemarkPluginsArray,
     className,
-    shikiTheme = defaultShikiTheme,
+    shikiTheme,
     mermaid,
     controls = true,
     isAnimating = false,
@@ -609,7 +609,8 @@ export const Streamdown = memo(
     // Combined context value - single object reduces React tree overhead
     const contextValue = useMemo<StreamdownContextType>(
       () => ({
-        shikiTheme: shikiTheme ?? plugins?.code?.getThemes(),
+        shikiTheme:
+          shikiTheme ?? plugins?.code?.getThemes() ?? defaultShikiTheme,
         controls,
         isAnimating,
         lineNumbers,


### PR DESCRIPTION
Fixes #496

The `shikiTheme` prop was being overridden by the code plugin's default theme due to incorrect nullish coalescing order. The prop should take priority over the plugin default, matching the documented behavior.\n\n### Changes\n- Swapped the nullish coalescing order so `shikiTheme` prop takes precedence over `plugins?.code?.getThemes()`