### PR TITLE
feat(table): configure `csvSeparator` through controls

### DIFF
--- a/.changeset/ten-pandas-swim.md
+++ b/.changeset/ten-pandas-swim.md
@@ -1,0 +1,8 @@
+---
+"streamdown": minor
+---
+
+- Add `csvSeparator` option for CSV export (`"," | ";" | "\t" | "auto"`).
+- Update `tableDataToCSV` to use configurable separator instead of hardcoded comma.
+- Add `"auto"` mode using locale-based decimal detection via `Intl.NumberFormat`.
+- Improve CSV escaping to respect selected separator for proper Excel compatibility.

--- a/.changeset/ten-pandas-swim.md
+++ b/.changeset/ten-pandas-swim.md
@@ -1,0 +1,7 @@
+---
+"streamdown": minor
+---
+
+- Add `controls.table.csvSeparator` (`"," | ";" | "\t" | "auto"`) for table copy and download CSV
+- Reuse `tableDataToCSV` separator handling, including locale-aware `"auto"` mode
+- Improve CSV escaping to respect the selected separator for Excel compatibility

--- a/.changeset/ten-pandas-swim.md
+++ b/.changeset/ten-pandas-swim.md
@@ -2,7 +2,6 @@
 "streamdown": minor
 ---
 
-- Add `csvSeparator` option for CSV export (`"," | ";" | "\t" | "auto"`).
-- Update `tableDataToCSV` to use configurable separator instead of hardcoded comma.
-- Add `"auto"` mode using locale-based decimal detection via `Intl.NumberFormat`.
-- Improve CSV escaping to respect selected separator for proper Excel compatibility.
+- Add `controls.table.csvSeparator` (`"," | ";" | "\t" | "auto"`) for table copy and download CSV
+- Reuse `tableDataToCSV` separator handling, including locale-aware `"auto"` mode
+- Improve CSV escaping to respect the selected separator for Excel compatibility

--- a/apps/website/content/docs/components.mdx
+++ b/apps/website/content/docs/components.mdx
@@ -224,6 +224,14 @@ import { TableDownloadButton } from "streamdown";
 <TableDownloadButton format="csv" />
 ```
 
+You can control the CSV delimiter used by the table actions with the optional `csvSeparator` prop. Supported values are `","`, `";"`, `"\t"`, and `"auto"` (locale-aware selection):
+
+```tsx title="app/page.tsx"
+<TableCopyDropdown csvSeparator="auto" />
+<TableDownloadDropdown csvSeparator=";" />
+<TableDownloadButton format="csv" csvSeparator="\t" />
+```
+
 ### Lower-level utilities
 
 For fully custom implementations, use the extraction and conversion utilities directly:
@@ -231,6 +239,7 @@ For fully custom implementations, use the extraction and conversion utilities di
 ```tsx title="app/page.tsx"
 import {
   extractTableDataFromElement,
+  type CSVSeparator,
   tableDataToCSV,
   tableDataToTSV,
   tableDataToMarkdown,
@@ -240,10 +249,12 @@ import {
 const data = extractTableDataFromElement(tableElement);
 
 // Convert to various formats
-const csv = tableDataToCSV(data);
+const csv = tableDataToCSV(data, "auto");
 const tsv = tableDataToTSV(data);
 const markdown = tableDataToMarkdown(data);
 ```
+
+The `tableDataToCSV` helper accepts an optional `CSVSeparator` argument (`"," | ";" | "\t" | "auto"`) so you can choose the delimiter explicitly or let `"auto"` pick a locale-friendly separator.
 
 ## Custom HTML Tags
 

--- a/apps/website/content/docs/components.mdx
+++ b/apps/website/content/docs/components.mdx
@@ -224,6 +224,14 @@ import { TableDownloadButton } from "streamdown";
 <TableDownloadButton format="csv" />
 ```
 
+You can control the CSV delimiter for table copy and download with `controls.table.csvSeparator`. Supported values are `","`, `";"`, `"\t"`, and `"auto"` (locale-aware selection). The default is `","`.
+
+```tsx title="app/page.tsx"
+<Streamdown controls={{ table: { csvSeparator: "auto" } }}>
+  {markdown}
+</Streamdown>
+```
+
 ### Lower-level utilities
 
 For fully custom implementations, use the extraction and conversion utilities directly:
@@ -231,6 +239,7 @@ For fully custom implementations, use the extraction and conversion utilities di
 ```tsx title="app/page.tsx"
 import {
   extractTableDataFromElement,
+  type CSVSeparator,
   tableDataToCSV,
   tableDataToTSV,
   tableDataToMarkdown,
@@ -240,10 +249,12 @@ import {
 const data = extractTableDataFromElement(tableElement);
 
 // Convert to various formats
-const csv = tableDataToCSV(data);
+const csv = tableDataToCSV(data, "auto");
 const tsv = tableDataToTSV(data);
 const markdown = tableDataToMarkdown(data);
 ```
+
+The `tableDataToCSV` helper accepts an optional `CSVSeparator` argument (`"," | ";" | "\t" | "auto"`) so you can choose the delimiter explicitly or let `"auto"` pick a locale-friendly separator.
 
 ## Custom HTML Tags
 

--- a/apps/website/content/docs/components.mdx
+++ b/apps/website/content/docs/components.mdx
@@ -224,12 +224,12 @@ import { TableDownloadButton } from "streamdown";
 <TableDownloadButton format="csv" />
 ```
 
-You can control the CSV delimiter used by the table actions with the optional `csvSeparator` prop. Supported values are `","`, `";"`, `"\t"`, and `"auto"` (locale-aware selection):
+You can control the CSV delimiter for table copy and download with `controls.table.csvSeparator`. Supported values are `","`, `";"`, `"\t"`, and `"auto"` (locale-aware selection). The default is `","`.
 
 ```tsx title="app/page.tsx"
-<TableCopyDropdown csvSeparator="auto" />
-<TableDownloadDropdown csvSeparator=";" />
-<TableDownloadButton format="csv" csvSeparator="\t" />
+<Streamdown controls={{ table: { csvSeparator: "auto" } }}>
+  {markdown}
+</Streamdown>
 ```
 
 ### Lower-level utilities

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -346,6 +346,7 @@ The `controls` prop can be configured granularly:
       copy: true, // Show table copy button
       download: true, // Show table download button
       fullscreen: true, // Show table fullscreen button
+      csvSeparator: ",", // "," | ";" | "\t" | "auto"
     },
     code: {
       copy: true, // Show code copy button

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -311,6 +311,7 @@ The `controls` prop can be configured granularly:
       copy: true, // Show table copy button
       download: true, // Show table download button
       fullscreen: true, // Show table fullscreen button
+      csvSeparator: ",", // "," | ";" | "\t" | "auto"
     },
     code: {
       copy: true, // Show code copy button

--- a/apps/website/content/docs/gfm.mdx
+++ b/apps/website/content/docs/gfm.mdx
@@ -84,6 +84,16 @@ You can disable the table download button:
 </Streamdown>
 ```
 
+### Custom CSV Separator
+
+By default, copied and downloaded CSV uses a comma. Set `controls.table.csvSeparator` to `";"`, `"\t"`, or `"auto"` (picks `;` in comma-decimal locales):
+
+```tsx
+<Streamdown controls={{ table: { csvSeparator: "auto" } }}>
+  {markdown}
+</Streamdown>
+```
+
 ## Task Lists
 
 Create interactive todo lists:

--- a/apps/website/content/docs/gfm.mdx
+++ b/apps/website/content/docs/gfm.mdx
@@ -118,6 +118,16 @@ You can disable the table download button:
 </Streamdown>
 ```
 
+### Custom CSV Separator
+
+By default, copied and downloaded CSV uses a comma. Set `controls.table.csvSeparator` to `";"`, `"\t"`, or `"auto"` (picks `;` in comma-decimal locales):
+
+```tsx
+<Streamdown controls={{ table: { csvSeparator: "auto" } }}>
+  {markdown}
+</Streamdown>
+```
+
 ## Task Lists
 
 Create interactive todo lists:

--- a/apps/website/content/docs/interactivity.mdx
+++ b/apps/website/content/docs/interactivity.mdx
@@ -41,6 +41,14 @@ Tables include a copy button that opens a dropdown menu allowing users to copy t
 
 Tables can be downloaded in two formats: CSV and Markdown. The download button will be shown for tables in the top-right corner on hover. The download button opens a dropdown menu with options to download as CSV or Markdown, making it easy to export table data for use in spreadsheets or documentation.
 
+CSV copy and download use a comma by default. Customize the delimiter with `controls.table.csvSeparator` (`","`, `";"`, `"\t"`, or `"auto"`):
+
+```tsx
+<Streamdown controls={{ table: { csvSeparator: ";" } }}>
+  {markdown}
+</Streamdown>
+```
+
 ## Code Block Buttons
 
 ### Copy Code

--- a/packages/streamdown/__tests__/table-dropdowns.test.tsx
+++ b/packages/streamdown/__tests__/table-dropdowns.test.tsx
@@ -79,7 +79,7 @@ describe("TableDownloadDropdown", () => {
 
     expect(save).toHaveBeenCalledWith(
       "table.csv",
-      expect.any(String),
+      "Name,Age\nAlice,30",
       "text/csv"
     );
     expect(onDownload).toHaveBeenCalledWith("csv");
@@ -112,6 +112,57 @@ describe("TableDownloadDropdown", () => {
       "text/markdown"
     );
     expect(onDownload).toHaveBeenCalledWith("markdown");
+  });
+
+  it("should use csvSeparator from controls for CSV downloads", async () => {
+    const { save } = await import("../lib/utils");
+    const onDownload = vi.fn();
+
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: { table: { csvSeparator: ";" } },
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableDownloadDropdown onDownload={onDownload} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const toggleBtn = container.querySelector('button[title="Download table"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(toggleBtn!);
+
+    const csvBtn = container.querySelector(
+      'button[title="Download table as CSV"]'
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(csvBtn!);
+
+    expect(save).toHaveBeenCalledWith(
+      "table.csv",
+      "Name;Age\nAlice;30",
+      "text/csv"
+    );
+    expect(onDownload).toHaveBeenCalledWith("csv");
   });
 
   it("should download when inside table-fullscreen", async () => {
@@ -263,6 +314,53 @@ describe("TableDownloadButton with format='markdown'", () => {
     expect(onDownload).toHaveBeenCalled();
   });
 
+  it("should use csvSeparator from controls for CSV button downloads", async () => {
+    const { save } = await import("../lib/utils");
+    const onDownload = vi.fn();
+
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: { table: { csvSeparator: ";" } },
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableDownloadButton format="csv" onDownload={onDownload} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const btn = container.querySelector(
+      'button[title="Download table as CSV"]'
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(btn!);
+
+    expect(save).toHaveBeenCalledWith(
+      "table.csv",
+      "Name;Age\nAlice;30",
+      "text/csv"
+    );
+    expect(onDownload).toHaveBeenCalled();
+  });
+
   it("should handle default format (fallback to csv)", () => {
     const { container } = renderInTableWrapper(
       <TableDownloadButton format={"unknown" as any} />
@@ -406,6 +504,20 @@ describe("TableCopyDropdown", () => {
 
   it("should copy as CSV when csv button clicked", async () => {
     const onCopy = vi.fn();
+    const OriginalBlob = globalThis.Blob;
+    const blobPartsByType: Record<string, BlobPart[]> = {};
+    const blobSpy = vi.spyOn(globalThis, "Blob").mockImplementation(function (
+      this: Blob,
+      parts?: BlobPart[],
+      opts?: BlobPropertyBag
+    ) {
+      const type = opts?.type ?? "";
+      if (parts) {
+        blobPartsByType[type] = parts;
+      }
+      return new OriginalBlob(parts, opts);
+    } as unknown as typeof Blob);
+
     const { container } = renderInTableWrapper(
       <TableCopyDropdown onCopy={onCopy} />
     );
@@ -421,7 +533,76 @@ describe("TableCopyDropdown", () => {
       fireEvent.click(csvBtn!);
     });
 
+    expect(navigator.clipboard.write).toHaveBeenCalled();
+    expect(String(blobPartsByType["text/plain"]?.[0] ?? "")).toBe(
+      "Name,Age\nAlice,30"
+    );
     expect(onCopy).toHaveBeenCalledWith("csv");
+    blobSpy.mockRestore();
+  });
+
+  it("should copy CSV when csvSeparator is configured", async () => {
+    const onCopy = vi.fn();
+    const OriginalBlob = globalThis.Blob;
+    const blobPartsByType: Record<string, BlobPart[]> = {};
+    const blobSpy = vi.spyOn(globalThis, "Blob").mockImplementation(function (
+      this: Blob,
+      parts?: BlobPart[],
+      opts?: BlobPropertyBag
+    ) {
+      const type = opts?.type ?? "";
+      if (parts) {
+        blobPartsByType[type] = parts;
+      }
+      return new OriginalBlob(parts, opts);
+    } as unknown as typeof Blob);
+
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: { table: { csvSeparator: ";" } },
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableCopyDropdown onCopy={onCopy} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const toggleBtn = container.querySelector('button[title="Copy table"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(toggleBtn!);
+
+    const csvBtn = container.querySelector('button[title="Copy table as CSV"]');
+    // biome-ignore lint/suspicious/useAwait: act needs async to flush clipboard promises
+    await act(async () => {
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      fireEvent.click(csvBtn!);
+    });
+
+    expect(navigator.clipboard.write).toHaveBeenCalled();
+    expect(String(blobPartsByType["text/plain"]?.[0] ?? "")).toBe(
+      "Name;Age\nAlice;30"
+    );
+    expect(onCopy).toHaveBeenCalledWith("csv");
+    blobSpy.mockRestore();
   });
 
   it("should copy as TSV when tsv button clicked", async () => {

--- a/packages/streamdown/__tests__/table-dropdowns.test.tsx
+++ b/packages/streamdown/__tests__/table-dropdowns.test.tsx
@@ -114,6 +114,57 @@ describe("TableDownloadDropdown", () => {
     expect(onDownload).toHaveBeenCalledWith("markdown");
   });
 
+  it("should use csvSeparator from controls for CSV downloads", async () => {
+    const { save } = await import("../lib/utils");
+    const onDownload = vi.fn();
+
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: { table: { csvSeparator: ";" } },
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableDownloadDropdown onDownload={onDownload} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const toggleBtn = container.querySelector('button[title="Download table"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(toggleBtn!);
+
+    const csvBtn = container.querySelector(
+      'button[title="Download table as CSV"]'
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(csvBtn!);
+
+    expect(save).toHaveBeenCalledWith(
+      "table.csv",
+      "Name;Age\nAlice;30",
+      "text/csv"
+    );
+    expect(onDownload).toHaveBeenCalledWith("csv");
+  });
+
   it("should call onError when save throws", async () => {
     const { save } = await import("../lib/utils");
     (save as any).mockImplementation(() => {
@@ -207,6 +258,53 @@ describe("TableDownloadButton with format='markdown'", () => {
     // biome-ignore lint/style/noNonNullAssertion: test assertion
     fireEvent.click(btn!);
 
+    expect(onDownload).toHaveBeenCalled();
+  });
+
+  it("should use csvSeparator from controls for CSV button downloads", async () => {
+    const { save } = await import("../lib/utils");
+    const onDownload = vi.fn();
+
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: { table: { csvSeparator: ";" } },
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableDownloadButton format="csv" onDownload={onDownload} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const btn = container.querySelector(
+      'button[title="Download table as CSV"]'
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(btn!);
+
+    expect(save).toHaveBeenCalledWith(
+      "table.csv",
+      "Name;Age\nAlice;30",
+      "text/csv"
+    );
     expect(onDownload).toHaveBeenCalled();
   });
 
@@ -328,6 +426,52 @@ describe("TableCopyDropdown", () => {
       fireEvent.click(csvBtn!);
     });
 
+    expect(onCopy).toHaveBeenCalledWith("csv");
+  });
+
+  it("should copy CSV when csvSeparator is configured", async () => {
+    const onCopy = vi.fn();
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: { table: { csvSeparator: ";" } },
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableCopyDropdown onCopy={onCopy} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const toggleBtn = container.querySelector('button[title="Copy table"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(toggleBtn!);
+
+    const csvBtn = container.querySelector('button[title="Copy table as CSV"]');
+    // biome-ignore lint/suspicious/useAwait: act needs async to flush clipboard promises
+    await act(async () => {
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      fireEvent.click(csvBtn!);
+    });
+
+    expect(navigator.clipboard.write).toHaveBeenCalled();
     expect(onCopy).toHaveBeenCalledWith("csv");
   });
 

--- a/packages/streamdown/__tests__/table-utils.test.ts
+++ b/packages/streamdown/__tests__/table-utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   escapeMarkdownTableCell,
   extractTableDataFromElement,
@@ -147,6 +147,59 @@ describe("Table Utils", () => {
       expect(result).toBe('Name,Location\nJohn,"New York, USA"');
     });
 
+    it("should escape quotes and separator together", () => {
+      const data: TableData = {
+        headers: ["Message"],
+        rows: [['Hello, "World"']],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe('Message\n"Hello, ""World"""');
+    });
+
+    it("should support semicolon separators", () => {
+      const data: TableData = {
+        headers: ["Name", "Location"],
+        rows: [["Aradhya", "New York; USA"]],
+      };
+
+      const result = tableDataToCSV(data, ";");
+
+      expect(result).toBe('Name;Location\nAradhya;"New York; USA"');
+    });
+
+    it("should use semicolon separator in auto mode for comma-decimal locales", () => {
+      const numberFormatSpy = vi.spyOn(Intl, "NumberFormat").mockImplementation(
+        () =>
+          ({
+            format: () => "1,1",
+          }) as Intl.NumberFormat
+      );
+
+      const data: TableData = {
+        headers: ["Name", "City"],
+        rows: [["John", "Paris; France"]],
+      };
+
+      const result = tableDataToCSV(data, "auto");
+
+      expect(result).toBe('Name;City\nJohn;"Paris; France"');
+
+      numberFormatSpy.mockRestore();
+    });
+
+    it("should escape carriage returns", () => {
+      const data: TableData = {
+        headers: ["Text"],
+        rows: [["line1\rline2"]],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe('Text\n"line1\rline2"');
+    });
+
     it("should escape quotes in values", () => {
       const data: TableData = {
         headers: ["Quote"],
@@ -169,6 +222,28 @@ describe("Table Utils", () => {
       expect(result).toBe('Text\n"Line 1\nLine 2"');
     });
 
+    it("should support tab separators", () => {
+      const data: TableData = {
+        headers: ["Name", "Note"],
+        rows: [["Mike", "A\tB"]],
+      };
+
+      const result = tableDataToCSV(data, "\t");
+
+      expect(result).toBe('Name\tNote\nMike\t"A\tB"');
+    });
+
+    it("should not use separators as its single column", () => {
+      const data: TableData = {
+        headers: ["Name"],
+        rows: [["John"]],
+      };
+
+      const result = tableDataToCSV(data, ";");
+
+      expect(result).toBe("Name\nJohn");
+    });
+
     it("should handle empty headers", () => {
       const data: TableData = {
         headers: [],
@@ -189,6 +264,28 @@ describe("Table Utils", () => {
       const result = tableDataToCSV(data);
 
       expect(result).toBe("Header1,Header2");
+    });
+
+    it("should handle empty values", () => {
+      const data: TableData = {
+        headers: ["Name", "Age"],
+        rows: [["", ""]],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe("Name,Age\n,");
+    });
+
+    it("should handle empty tables", () => {
+      const data: TableData = {
+        headers: [],
+        rows: [],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe("");
     });
   });
 

--- a/packages/streamdown/__tests__/table-utils.test.ts
+++ b/packages/streamdown/__tests__/table-utils.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   escapeMarkdownTableCell,
   extractTableDataFromElement,
+  getTableCsvSeparator,
   type TableData,
   tableDataToCSV,
   tableDataToMarkdown,
@@ -205,6 +206,59 @@ describe("Table Utils", () => {
       expect(result).toBe('Name,Location\nJohn,"New York, USA"');
     });
 
+    it("should escape quotes and separator together", () => {
+      const data: TableData = {
+        headers: ["Message"],
+        rows: [['Hello, "World"']],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe('Message\n"Hello, ""World"""');
+    });
+
+    it("should support semicolon separators", () => {
+      const data: TableData = {
+        headers: ["Name", "Location"],
+        rows: [["Aradhya", "New York; USA"]],
+      };
+
+      const result = tableDataToCSV(data, ";");
+
+      expect(result).toBe('Name;Location\nAradhya;"New York; USA"');
+    });
+
+    it("should use semicolon separator in auto mode for comma-decimal locales", () => {
+      const numberFormatSpy = vi.spyOn(Intl, "NumberFormat").mockImplementation(
+        () =>
+          ({
+            format: () => "1,1",
+          }) as Intl.NumberFormat
+      );
+
+      const data: TableData = {
+        headers: ["Name", "City"],
+        rows: [["John", "Paris; France"]],
+      };
+
+      const result = tableDataToCSV(data, "auto");
+
+      expect(result).toBe('Name;City\nJohn;"Paris; France"');
+
+      numberFormatSpy.mockRestore();
+    });
+
+    it("should escape carriage returns", () => {
+      const data: TableData = {
+        headers: ["Text"],
+        rows: [["line1\rline2"]],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe('Text\n"line1\rline2"');
+    });
+
     it("should escape quotes in values", () => {
       const data: TableData = {
         headers: ["Quote"],
@@ -227,6 +281,28 @@ describe("Table Utils", () => {
       expect(result).toBe('Text\n"Line 1\nLine 2"');
     });
 
+    it("should support tab separators", () => {
+      const data: TableData = {
+        headers: ["Name", "Note"],
+        rows: [["Mike", "A\tB"]],
+      };
+
+      const result = tableDataToCSV(data, "\t");
+
+      expect(result).toBe('Name\tNote\nMike\t"A\tB"');
+    });
+
+    it("should not use separators as its single column", () => {
+      const data: TableData = {
+        headers: ["Name"],
+        rows: [["John"]],
+      };
+
+      const result = tableDataToCSV(data, ";");
+
+      expect(result).toBe("Name\nJohn");
+    });
+
     it("should handle empty headers", () => {
       const data: TableData = {
         headers: [],
@@ -247,6 +323,55 @@ describe("Table Utils", () => {
       const result = tableDataToCSV(data);
 
       expect(result).toBe("Header1,Header2");
+    });
+
+    it("should handle empty values", () => {
+      const data: TableData = {
+        headers: ["Name", "Age"],
+        rows: [["", ""]],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe("Name,Age\n,");
+    });
+
+    it("should handle empty tables", () => {
+      const data: TableData = {
+        headers: [],
+        rows: [],
+      };
+
+      const result = tableDataToCSV(data);
+
+      expect(result).toBe("");
+    });
+  });
+
+  describe("getTableCsvSeparator", () => {
+    it("returns comma when controls is a boolean", () => {
+      expect(getTableCsvSeparator(true)).toBe(",");
+      expect(getTableCsvSeparator(false)).toBe(",");
+    });
+
+    it("returns comma when table is missing or a boolean", () => {
+      expect(getTableCsvSeparator({})).toBe(",");
+      expect(getTableCsvSeparator({ table: true })).toBe(",");
+      expect(getTableCsvSeparator({ table: false })).toBe(",");
+    });
+
+    it("returns comma when csvSeparator is not set", () => {
+      expect(getTableCsvSeparator({ table: {} })).toBe(",");
+    });
+
+    it("returns the configured separator", () => {
+      expect(getTableCsvSeparator({ table: { csvSeparator: ";" } })).toBe(";");
+      expect(getTableCsvSeparator({ table: { csvSeparator: "\t" } })).toBe(
+        "\t"
+      );
+      expect(getTableCsvSeparator({ table: { csvSeparator: "auto" } })).toBe(
+        "auto"
+      );
     });
   });
 

--- a/packages/streamdown/__tests__/table-utils.test.ts
+++ b/packages/streamdown/__tests__/table-utils.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   escapeMarkdownTableCell,
   extractTableDataFromElement,
+  getTableCsvSeparator,
   type TableData,
   tableDataToCSV,
   tableDataToMarkdown,
@@ -286,6 +287,33 @@ describe("Table Utils", () => {
       const result = tableDataToCSV(data);
 
       expect(result).toBe("");
+    });
+  });
+
+  describe("getTableCsvSeparator", () => {
+    it("returns comma when controls is a boolean", () => {
+      expect(getTableCsvSeparator(true)).toBe(",");
+      expect(getTableCsvSeparator(false)).toBe(",");
+    });
+
+    it("returns comma when table is missing or a boolean", () => {
+      expect(getTableCsvSeparator({})).toBe(",");
+      expect(getTableCsvSeparator({ table: true })).toBe(",");
+      expect(getTableCsvSeparator({ table: false })).toBe(",");
+    });
+
+    it("returns comma when csvSeparator is not set", () => {
+      expect(getTableCsvSeparator({ table: {} })).toBe(",");
+    });
+
+    it("returns the configured separator", () => {
+      expect(getTableCsvSeparator({ table: { csvSeparator: ";" } })).toBe(";");
+      expect(getTableCsvSeparator({ table: { csvSeparator: "\t" } })).toBe(
+        "\t"
+      );
+      expect(getTableCsvSeparator({ table: { csvSeparator: "auto" } })).toBe(
+        "auto"
+      );
     });
   });
 

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -94,6 +94,7 @@ export {
   type TableDownloadDropdownProps,
 } from "./lib/table/download-dropdown";
 export {
+  type CSVSeparator,
   escapeMarkdownTableCell,
   extractTableDataFromElement,
   type TableData,

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -44,6 +44,7 @@ import { preprocessLiteralTagContent } from "./lib/preprocess-literal-tag-conten
 import { rehypeBlockDirection } from "./lib/rehype/block-direction";
 import { rehypeLiteralTagContent } from "./lib/rehype/literal-tag-content";
 import { remarkCodeMeta } from "./lib/remark/code-meta";
+import type { CSVSeparator } from "./lib/table/utils";
 import {
   defaultTranslations,
   type StreamdownTranslations,
@@ -97,6 +98,7 @@ export {
   type TableDownloadDropdownProps,
 } from "./lib/table/download-dropdown";
 export {
+  type CSVSeparator,
   escapeMarkdownTableCell,
   extractTableDataFromElement,
   type TableData,
@@ -142,6 +144,7 @@ export type ControlsConfig =
         | boolean
         | {
             copy?: boolean;
+            csvSeparator?: CSVSeparator;
             download?: boolean;
             fullscreen?: boolean;
           };

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -39,6 +39,7 @@ import { preprocessCustomTags } from "./lib/preprocess-custom-tags";
 import { preprocessLiteralTagContent } from "./lib/preprocess-literal-tag-content";
 import { rehypeLiteralTagContent } from "./lib/rehype/literal-tag-content";
 import { remarkCodeMeta } from "./lib/remark/code-meta";
+import type { CSVSeparator } from "./lib/table/utils";
 import {
   defaultTranslations,
   type StreamdownTranslations,
@@ -140,6 +141,7 @@ export type ControlsConfig =
         | boolean
         | {
             copy?: boolean;
+            csvSeparator?: CSVSeparator;
             download?: boolean;
             fullscreen?: boolean;
           };

--- a/packages/streamdown/lib/table/copy-dropdown.tsx
+++ b/packages/streamdown/lib/table/copy-dropdown.tsx
@@ -4,6 +4,7 @@ import { useIcons } from "../icon-context";
 import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
 import {
+  type CSVSeparator,
   extractTableDataFromElement,
   tableDataToCSV,
   tableDataToMarkdown,
@@ -13,6 +14,7 @@ import {
 export interface TableCopyDropdownProps {
   children?: React.ReactNode;
   className?: string;
+  csvSeparator?: CSVSeparator;
   onCopy?: (format: "csv" | "tsv" | "md") => void;
   onError?: (error: Error) => void;
   timeout?: number;
@@ -21,6 +23,7 @@ export interface TableCopyDropdownProps {
 export const TableCopyDropdown = ({
   children,
   className,
+  csvSeparator,
   onCopy,
   onError,
   timeout = 2000,
@@ -53,14 +56,15 @@ export const TableCopyDropdown = ({
       }
 
       const tableData = extractTableDataFromElement(tableElement);
+      let content = "";
 
-      const formatters = {
-        csv: tableDataToCSV,
-        tsv: tableDataToTSV,
-        md: tableDataToMarkdown,
-      };
-      const formatter = formatters[format] || tableDataToMarkdown;
-      const content = formatter(tableData);
+      if (format === "csv") {
+        content = tableDataToCSV(tableData, csvSeparator);
+      } else if (format === "tsv") {
+        content = tableDataToTSV(tableData);
+      } else {
+        content = tableDataToMarkdown(tableData);
+      }
 
       const clipboardItemData = new ClipboardItem({
         "text/plain": new Blob([content], { type: "text/plain" }),

--- a/packages/streamdown/lib/table/copy-dropdown.tsx
+++ b/packages/streamdown/lib/table/copy-dropdown.tsx
@@ -5,6 +5,7 @@ import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
 import {
   extractTableDataFromElement,
+  getTableCsvSeparator,
   tableDataToCSV,
   tableDataToMarkdown,
   tableDataToTSV,
@@ -30,8 +31,9 @@ export const TableCopyDropdown = ({
   const [isCopied, setIsCopied] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef(0);
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, controls } = useContext(StreamdownContext);
   const t = useTranslations();
+  const csvSeparator = getTableCsvSeparator(controls);
 
   const copyTableData = async (format: "csv" | "tsv" | "md") => {
     if (typeof window === "undefined" || !navigator?.clipboard?.write) {
@@ -53,14 +55,15 @@ export const TableCopyDropdown = ({
       }
 
       const tableData = extractTableDataFromElement(tableElement);
+      let content = "";
 
-      const formatters = {
-        csv: tableDataToCSV,
-        tsv: tableDataToTSV,
-        md: tableDataToMarkdown,
-      };
-      const formatter = formatters[format] || tableDataToMarkdown;
-      const content = formatter(tableData);
+      if (format === "csv") {
+        content = tableDataToCSV(tableData, csvSeparator);
+      } else if (format === "tsv") {
+        content = tableDataToTSV(tableData);
+      } else {
+        content = tableDataToMarkdown(tableData);
+      }
 
       const clipboardItemData = new ClipboardItem({
         "text/plain": new Blob([content], { type: "text/plain" }),

--- a/packages/streamdown/lib/table/copy-dropdown.tsx
+++ b/packages/streamdown/lib/table/copy-dropdown.tsx
@@ -4,8 +4,8 @@ import { useIcons } from "../icon-context";
 import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
 import {
-  type CSVSeparator,
   extractTableDataFromElement,
+  getTableCsvSeparator,
   tableDataToCSV,
   tableDataToMarkdown,
   tableDataToTSV,
@@ -14,7 +14,6 @@ import {
 export interface TableCopyDropdownProps {
   children?: React.ReactNode;
   className?: string;
-  csvSeparator?: CSVSeparator;
   onCopy?: (format: "csv" | "tsv" | "md") => void;
   onError?: (error: Error) => void;
   timeout?: number;
@@ -23,7 +22,6 @@ export interface TableCopyDropdownProps {
 export const TableCopyDropdown = ({
   children,
   className,
-  csvSeparator,
   onCopy,
   onError,
   timeout = 2000,
@@ -33,8 +31,9 @@ export const TableCopyDropdown = ({
   const [isCopied, setIsCopied] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef(0);
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, controls } = useContext(StreamdownContext);
   const t = useTranslations();
+  const csvSeparator = getTableCsvSeparator(controls);
 
   const copyTableData = async (format: "csv" | "tsv" | "md") => {
     if (typeof window === "undefined" || !navigator?.clipboard?.write) {

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -5,6 +5,7 @@ import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
 import { save } from "../utils";
 import {
+  type CSVSeparator,
   extractTableDataFromElement,
   tableDataToCSV,
   tableDataToMarkdown,
@@ -13,6 +14,7 @@ import {
 export interface TableDownloadButtonProps {
   children?: React.ReactNode;
   className?: string;
+  csvSeparator?: CSVSeparator;
   filename?: string;
   format?: "csv" | "markdown";
   onDownload?: () => void;
@@ -22,6 +24,7 @@ export interface TableDownloadButtonProps {
 export const TableDownloadButton = ({
   children,
   className,
+  csvSeparator,
   onDownload,
   onError,
   format = "csv",
@@ -53,7 +56,7 @@ export const TableDownloadButton = ({
 
       switch (format) {
         case "csv":
-          content = tableDataToCSV(tableData);
+          content = tableDataToCSV(tableData, csvSeparator);
           mimeType = "text/csv";
           extension = "csv";
           break;
@@ -63,7 +66,7 @@ export const TableDownloadButton = ({
           extension = "md";
           break;
         default:
-          content = tableDataToCSV(tableData);
+          content = tableDataToCSV(tableData, csvSeparator);
           mimeType = "text/csv";
           extension = "csv";
       }
@@ -97,6 +100,7 @@ export const TableDownloadButton = ({
 export interface TableDownloadDropdownProps {
   children?: React.ReactNode;
   className?: string;
+  csvSeparator?: CSVSeparator;
   onDownload?: (format: "csv" | "markdown") => void;
   onError?: (error: Error) => void;
 }
@@ -104,6 +108,7 @@ export interface TableDownloadDropdownProps {
 export const TableDownloadDropdown = ({
   children,
   className,
+  csvSeparator,
   onDownload,
   onError,
 }: TableDownloadDropdownProps) => {
@@ -131,7 +136,7 @@ export const TableDownloadDropdown = ({
       const tableData = extractTableDataFromElement(tableElement);
       const content =
         format === "csv"
-          ? tableDataToCSV(tableData)
+          ? tableDataToCSV(tableData, csvSeparator)
           : tableDataToMarkdown(tableData);
       const extension = format === "csv" ? "csv" : "md";
       const filename = `table.${extension}`;

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -5,8 +5,8 @@ import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
 import { save } from "../utils";
 import {
-  type CSVSeparator,
   extractTableDataFromElement,
+  getTableCsvSeparator,
   tableDataToCSV,
   tableDataToMarkdown,
 } from "./utils";
@@ -14,7 +14,6 @@ import {
 export interface TableDownloadButtonProps {
   children?: React.ReactNode;
   className?: string;
-  csvSeparator?: CSVSeparator;
   filename?: string;
   format?: "csv" | "markdown";
   onDownload?: () => void;
@@ -24,17 +23,16 @@ export interface TableDownloadButtonProps {
 export const TableDownloadButton = ({
   children,
   className,
-  csvSeparator,
   onDownload,
   onError,
   format = "csv",
   filename,
 }: TableDownloadButtonProps) => {
   const cn = useCn();
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, controls } = useContext(StreamdownContext);
   const t = useTranslations();
   const icons = useIcons();
-
+  const csvSeparator = getTableCsvSeparator(controls);
   const downloadTableData = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
       // Find the closest table element
@@ -100,7 +98,6 @@ export const TableDownloadButton = ({
 export interface TableDownloadDropdownProps {
   children?: React.ReactNode;
   className?: string;
-  csvSeparator?: CSVSeparator;
   onDownload?: (format: "csv" | "markdown") => void;
   onError?: (error: Error) => void;
 }
@@ -108,16 +105,16 @@ export interface TableDownloadDropdownProps {
 export const TableDownloadDropdown = ({
   children,
   className,
-  csvSeparator,
   onDownload,
   onError,
 }: TableDownloadDropdownProps) => {
   const cn = useCn();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, controls } = useContext(StreamdownContext);
   const t = useTranslations();
   const icons = useIcons();
+  const csvSeparator = getTableCsvSeparator(controls);
 
   const downloadTableData = (format: "csv" | "markdown") => {
     try {

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "../translations-context";
 import { save } from "../utils";
 import {
   extractTableDataFromElement,
+  getTableCsvSeparator,
   tableDataToCSV,
   tableDataToMarkdown,
 } from "./utils";
@@ -28,10 +29,10 @@ export const TableDownloadButton = ({
   filename,
 }: TableDownloadButtonProps) => {
   const cn = useCn();
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, controls } = useContext(StreamdownContext);
   const t = useTranslations();
   const icons = useIcons();
-
+  const csvSeparator = getTableCsvSeparator(controls);
   const downloadTableData = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
       // Find the closest table element
@@ -53,7 +54,7 @@ export const TableDownloadButton = ({
 
       switch (format) {
         case "csv":
-          content = tableDataToCSV(tableData);
+          content = tableDataToCSV(tableData, csvSeparator);
           mimeType = "text/csv";
           extension = "csv";
           break;
@@ -63,7 +64,7 @@ export const TableDownloadButton = ({
           extension = "md";
           break;
         default:
-          content = tableDataToCSV(tableData);
+          content = tableDataToCSV(tableData, csvSeparator);
           mimeType = "text/csv";
           extension = "csv";
       }
@@ -110,9 +111,10 @@ export const TableDownloadDropdown = ({
   const cn = useCn();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const { isAnimating } = useContext(StreamdownContext);
+  const { isAnimating, controls } = useContext(StreamdownContext);
   const t = useTranslations();
   const icons = useIcons();
+  const csvSeparator = getTableCsvSeparator(controls);
 
   const downloadTableData = (format: "csv" | "markdown") => {
     try {
@@ -131,7 +133,7 @@ export const TableDownloadDropdown = ({
       const tableData = extractTableDataFromElement(tableElement);
       const content =
         format === "csv"
-          ? tableDataToCSV(tableData)
+          ? tableDataToCSV(tableData, csvSeparator)
           : tableDataToMarkdown(tableData);
       const extension = format === "csv" ? "csv" : "md";
       const filename = `table.${extension}`;

--- a/packages/streamdown/lib/table/utils.ts
+++ b/packages/streamdown/lib/table/utils.ts
@@ -29,35 +29,47 @@ export const extractTableDataFromElement = (
   return { headers, rows };
 };
 
-export const tableDataToCSV = (data: TableData): string => {
+export type CSVSeparator = "," | ";" | "\t" | "auto";
+
+export const tableDataToCSV = (
+  data: TableData,
+  separator: CSVSeparator = ","
+): string => {
+  let resolvedSeparator: string;
+
+  if (separator === "auto") {
+    const formatter = Intl.NumberFormat().format(1.1);
+
+    if (formatter.includes(",")) {
+      resolvedSeparator = ";";
+    } else {
+      resolvedSeparator = ",";
+    }
+  } else {
+    resolvedSeparator = separator;
+  }
   const { headers, rows } = data;
 
   const escapeCSV = (value: string): string => {
-    // OPTIMIZATION: Fast path for values that don't need escaping
-    // Check characters directly to avoid multiple string scans
     let needsEscaping = false;
-    let hasQuote = false;
 
     for (const char of value) {
-      if (char === '"') {
+      if (
+        char === resolvedSeparator ||
+        char === '"' ||
+        char === "\n" ||
+        char === "\r"
+      ) {
         needsEscaping = true;
-        hasQuote = true;
         break;
-      }
-      if (char === "," || char === "\n") {
-        needsEscaping = true;
       }
     }
 
     if (!needsEscaping) {
       return value;
     }
-
-    // If the value contains comma, quote, or newline, wrap in quotes and escape internal quotes
-    if (hasQuote) {
-      return `"${value.replace(/"/g, '""')}"`;
-    }
-    return `"${value}"`;
+    // Escape internal quotes by doubling them
+    return `"${value.replace(/"/g, '""')}"`;
   };
 
   // Pre-allocate array with known size
@@ -67,13 +79,13 @@ export const tableDataToCSV = (data: TableData): string => {
 
   // Add headers
   if (headers.length > 0) {
-    csvRows[rowIndex] = headers.map(escapeCSV).join(",");
+    csvRows[rowIndex] = headers.map(escapeCSV).join(resolvedSeparator);
     rowIndex += 1;
   }
 
   // Add data rows
   for (const row of rows) {
-    csvRows[rowIndex] = row.map(escapeCSV).join(",");
+    csvRows[rowIndex] = row.map(escapeCSV).join(resolvedSeparator);
     rowIndex += 1;
   }
 

--- a/packages/streamdown/lib/table/utils.ts
+++ b/packages/streamdown/lib/table/utils.ts
@@ -31,6 +31,21 @@ export const extractTableDataFromElement = (
 
 export type CSVSeparator = "," | ";" | "\t" | "auto";
 
+export const getTableCsvSeparator = (
+  config: boolean | { table?: boolean | { csvSeparator?: CSVSeparator } }
+): CSVSeparator => {
+  if (typeof config !== "object") {
+    return ",";
+  }
+
+  const tableConfig = config.table;
+  if (typeof tableConfig !== "object") {
+    return ",";
+  }
+
+  return tableConfig.csvSeparator ?? ",";
+};
+
 export const tableDataToCSV = (
   data: TableData,
   separator: CSVSeparator = ","

--- a/packages/streamdown/lib/table/utils.ts
+++ b/packages/streamdown/lib/table/utils.ts
@@ -47,35 +47,62 @@ export const extractTableDataFromElement = (
   return { headers, rows };
 };
 
-export const tableDataToCSV = (data: TableData): string => {
+export type CSVSeparator = "," | ";" | "\t" | "auto";
+
+export const getTableCsvSeparator = (
+  config: boolean | { table?: boolean | { csvSeparator?: CSVSeparator } }
+): CSVSeparator => {
+  if (typeof config !== "object") {
+    return ",";
+  }
+
+  const tableConfig = config.table;
+  if (typeof tableConfig !== "object") {
+    return ",";
+  }
+
+  return tableConfig.csvSeparator ?? ",";
+};
+
+export const tableDataToCSV = (
+  data: TableData,
+  separator: CSVSeparator = ","
+): string => {
+  let resolvedSeparator: string;
+
+  if (separator === "auto") {
+    const formatter = Intl.NumberFormat().format(1.1);
+
+    if (formatter.includes(",")) {
+      resolvedSeparator = ";";
+    } else {
+      resolvedSeparator = ",";
+    }
+  } else {
+    resolvedSeparator = separator;
+  }
   const { headers, rows } = data;
 
   const escapeCSV = (value: string): string => {
-    // OPTIMIZATION: Fast path for values that don't need escaping
-    // Check characters directly to avoid multiple string scans
     let needsEscaping = false;
-    let hasQuote = false;
 
     for (const char of value) {
-      if (char === '"') {
+      if (
+        char === resolvedSeparator ||
+        char === '"' ||
+        char === "\n" ||
+        char === "\r"
+      ) {
         needsEscaping = true;
-        hasQuote = true;
         break;
-      }
-      if (char === "," || char === "\n") {
-        needsEscaping = true;
       }
     }
 
     if (!needsEscaping) {
       return value;
     }
-
-    // If the value contains comma, quote, or newline, wrap in quotes and escape internal quotes
-    if (hasQuote) {
-      return `"${value.replace(/"/g, '""')}"`;
-    }
-    return `"${value}"`;
+    // Escape internal quotes by doubling them
+    return `"${value.replace(/"/g, '""')}"`;
   };
 
   // Pre-allocate array with known size
@@ -85,13 +112,13 @@ export const tableDataToCSV = (data: TableData): string => {
 
   // Add headers
   if (headers.length > 0) {
-    csvRows[rowIndex] = headers.map(escapeCSV).join(",");
+    csvRows[rowIndex] = headers.map(escapeCSV).join(resolvedSeparator);
     rowIndex += 1;
   }
 
   // Add data rows
   for (const row of rows) {
-    csvRows[rowIndex] = row.map(escapeCSV).join(",");
+    csvRows[rowIndex] = row.map(escapeCSV).join(resolvedSeparator);
     rowIndex += 1;
   }
 

--- a/skills/streamdown/references/api.md
+++ b/skills/streamdown/references/api.md
@@ -147,9 +147,19 @@ interface RemendOptions {
 ## ControlsConfig
 
 ```tsx
+type CSVSeparator = "," | ";" | "\t" | "auto";
+
 type ControlsConfig = boolean | {
-  table?: boolean;
-  code?: boolean;
+  table?: boolean | {
+    copy?: boolean;
+    download?: boolean;
+    fullscreen?: boolean;
+    csvSeparator?: CSVSeparator; // default: ","
+  };
+  code?: boolean | {
+    copy?: boolean;
+    download?: boolean;
+  };
   mermaid?: boolean | {
     download?: boolean;
     copy?: boolean;

--- a/skills/streamdown/references/features.md
+++ b/skills/streamdown/references/features.md
@@ -118,7 +118,11 @@ Auto-added buttons for images, tables, code, and Mermaid.
 ```tsx
 <Streamdown
   controls={{
-    table: true,
+    table: {
+      copy: true,
+      download: true,
+      csvSeparator: "auto", // "," | ";" | "\t" | "auto"
+    },
     code: false, // No copy/download on code blocks
     mermaid: {
       download: true,


### PR DESCRIPTION
## Description

This PR is a follow-up to #524, which added configurable CSV separators and locale-aware `"auto"` detection.

The CSV conversion work from #524 is already implemented and remains unchanged. This PR fixes where `csvSeparator` is exposed and configured.

The initial implementation added `csvSeparator` as a prop on `TableCopyDropdown`, `TableDownloadDropdown`, and `TableDownloadButton`. After discussion in #559, we decided that `csvSeparator` should be configured through the existing `controls.table` configuration instead.

The new API is:

```tsx
<Streamdown
  controls={{
    table: {
      download: true,
      csvSeparator: "auto",
    },
  }}
>
  {markdown}
</Streamdown>
```

This provides a single configuration for both CSV copy and CSV download actions and allows the built-in table controls to consume the setting through `StreamdownContext`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature which would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Performance improvement
* [x] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues using #issue-number -->

Fixes #521
Closes #521
Related to #521

Related PRs:

* Follow-up to [[#524](https://github.com/vercel/streamdown/pull/524)](https://github.com/vercel/streamdown/pull/524)
* Configuration approach discussed in [[#559](https://github.com/vercel/streamdown/pull/559)](https://github.com/vercel/streamdown/pull/559)

## Changes Made

* Added `csvSeparator?: CSVSeparator` to `controls.table`.
* Updated `TableCopyDropdown` to read `csvSeparator` from `StreamdownContext`.
* Updated `TableDownloadDropdown` and `TableDownloadButton` to read `csvSeparator` from `StreamdownContext`.
* Removed the component-level `csvSeparator` props.
* Added shared configuration resolution for `controls.table.csvSeparator`.
* Preserved the existing `tableDataToCSV` implementation and separator handling from #524.
* Preserved support for `","`, `";"`, `"\t"`, and `"auto"`.
* Preserved comma-separated output as the default when `csvSeparator` is not configured.
* Added test coverage for configuring the separator through `controls`.
* Updated documentation to use `controls.table.csvSeparator`.

## API

CSV separator configuration is now controlled through `controls.table`:

```tsx
<Streamdown
  controls={{
    table: {
      csvSeparator: "auto",
    },
  }}
>
  {markdown}
</Streamdown>
```

Supported values:

* `","` — comma
* `";"` — semicolon
* `"\t"` — tab
* `"auto"` — locale-aware separator selection

The default remains `","`.

The lower-level `tableDataToCSV` utility continues to accept an explicit separator:

```ts
tableDataToCSV(data, "auto");
```

This remains available for custom extraction and conversion implementations.

## Testing

<!-- Describe the tests you ran to verify your changes -->

* [x] All existing tests pass
* [x] Added new tests for the changes
* [x] Manually tested the changes

### Test Coverage

Added test coverage to verify that `csvSeparator` is correctly read from `controls.table` for both CSV copy and CSV download.

Also manually verified the feature using the following Streamdown configuration:

```tsx
import { Streamdown } from "streamdown";
import "streamdown/styles.css";

const App = () => {
  const markdown = `
| Feature | Status | Notes |
|:--------|:------:|------:|
| Markdown | Supported | CommonMark compliant |
| GFM | Supported | Tables, tasks, strikethrough |
| Code highlighting | Supported | 200+ languages via Shiki |
| Math | Supported | KaTeX rendering |
| Mermaid | Supported | Flowcharts, sequences, and more |
| CJK | Supported | Chinese, Japanese, Korean |
`;

  return (
    <div className="App">
      <div className="mx-auto mt-5 w-200">
        <Streamdown
          controls={{
            code: {
              download: true,
            },
            mermaid: {
              download: true,
            },
            table: {
              download: true,
              csvSeparator: "auto",
            },
          }}
        >
          {markdown}
        </Streamdown>
      </div>
    </div>
  );
};

export default App;
```

Verified that the table CSV actions use the configured separator when `csvSeparator` is set through `controls.table`.

### Additional Test Coverage

* Semicolon separator through `controls.table.csvSeparator`
* `"auto"` separator through `controls.table.csvSeparator`
* CSV copy uses the configured separator
* CSV download uses the configured separator
* Default comma behavior remains unchanged
* Existing utility tests continue to cover separator handling and CSV escaping

## Screenshots/Demos

<!-- If applicable, add screenshots or demos -->

## Checklist

<!-- Mark completed items with an "x" -->

* [x] My code follows the project's code style
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings or errors
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have created a changeset (`pnpm changeset`)

## Changeset

<!-- Confirm you've created a changeset for this PR -->

* [x] I have created a changeset for this PR

## Additional Notes

The CSV conversion implementation from #524 is intentionally unchanged. This PR only changes how Streamdown users configure and consume the existing functionality.

The component-level API:

```tsx
<TableCopyDropdown csvSeparator="auto" />
<TableDownloadDropdown csvSeparator=";" />
<TableDownloadButton format="csv" csvSeparator="\t" />
```

has been replaced with the table-level configuration:

```tsx
<Streamdown
  controls={{
    table: {
      csvSeparator: "auto",
    },
  }}
>
  {markdown}
</Streamdown>
```

This keeps `csvSeparator` as a single table-level setting shared by both copy and download actions while retaining the existing lower-level `tableDataToCSV(data, separator)` API.