### PR TITLE
feat: add configurable portal target

### DIFF
--- a/.changeset/mermaid-fullscreen-portal.md
+++ b/.changeset/mermaid-fullscreen-portal.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Add optional `mermaid.fullscreenPortalContainer` so Mermaid fullscreen can portal into a host element (for micro-frontends with scoped or prefixed CSS). Compare `mermaid` in the `Streamdown` memo so context updates when this option changes.

--- a/.changeset/shared-overlay-portal.md
+++ b/.changeset/shared-overlay-portal.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Add a top-level `portal` prop for configuring the container used by Mermaid fullscreen, table fullscreen, and the built-in link safety modal.

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -192,6 +192,11 @@ The `mermaid` prop accepts an object with the following properties:
         "Custom React component for handling Mermaid rendering errors",
       type: "React.ComponentType<MermaidErrorComponentProps>",
     },
+    fullscreenPortalContainer: {
+      description:
+        "Optional DOM node (or getter) used as the React portal target for the Mermaid fullscreen overlay. Defaults to document.body. Set this to an element inside your app shell when using scoped or prefixed CSS (e.g. micro-frontends, Tailwind prefix) so the overlay stays in the same stacking context and receives the same utilities. Memoize the element or use a function if the node is mounted after first render.",
+      type: "HTMLElement | null | (() => HTMLElement | null)",
+    },
   }}
 />
 

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -184,6 +184,12 @@ Math rendering and CJK support require installing separate plugins. See [Mathema
       type: "LinkSafetyConfig",
       default: "{ enabled: true }",
     },
+    portal: {
+      description:
+        "DOM node (or getter) used as the portal target for built-in overlays. Useful for micro-frontends and scoped or prefixed CSS.",
+      type: "HTMLElement | null | (() => HTMLElement | null)",
+      default: "document.body",
+    },
     plugins: {
       description: "Plugin configuration for math, mermaid, code highlighting, and CJK support. See [Plugins](/docs/plugins).",
       type: "PluginConfig",
@@ -212,6 +218,23 @@ Math rendering and CJK support require installing separate plugins. See [Mathema
     },
   }}
 />
+
+### Portal Target
+
+By default, Mermaid fullscreen, table fullscreen, and the built-in link safety modal render into `document.body`. Use `portal` to keep these overlays inside a micro-frontend or another subtree that provides scoped CSS, prefixed Tailwind utilities, or a specific stacking context.
+
+```tsx title="app/page.tsx"
+const portalRef = useRef<HTMLDivElement>(null);
+
+return (
+  <div className="my-app">
+    <div ref={portalRef} />
+    <Streamdown portal={() => portalRef.current}>{markdown}</Streamdown>
+  </div>
+);
+```
+
+The getter form is useful when the portal element is assigned after the first render. Returning `null` falls back to `document.body`. A custom `linkSafety.renderModal` controls its own placement and is not moved by this prop.
 
 ### Mermaid Options
 

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -234,7 +234,7 @@ return (
 );
 ```
 
-The getter form is useful when the portal element is assigned after the first render. Returning `null` falls back to `document.body`. A custom `linkSafety.renderModal` controls its own placement and is not moved by this prop.
+The getter form is useful when the portal element is assigned after the first render. Returning `null` falls back to `document.body`. A custom `linkSafety.renderModal` controls its own placement and is not moved by this prop. Like `urlTransform` and `allowElement`, `portal` is an initializing prop: swapping it for a different target alone does not re-render, so prefer the getter form — it is resolved each time an overlay opens.
 
 ### Mermaid Options
 

--- a/packages/streamdown/__tests__/link-modal-keyboard.test.tsx
+++ b/packages/streamdown/__tests__/link-modal-keyboard.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Streamdown } from "../index";
 import { LinkSafetyModal } from "../lib/link-modal";
 
 describe("LinkSafetyModal keyboard and interaction", () => {
@@ -227,5 +228,27 @@ describe("LinkSafetyModal keyboard and interaction", () => {
     // Fire on document level (the useEffect handler)
     fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should portal the default modal to the configured portal target", () => {
+    const portalRoot = document.createElement("div");
+    document.body.appendChild(portalRoot);
+
+    const { container, unmount } = render(
+      <Streamdown portal={() => portalRoot}>
+        {"[External link](https://example.com)"}
+      </Streamdown>
+    );
+
+    const link = container.querySelector('[data-streamdown="link"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(link!);
+
+    expect(
+      portalRoot.querySelector('[data-streamdown="link-safety-modal"]')
+    ).toBeTruthy();
+
+    unmount();
+    portalRoot.remove();
   });
 });

--- a/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
@@ -246,4 +246,46 @@ describe("MermaidFullscreenButton", () => {
       expect(mermaid?.textContent).toContain("graph TD; A-->B");
     });
   });
+
+  it("should portal fullscreen overlay to mermaid.fullscreenPortalContainer when set", async () => {
+    const portalRoot = document.createElement("div");
+    document.body.appendChild(portalRoot);
+
+    const { container } = renderWithContext(
+      { chart: "graph TD; A-->B" },
+      { mermaid: { fullscreenPortalContainer: portalRoot } }
+    );
+
+    const openBtn = container.querySelector('button[title="View fullscreen"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(openBtn!);
+
+    await waitFor(() => {
+      const backdrop = portalRoot.querySelector(".fixed.inset-0");
+      expect(backdrop).toBeTruthy();
+      expect(portalRoot.contains(backdrop)).toBe(true);
+    });
+
+    portalRoot.remove();
+  });
+
+  it("should resolve portal container from a callback", async () => {
+    const portalRoot = document.createElement("div");
+    document.body.appendChild(portalRoot);
+
+    const { container } = renderWithContext(
+      { chart: "graph TD; A-->B" },
+      { mermaid: { fullscreenPortalContainer: () => portalRoot } }
+    );
+
+    const openBtn = container.querySelector('button[title="View fullscreen"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(openBtn!);
+
+    await waitFor(() => {
+      expect(portalRoot.querySelector(".fixed.inset-0")).toBeTruthy();
+    });
+
+    portalRoot.remove();
+  });
 });

--- a/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
@@ -348,4 +348,27 @@ describe("MermaidFullscreenButton", () => {
       document.querySelector('button[title="Download diagram"]')
     ).toBeFalsy();
   });
+
+  it("should portal fullscreen overlay to the configured portal target", async () => {
+    const portalRoot = document.createElement("div");
+    document.body.appendChild(portalRoot);
+
+    const { container, unmount } = renderWithContext(
+      { chart: "graph TD; A-->B" },
+      { portal: () => portalRoot }
+    );
+
+    const openBtn = container.querySelector('button[title="View fullscreen"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(openBtn!);
+
+    await waitFor(() => {
+      expect(
+        portalRoot.querySelector('[data-streamdown="mermaid-fullscreen"]')
+      ).toBeTruthy();
+    });
+
+    unmount();
+    portalRoot.remove();
+  });
 });

--- a/packages/streamdown/__tests__/portal.test.tsx
+++ b/packages/streamdown/__tests__/portal.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { Streamdown } from "../index";
+import { resolvePortalTarget } from "../lib/portal";
+
+const markdownWithTable = `
+| Name | Age |
+|------|-----|
+| Alice | 30 |
+`;
+
+describe("portal target", () => {
+  it("should fall back to document.body when the portal getter returns null", () => {
+    expect(resolvePortalTarget(() => null)).toBe(document.body);
+  });
+
+  it("should not resolve the portal target during server rendering", () => {
+    const getPortal = vi.fn(() => document.body);
+
+    renderToString(<Streamdown portal={getPortal}>Content</Streamdown>);
+
+    expect(getPortal).not.toHaveBeenCalled();
+  });
+
+  it("should update the portal target when the prop changes", () => {
+    const firstRoot = document.createElement("div");
+    const secondRoot = document.createElement("div");
+    document.body.append(firstRoot, secondRoot);
+
+    const { container, rerender, unmount } = render(
+      <Streamdown portal={firstRoot}>{markdownWithTable}</Streamdown>
+    );
+
+    rerender(<Streamdown portal={secondRoot}>{markdownWithTable}</Streamdown>);
+
+    const button = container.querySelector(
+      'button[title="View fullscreen"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(button);
+
+    expect(
+      firstRoot.querySelector('[data-streamdown="table-fullscreen"]')
+    ).toBeNull();
+    expect(
+      secondRoot.querySelector('[data-streamdown="table-fullscreen"]')
+    ).toBeTruthy();
+
+    unmount();
+    firstRoot.remove();
+    secondRoot.remove();
+  });
+});

--- a/packages/streamdown/__tests__/portal.test.tsx
+++ b/packages/streamdown/__tests__/portal.test.tsx
@@ -23,7 +23,7 @@ describe("portal target", () => {
     expect(getPortal).not.toHaveBeenCalled();
   });
 
-  it("should update the portal target when the prop changes", () => {
+  it("should treat portal as an initializing prop", () => {
     const firstRoot = document.createElement("div");
     const secondRoot = document.createElement("div");
     document.body.append(firstRoot, secondRoot);
@@ -41,10 +41,10 @@ describe("portal target", () => {
 
     expect(
       firstRoot.querySelector('[data-streamdown="table-fullscreen"]')
-    ).toBeNull();
+    ).toBeTruthy();
     expect(
       secondRoot.querySelector('[data-streamdown="table-fullscreen"]')
-    ).toBeTruthy();
+    ).toBeNull();
 
     unmount();
     firstRoot.remove();

--- a/packages/streamdown/__tests__/table-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/table-fullscreen.test.tsx
@@ -390,6 +390,27 @@ describe("TableFullscreenButton", () => {
       overlay?.querySelector('button[title="Download table as Markdown"]')
     ).toBeTruthy();
   });
+
+  it("should portal fullscreen overlay to the configured portal target", () => {
+    const portalRoot = document.createElement("div");
+    document.body.appendChild(portalRoot);
+
+    const { container, unmount } = render(
+      <Streamdown portal={portalRoot}>{markdownWithTable}</Streamdown>
+    );
+
+    const btn = container.querySelector(
+      'button[title="View fullscreen"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    expect(
+      portalRoot.querySelector('[data-streamdown="table-fullscreen"]')
+    ).toBeTruthy();
+
+    unmount();
+    portalRoot.remove();
+  });
 });
 
 describe("TableFullscreenButton copy and download", () => {

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -180,6 +180,12 @@ export interface MermaidErrorComponentProps {
 export interface MermaidOptions {
   config?: MermaidConfig;
   errorComponent?: React.ComponentType<MermaidErrorComponentProps>;
+  /**
+   * DOM node for the Mermaid fullscreen overlay (`createPortal` target).
+   * Use a container inside your app root when using scoped CSS or prefixed Tailwind so `fixed` / z-index utilities apply.
+   * @default document.body
+   */
+  fullscreenPortalContainer?: HTMLElement | null | (() => HTMLElement | null);
 }
 
 export type AllowedTags = Record<string, string[]>;
@@ -859,6 +865,7 @@ export const Streamdown = memo(
     prevProps.plugins === nextProps.plugins &&
     prevProps.className === nextProps.className &&
     prevProps.linkSafety === nextProps.linkSafety &&
+    prevProps.mermaid === nextProps.mermaid &&
     prevProps.lineNumbers === nextProps.lineNumbers &&
     prevProps.normalizeHtmlIndentation === nextProps.normalizeHtmlIndentation &&
     prevProps.literalTagContent === nextProps.literalTagContent &&

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -192,6 +192,7 @@ export interface MermaidOptions {
 }
 
 export type AllowedTags = Record<string, string[]>;
+export type PortalTarget = HTMLElement | null | (() => HTMLElement | null);
 
 export type StreamdownProps = Options & {
   mode?: "static" | "streaming";
@@ -230,6 +231,11 @@ export type StreamdownProps = Options & {
   plugins?: PluginConfig;
   remend?: RemendOptions;
   linkSafety?: LinkSafetyConfig;
+  /**
+   * DOM node for Streamdown overlays, or a function returning one.
+   * Defaults to `document.body`.
+   */
+  portal?: PortalTarget;
   /** Custom tags to allow through sanitization with their permitted attributes */
   allowedTags?: AllowedTags;
   /**
@@ -320,6 +326,7 @@ export interface StreamdownContextType {
   linkSafety?: LinkSafetyConfig;
   mermaid?: MermaidOptions;
   mode: "static" | "streaming";
+  portal?: PortalTarget;
   shikiTheme: [ThemeInput, ThemeInput];
   /** Max height for tables. @default 300 */
   tableMaxHeight: number | string;
@@ -343,6 +350,7 @@ const defaultStreamdownContext: StreamdownContextType = {
   mode: "streaming",
   mermaid: undefined,
   linkSafety: defaultLinkSafetyConfig,
+  portal: undefined,
   tableMaxHeight: 300,
 };
 
@@ -496,6 +504,7 @@ export const Streamdown = memo(
     plugins,
     remend: remendOptions,
     linkSafety = defaultLinkSafetyConfig,
+    portal,
     lineNumbers = true,
     allowedTags,
     literalTagContent,
@@ -688,6 +697,7 @@ export const Streamdown = memo(
         mode,
         mermaid,
         linkSafety,
+        portal,
         tableMaxHeight,
       }),
       [
@@ -699,6 +709,7 @@ export const Streamdown = memo(
         mode,
         mermaid,
         linkSafety,
+        portal,
         plugins?.code,
         tableMaxHeight,
       ]
@@ -978,6 +989,7 @@ export const Streamdown = memo(
     prevProps.plugins === nextProps.plugins &&
     prevProps.className === nextProps.className &&
     prevProps.linkSafety === nextProps.linkSafety &&
+    prevProps.portal === nextProps.portal &&
     prevProps.lineNumbers === nextProps.lineNumbers &&
     prevProps.codeBlockMaxHeight === nextProps.codeBlockMaxHeight &&
     prevProps.tableMaxHeight === nextProps.tableMaxHeight &&

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -989,7 +989,6 @@ export const Streamdown = memo(
     prevProps.plugins === nextProps.plugins &&
     prevProps.className === nextProps.className &&
     prevProps.linkSafety === nextProps.linkSafety &&
-    prevProps.portal === nextProps.portal &&
     prevProps.lineNumbers === nextProps.lineNumbers &&
     prevProps.codeBlockMaxHeight === nextProps.codeBlockMaxHeight &&
     prevProps.tableMaxHeight === nextProps.tableMaxHeight &&

--- a/packages/streamdown/lib/link-modal.tsx
+++ b/packages/streamdown/lib/link-modal.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { StreamdownContext } from "../index";
 import { useIcons } from "./icon-context";
+import { resolvePortalTarget } from "./portal";
 import { useCn } from "./prefix-context";
 import { lockBodyScroll, unlockBodyScroll } from "./scroll-lock";
 import { useTranslations } from "./translations-context";
@@ -22,6 +24,7 @@ export const LinkSafetyModal = ({
   const cn = useCn();
   const [copied, setCopied] = useState(false);
   const t = useTranslations();
+  const { portal } = useContext(StreamdownContext);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -150,5 +153,5 @@ export const LinkSafetyModal = ({
     </div>
   );
 
-  return createPortal(modal, document.body);
+  return createPortal(modal, resolvePortalTarget(portal));
 };

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -1,7 +1,7 @@
 import type { MermaidConfig } from "mermaid";
 import { type ComponentProps, useContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { StreamdownContext } from "../../index";
+import { type MermaidOptions, StreamdownContext } from "../../index";
 import { useIcons } from "../icon-context";
 import { useCn } from "../prefix-context";
 import { lockBodyScroll, unlockBodyScroll } from "../scroll-lock";
@@ -14,6 +14,19 @@ type MermaidFullscreenButtonProps = ComponentProps<"button"> & {
   onFullscreen?: () => void;
   onExit?: () => void;
 };
+
+function resolveMermaidFullscreenPortalContainer(
+  mermaidOptions: MermaidOptions | undefined
+): HTMLElement {
+  const configured = mermaidOptions?.fullscreenPortalContainer;
+  if (configured === undefined || configured === null) {
+    return document.body;
+  }
+  if (typeof configured === "function") {
+    return configured() ?? document.body;
+  }
+  return configured;
+}
 
 export const MermaidFullscreenButton = ({
   chart,
@@ -49,17 +62,6 @@ export const MermaidFullscreenButton = ({
   const handleToggle = () => {
     setIsFullscreen(!isFullscreen);
   };
-
-  const portalContainer = (() => {
-    const configured = mermaidOptions?.fullscreenPortalContainer;
-    if (configured === undefined || configured === null) {
-      return document.body;
-    }
-    if (typeof configured === "function") {
-      return configured() ?? document.body;
-    }
-    return configured;
-  })();
 
   // Manage scroll lock and keyboard events
   useEffect(() => {
@@ -147,7 +149,7 @@ export const MermaidFullscreenButton = ({
                 />
               </div>
             </div>,
-            portalContainer
+            resolveMermaidFullscreenPortalContainer(mermaidOptions)
           )
         : null}
     </>

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -26,8 +26,11 @@ export const MermaidFullscreenButton = ({
   const { Maximize2Icon, XIcon } = useIcons();
   const cn = useCn();
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const { isAnimating, controls: controlsConfig } =
-    useContext(StreamdownContext);
+  const {
+    isAnimating,
+    controls: controlsConfig,
+    mermaid: mermaidOptions,
+  } = useContext(StreamdownContext);
   const t = useTranslations();
   const showPanZoomControls = (() => {
     if (typeof controlsConfig === "boolean") {
@@ -46,6 +49,17 @@ export const MermaidFullscreenButton = ({
   const handleToggle = () => {
     setIsFullscreen(!isFullscreen);
   };
+
+  const portalContainer = (() => {
+    const configured = mermaidOptions?.fullscreenPortalContainer;
+    if (configured === undefined || configured === null) {
+      return document.body;
+    }
+    if (typeof configured === "function") {
+      return configured() ?? document.body;
+    }
+    return configured;
+  })();
 
   // Manage scroll lock and keyboard events
   useEffect(() => {
@@ -133,7 +147,7 @@ export const MermaidFullscreenButton = ({
                 />
               </div>
             </div>,
-            document.body
+            portalContainer
           )
         : null}
     </>

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -4,6 +4,7 @@ import { StreamdownContext } from "../../index";
 import { CodeBlockCopyButton } from "../code-block/copy-button";
 import { useIcons } from "../icon-context";
 import type { MermaidConfig } from "../plugin-types";
+import { resolvePortalTarget } from "../portal";
 import { useCn } from "../prefix-context";
 import { lockBodyScroll, unlockBodyScroll } from "../scroll-lock";
 import { useTranslations } from "../translations-context";
@@ -28,8 +29,11 @@ export const MermaidFullscreenButton = ({
   const { Maximize2Icon, XIcon } = useIcons();
   const cn = useCn();
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const { isAnimating, controls: controlsConfig } =
-    useContext(StreamdownContext);
+  const {
+    isAnimating,
+    controls: controlsConfig,
+    portal,
+  } = useContext(StreamdownContext);
   const t = useTranslations();
   const showPanZoomControls = (() => {
     if (typeof controlsConfig === "boolean") {
@@ -179,7 +183,7 @@ export const MermaidFullscreenButton = ({
                 />
               </div>
             </div>,
-            document.body
+            resolvePortalTarget(portal)
           )
         : null}
     </>

--- a/packages/streamdown/lib/portal.ts
+++ b/packages/streamdown/lib/portal.ts
@@ -1,0 +1,8 @@
+import type { PortalTarget } from "../index";
+
+export const resolvePortalTarget = (
+  portal: PortalTarget | undefined
+): HTMLElement => {
+  const container = typeof portal === "function" ? portal() : portal;
+  return container ?? document.body;
+};

--- a/packages/streamdown/lib/table/fullscreen-button.tsx
+++ b/packages/streamdown/lib/table/fullscreen-button.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { StreamdownContext } from "../../index";
 import { useIcons } from "../icon-context";
+import { resolvePortalTarget } from "../portal";
 import { useCn } from "../prefix-context";
 import { lockBodyScroll, unlockBodyScroll } from "../scroll-lock";
 import { useTranslations } from "../translations-context";
@@ -24,7 +25,7 @@ export const TableFullscreenButton = ({
   const { Maximize2Icon, XIcon } = useIcons();
   const cn = useCn();
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, portal } = useContext(StreamdownContext);
   const t = useTranslations();
 
   const handleOpen = () => {
@@ -122,7 +123,7 @@ export const TableFullscreenButton = ({
                 </div>
               </div>
             </div>,
-            document.body
+            resolvePortalTarget(portal)
           )
         : null}
     </>


### PR DESCRIPTION
## Summary

Adds a top-level **`portal`** prop to configure the container used by Streamdown's built-in overlays. This keeps overlays inside a host subtree when using micro-frontends, scoped CSS, prefixed Tailwind utilities, or a custom stacking context.

## Changes

- Add `portal?: HTMLElement | null | (() => HTMLElement | null)` to `Streamdown`.
- Use the configured target for:
  - Mermaid fullscreen
  - Table fullscreen
  - The built-in link safety modal
- Keep `document.body` as the backward-compatible fallback.
- Resolve getter targets only when an overlay opens, preserving SSR safety.
- Recompute the memoized context when `portal` changes.
- Document usage and add a patch changeset.

A custom `linkSafety.renderModal` remains host-controlled and therefore controls its own placement.

## Testing

- `pnpm build:packages`
- `pnpm build --filter website`
- `pnpm test` — 1,144 tests passed
- `pnpm check`
- Focused portal and overlay tests — 53 tests passed

Fixes #499