### PR TITLE
fix(remend): recognize LaTeX paren and bracket math in emphasis completion

### DIFF
--- a/.changeset/latex-math-emphasis.md
+++ b/.changeset/latex-math-emphasis.md
@@ -1,0 +1,5 @@
+---
+"remend": patch
+---
+
+Treat LaTeX paren and bracket math as protected math contexts during emphasis completion.

--- a/packages/remend/__tests__/katex.test.ts
+++ b/packages/remend/__tests__/katex.test.ts
@@ -286,3 +286,49 @@ describe("math blocks with asterisks", () => {
     expect(remend(text)).toBe("Start *italic with $$x^{*}$$*");
   });
 });
+
+describe("LaTeX delimited math with emphasis markers", () => {
+  it("should not complete underscores within paren-style inline math", () => {
+    const text = String.raw`\(P(x_{t+1})\)
+
+plain trailing text.`;
+
+    expect(remend(text)).toBe(text);
+  });
+
+  it("should not complete underscores within bracket-style display math", () => {
+    const text = String.raw`\[
+P(x_{t+1} | x_t)
+\]`;
+
+    expect(remend(text)).toBe(text);
+  });
+
+  it("should not complete asterisks within paren-style inline math", () => {
+    const text = String.raw`\(w^{*}\)
+
+plain trailing text.`;
+
+    expect(remend(text)).toBe(text);
+  });
+
+  it("should complete bold after LaTeX inline math without leaking subscripts", () => {
+    const text = [
+      String.raw`> Given tokens \(x_1, ..., x_t\), maximize \(P(x_{t+1} | x_1, ..., x_t)\)`,
+      "",
+      "**2. Instruction Tuning (SFT)**",
+      "- Dataset size is much smaller than pre-training",
+    ].join("\n");
+    const partial = text.slice(0, text.indexOf("(SFT)") + "(SFT".length);
+
+    expect(remend(partial)).toBe(`${partial}**`);
+  });
+
+  it("should complete ordinary underscore emphasis outside LaTeX math", () => {
+    const text = String.raw`Inline math \(x_1\) and _ordinary italic`;
+
+    expect(remend(text)).toBe(
+      String.raw`Inline math \(x_1\) and _ordinary italic_`
+    );
+  });
+});

--- a/packages/remend/src/emphasis-handlers.ts
+++ b/packages/remend/src/emphasis-handlers.ts
@@ -21,6 +21,9 @@ import {
   isWordChar,
 } from "./utils";
 
+const hasMathDelimiters = (text: string): boolean =>
+  text.includes("$") || text.includes("\\(") || text.includes("\\[");
+
 // Helper function to check if an asterisk should be skipped
 const shouldSkipAsterisk = (
   text: string,
@@ -33,9 +36,8 @@ const shouldSkipAsterisk = (
     return true;
   }
 
-  // Skip if within math block (only check if text has dollar signs)
-  const hasMathBlocks = text.includes("$");
-  if (hasMathBlocks && isWithinMathBlock(text, index)) {
+  // Skip if within math block
+  if (hasMathDelimiters(text) && isWithinMathBlock(text, index)) {
     return true;
   }
 
@@ -129,9 +131,8 @@ const shouldSkipUnderscore = (
     return true;
   }
 
-  // Skip if within math block (only check if text has dollar signs)
-  const hasMathBlocks = text.includes("$");
-  if (hasMathBlocks && isWithinMathBlock(text, index)) {
+  // Skip if within math block
+  if (hasMathDelimiters(text) && isWithinMathBlock(text, index)) {
     return true;
   }
 

--- a/packages/remend/src/utils.ts
+++ b/packages/remend/src/utils.ts
@@ -75,11 +75,51 @@ export const findMatchingClosingBracket = (
   return -1; // No matching bracket found
 };
 
-// Check if a position is within a math block (between $ or $$)
+type MathContext =
+  | "none"
+  | "inlineDollar"
+  | "blockDollar"
+  | "inlineLatex"
+  | "blockLatex";
+
+const isLatexMathContext = (context: MathContext): boolean =>
+  context === "inlineLatex" || context === "blockLatex";
+
+const getLatexMathContext = (
+  context: MathContext,
+  nextChar: string
+): MathContext | null => {
+  if (nextChar === "[" && context === "none") {
+    return "blockLatex";
+  }
+  if (nextChar === "]" && context === "blockLatex") {
+    return "none";
+  }
+  if (nextChar === "(" && context === "none") {
+    return "inlineLatex";
+  }
+  if (nextChar === ")" && context === "inlineLatex") {
+    return "none";
+  }
+  return null;
+};
+
+const getDollarMathContext = (
+  context: MathContext,
+  isBlockDelimiter: boolean
+): MathContext => {
+  if (isBlockDelimiter) {
+    return context === "blockDollar" ? "none" : "blockDollar";
+  }
+  if (context === "blockDollar") {
+    return context;
+  }
+  return context === "inlineDollar" ? "none" : "inlineDollar";
+};
+
+// Check if a position is within a math block (between $, $$, \(, or \[)
 export const isWithinMathBlock = (text: string, position: number): boolean => {
-  // Count dollar signs before this position
-  let inInlineMath = false;
-  let inBlockMath = false;
+  let mathContext: MathContext = "none";
 
   for (let i = 0; i < text.length && i < position; i += 1) {
     // Skip escaped dollar signs
@@ -88,20 +128,25 @@ export const isWithinMathBlock = (text: string, position: number): boolean => {
       continue;
     }
 
-    if (text[i] === "$") {
-      // Check for block math ($$)
-      if (text[i + 1] === "$") {
-        inBlockMath = !inBlockMath;
+    if (text[i] === "\\") {
+      const nextContext = getLatexMathContext(mathContext, text[i + 1]);
+      if (nextContext !== null) {
+        mathContext = nextContext;
+        i += 1;
+        continue;
+      }
+    }
+
+    if (text[i] === "$" && !isLatexMathContext(mathContext)) {
+      const isBlockDelimiter = text[i + 1] === "$";
+      mathContext = getDollarMathContext(mathContext, isBlockDelimiter);
+      if (isBlockDelimiter) {
         i += 1; // Skip the second $
-        inInlineMath = false; // Block math takes precedence
-      } else if (!inBlockMath) {
-        // Only toggle inline math if not in block math
-        inInlineMath = !inInlineMath;
       }
     }
   }
 
-  return inInlineMath || inBlockMath;
+  return mathContext !== "none";
 };
 
 // Helper to check if position is before closing paren on same line


### PR DESCRIPTION
## Summary

- Treat LaTeX paren-style math (`\(...\)`) and bracket-style math (`\[...\]`) as math contexts in `remend`
- Ignore `_` and `*` inside those math contexts during emphasis completion
- Add regression coverage for LaTeX math subscripts, asterisks, and bold completion after math

Closes #522

## Test plan

- [x] `pnpm --filter remend test`
- [x] `pnpm --filter remend build`
- [x] `pnpm exec ultracite check packages/remend/src/utils.ts packages/remend/src/emphasis-handlers.ts packages/remend/__tests__/katex.test.ts`

## Changeset

- [x] Added a patch changeset for `remend`
