### PR TITLE
fix(mermaid): add data-streamdown, aria-modal, and correct role to fullscreen overlay

### DIFF
--- a/.changeset/fix-mermaid-fullscreen-a11y.md
+++ b/.changeset/fix-mermaid-fullscreen-a11y.md
@@ -1,0 +1,7 @@
+---
+"streamdown": patch
+---
+
+fix(mermaid): add data-streamdown, aria-modal, and correct role to fullscreen overlay
+
+The Mermaid fullscreen overlay was missing the `data-streamdown="mermaid-fullscreen"` attribute and using `role="button"` instead of `role="dialog"`, and was missing `aria-modal="true"`. This matches the table fullscreen overlay pattern and enables stable CSS targeting and correct accessibility semantics.

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -93,19 +93,21 @@ export const MermaidFullscreenButton = ({
 
       {isFullscreen
         ? createPortal(
-            // biome-ignore lint/a11y/useSemanticElements: "div is used as a backdrop overlay, not a button"
+            // biome-ignore lint/a11y/noNoninteractiveElementInteractions: "dialog overlay needs click-to-dismiss"
             <div
+              aria-label={t.viewFullscreen}
+              aria-modal="true"
               className={cn(
                 "fixed inset-0 z-50 flex items-center justify-center bg-background/95 backdrop-blur-sm"
               )}
+              data-streamdown="mermaid-fullscreen"
               onClick={handleToggle}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
                   handleToggle();
                 }
               }}
-              role="button"
-              tabIndex={0}
+              role="dialog"
             >
               <button
                 className={cn(


### PR DESCRIPTION
- Add `data-streamdown="mermaid-fullscreen"` for stable CSS targeting
- Change `role="button"` to `role="dialog"` (correct semantics for a modal overlay)
- Add `aria-modal="true"` for screen readers
- Add `aria-label` for accessible name
- Remove `tabIndex={0}` (not needed on dialog element)
- Update biome-ignore comment to match table fullscreen pattern

Closes #506