### PR TITLE
fix(streamdown): correct CSS bracket syntax in code-block bg classes

### DIFF
--- a/packages/streamdown/lib/code-block/body.tsx
+++ b/packages/streamdown/lib/code-block/body.tsx
@@ -94,8 +94,8 @@ export const CodeBlockBody = memo(
         <pre
           className={cn(
             className,
-            "bg-[var(--sdm-bg,inherit]",
-            "dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit)]"
+            "bg-[var(--sdm-bg,inherit)]",
+            "dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit))]"
           )}
           style={preStyle}
         >


### PR DESCRIPTION
## Summary
Fix CSS bracket syntax errors in `code-block/body.tsx` where Tailwind classes for background color were missing closing brackets, causing invalid class names to be generated.

- `bg-[var(--sdm-bg,inherit]` → `bg-[var(--sdm-bg,inherit)]`
- `dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit)]` → `dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit))]`

## Test plan
- [x] Verify dark mode background fallback works correctly when Shiki does not provide `--shiki-dark-bg`
- [x] Verify light mode background still works (backed by inline CSS variables)