### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/apps/test/app/static/page.tsx
+++ b/apps/test/app/static/page.tsx
@@ -46,7 +46,7 @@ This is ~~strikethrough~~ text.
 
 [This is a link](https://example.com)
 
-![Alt text for image](https://via.placeholder.com/300x200)
+![Alt text for image](https://placehold.co/300x200)
 
 ## Code
 


### PR DESCRIPTION
`apps/test/app/static/page.tsx` references `via.placeholder.com/*`. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Any example that references it renders a broken-image icon (and any code that depends on a 200 from it silently breaks).

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo "connection refused / DNS gone"
```

#### What this PR changes

Fixes the Markdown image link inside the streamdown static-rendering test page so the `Images` section renders an actual image when the Streamdown docs/demo are served.

#### Replacement details

Docs-test-only change. `placehold.co/300x200` uses the same `/<W>x<H>` path shape and returns a 200 PNG.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** a dependency of this PR — the diff uses the dependency-free canonical replacement (`placehold.co`, which accepts the same path shape as `via.placeholder.com`). If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.
