### PR TITLE
fix: avoid app token in changeset verification

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -21,17 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Generate GitHub App Token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.STREAMDOWN_APP_ID }}
-          private-key: ${{ secrets.STREAMDOWN_APP_PRIVATE_KEY }}
-      
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token }}
       
       - uses: actions/setup-node@v4
         with:
@@ -50,5 +42,4 @@ jobs:
         run: |
           node index.js
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CHANGED_FILES: ${{ steps.changeset-files.outputs.changed-files }}


### PR DESCRIPTION
Summary:
- removed the GitHub App token generation from the changeset verification workflow
- let `actions/checkout` use the default read-only token so fork PRs do not need repository secrets
- removed the now-unused `GITHUB_TOKEN` env from the verifier step

Verification:
- `node --check .github/workflows/actions/verify-changesets/index.js`
- direct `verifyChangesets()` smoke test with a valid patch changeset
- `git diff --check -- .github/workflows/verify-changesets.yml .github/workflows/actions/verify-changesets/index.js`
- `actionlint .github/workflows/verify-changesets.yml`

This keeps the workflow on `pull_request` instead of moving to `pull_request_target`, so fork PR validation remains unprivileged. It addresses the fork-secret failure path from #520; I left the separate missing-changeset guidance behavior alone because that likely needs a maintainer preference on whether to comment, warn, or enforce.

Implemented with Codex assistance, with the workflow change kept focused and manually reviewed.
