### PR TITLE
fix: serialize Mermaid SVG downloads

### DIFF
--- a/.changeset/clean-walls-agree.md
+++ b/.changeset/clean-walls-agree.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Serialize Mermaid SVGs before download so HTML-style tags render as valid SVG markup.

--- a/packages/streamdown/__tests__/mermaid-download.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-download.test.tsx
@@ -5,6 +5,8 @@ import { MermaidDownloadDropdown } from "../lib/mermaid/download-button";
 import { PluginContext } from "../lib/plugin-context";
 import type { DiagramPlugin, MermaidInstance } from "../lib/plugin-types";
 
+const RAW_BR_TAG_REGEX = /<br(?:\s[^/>]*)?>/;
+
 vi.mock("../lib/utils", async () => {
   const actual = await vi.importActual("../lib/utils");
   return {
@@ -13,11 +15,15 @@ vi.mock("../lib/utils", async () => {
   };
 });
 
-vi.mock("../lib/mermaid/utils", () => ({
-  svgToPngBlob: vi
-    .fn()
-    .mockResolvedValue(new Blob(["png"], { type: "image/png" })),
-}));
+vi.mock("../lib/mermaid/utils", async () => {
+  const actual = await vi.importActual("../lib/mermaid/utils");
+  return {
+    ...actual,
+    svgToPngBlob: vi
+      .fn()
+      .mockResolvedValue(new Blob(["png"], { type: "image/png" })),
+  };
+});
 
 describe("MermaidDownloadDropdown", () => {
   const defaultContext = {
@@ -131,10 +137,38 @@ describe("MermaidDownloadDropdown", () => {
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith(
         "diagram.svg",
-        "<svg><text>Chart</text></svg>",
+        expect.stringContaining("<text>Chart</text>"),
         "image/svg+xml"
       );
       expect(onDownload).toHaveBeenCalledWith("svg");
+    });
+  });
+
+  it("should serialize SVG markup before downloading", async () => {
+    const { save } = await import("../lib/utils");
+    const plugin = createMockPlugin({
+      svg: '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>Line 1<br>Line 2</div></foreignObject></svg>',
+    });
+    const { container } = renderWithContext(
+      { chart: "graph TD; A-->B" },
+      plugin
+    );
+
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(container.querySelector("button")!);
+
+    const svgButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent === "SVG"
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(svgButton!);
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        "diagram.svg",
+        expect.not.stringMatching(RAW_BR_TAG_REGEX),
+        "image/svg+xml"
+      );
     });
   });
 
@@ -161,7 +195,7 @@ describe("MermaidDownloadDropdown", () => {
 
     await waitFor(() => {
       expect(svgToPngBlob).toHaveBeenCalledWith(
-        "<svg><text>Chart</text></svg>"
+        expect.stringContaining("<text>Chart</text>")
       );
       expect(save).toHaveBeenCalledWith(
         "diagram.png",

--- a/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
@@ -21,11 +21,15 @@ vi.mock("../lib/utils", async () => {
   };
 });
 
-vi.mock("../lib/mermaid/utils", () => ({
-  svgToPngBlob: vi
-    .fn()
-    .mockResolvedValue(new Blob(["png"], { type: "image/png" })),
-}));
+vi.mock("../lib/mermaid/utils", async () => {
+  const actual = await vi.importActual("../lib/mermaid/utils");
+  return {
+    ...actual,
+    svgToPngBlob: vi
+      .fn()
+      .mockResolvedValue(new Blob(["png"], { type: "image/png" })),
+  };
+});
 
 import { MermaidFullscreenButton } from "../lib/mermaid/fullscreen-button";
 // Import after mocks

--- a/packages/streamdown/__tests__/mermaid-utils.test.ts
+++ b/packages/streamdown/__tests__/mermaid-utils.test.ts
@@ -1,7 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { svgToPngBlob } from "../lib/mermaid/utils";
+import { serializeSvgForDownload, svgToPngBlob } from "../lib/mermaid/utils";
 
 const BASE64_SVG_DATA_URL_REGEX = /^data:image\/svg\+xml;base64,/;
+const RAW_BR_TAG_REGEX = /<br(?:\s[^/>]*)?>/;
+
+describe("serializeSvgForDownload", () => {
+  it("serializes HTML-style SVG markup as XML", () => {
+    const svgString =
+      '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>Line 1<br>Line 2</div></foreignObject></svg>';
+
+    const serialized = serializeSvgForDownload(svgString);
+
+    expect(serialized).toContain("<svg");
+    expect(serialized).toContain("Line 1");
+    expect(serialized).toContain("Line 2");
+    expect(serialized).not.toMatch(RAW_BR_TAG_REGEX);
+  });
+
+  it("returns the original string when no SVG element exists", () => {
+    const html = "<div>Not an SVG</div>";
+
+    expect(serializeSvgForDownload(html)).toBe(html);
+  });
+});
 
 describe("svgToPngBlob", () => {
   let mockCanvas: any;

--- a/packages/streamdown/__tests__/mermaid.test.tsx
+++ b/packages/streamdown/__tests__/mermaid.test.tsx
@@ -570,7 +570,7 @@ describe("Mermaid", () => {
       await waitFor(() => {
         expect(saveMock).toHaveBeenCalledWith(
           "diagram.svg",
-          "<svg>Test SVG</svg>",
+          expect.stringContaining("Test SVG"),
           "image/svg+xml"
         );
       });

--- a/packages/streamdown/lib/mermaid/download-button.tsx
+++ b/packages/streamdown/lib/mermaid/download-button.tsx
@@ -6,7 +6,7 @@ import type { MermaidConfig } from "../plugin-types";
 import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
 import { save } from "../utils";
-import { svgToPngBlob } from "./utils";
+import { serializeSvgForDownload, svgToPngBlob } from "./utils";
 
 interface MermaidDownloadDropdownProps {
   chart: string;
@@ -69,17 +69,19 @@ export const MermaidDownloadDropdown = ({
         return;
       }
 
+      const serializedSvg = serializeSvgForDownload(svg);
+
       if (format === "svg") {
         const filename = "diagram.svg";
         const mimeType = "image/svg+xml";
-        save(filename, svg, mimeType);
+        save(filename, serializedSvg, mimeType);
         setIsOpen(false);
         onDownload?.(format);
         return;
       }
 
       if (format === "png") {
-        const blob = await svgToPngBlob(svg);
+        const blob = await svgToPngBlob(serializedSvg);
         save("diagram.png", blob, "image/png");
         onDownload?.(format);
         setIsOpen(false);

--- a/packages/streamdown/lib/mermaid/utils.ts
+++ b/packages/streamdown/lib/mermaid/utils.ts
@@ -1,4 +1,26 @@
 /**
+ * Mermaid render output may be HTML-serialized. Serialize the SVG node as XML
+ * before downloading so embedded HTML like <br> becomes valid SVG markup.
+ */
+export const serializeSvgForDownload = (svgString: string): string => {
+  if (
+    typeof DOMParser === "undefined" ||
+    typeof XMLSerializer === "undefined"
+  ) {
+    return svgString;
+  }
+
+  const doc = new DOMParser().parseFromString(svgString, "text/html");
+  const svg = doc.querySelector("svg");
+
+  if (!svg) {
+    return svgString;
+  }
+
+  return new XMLSerializer().serializeToString(svg);
+};
+
+/**
  * Convert SVG string to PNG blob for export
  */
 export const svgToPngBlob = (


### PR DESCRIPTION
## Description

Fixes Mermaid SVG/PNG downloads when Mermaid returns HTML-serialized SVG markup containing tags like `<br>`.

The download path now parses the rendered markup as HTML, selects the SVG node, and serializes it with `XMLSerializer` before saving the SVG or converting it to PNG. That keeps the browser-normalized `<br>` from being written back out as invalid SVG markup.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #516

## Changes Made

- Added a Mermaid SVG download serializer helper.
- Reused the serialized SVG for both SVG download and PNG conversion.
- Added regression coverage for HTML-style `<br>` markup in Mermaid SVG output.
- Added a patch changeset for `streamdown`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [ ] Manually tested the changes

### Test Coverage

- `corepack pnpm build:packages`
- `corepack pnpm --dir packages/streamdown exec vitest run __tests__/mermaid-utils.test.ts __tests__/mermaid-download.test.tsx`
- `corepack pnpm check packages/streamdown/lib/mermaid/download-button.tsx packages/streamdown/lib/mermaid/utils.ts packages/streamdown/__tests__/mermaid-download.test.tsx packages/streamdown/__tests__/mermaid-utils.test.ts packages/streamdown/__tests__/mermaid.test.tsx .changeset/clean-walls-agree.md`
- `corepack pnpm --dir packages/streamdown test`
- `git diff --check`

## Screenshots/Demos

Not applicable.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] I have created a changeset for these changes

## Additional Notes

Implemented with Codex assistance, with the final patch reviewed and kept focused.
