### PR TITLE
fix(link-modal): render link safety modal in a portal to hydration error

### DIFF
--- a/.changeset/fix-link-modal-portal.md
+++ b/.changeset/fix-link-modal-portal.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Render the link safety modal through a portal to `document.body` so it is no longer nested inside the paragraph's `<p>` element. This fixes the React hydration error "In HTML, `<div>` cannot be a descendant of `<p>`" that occurred when a link with link safety enabled appeared inside a paragraph.

--- a/packages/streamdown/__tests__/link-modal-keyboard.test.tsx
+++ b/packages/streamdown/__tests__/link-modal-keyboard.test.tsx
@@ -9,7 +9,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
 
   it("should call onClose when Escape key is pressed on backdrop", () => {
     const onClose = vi.fn();
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={onClose}
@@ -18,7 +18,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
       />
     );
 
-    const backdrop = container.querySelector(
+    const backdrop = document.querySelector(
       '[data-streamdown="link-safety-modal"]'
     );
     expect(backdrop).toBeTruthy();
@@ -30,7 +30,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
 
   it("should not call onClose for non-Escape keys on backdrop", () => {
     const onClose = vi.fn();
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={onClose}
@@ -39,7 +39,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
       />
     );
 
-    const backdrop = container.querySelector(
+    const backdrop = document.querySelector(
       '[data-streamdown="link-safety-modal"]'
     );
     // biome-ignore lint/style/noNonNullAssertion: test assertion
@@ -50,7 +50,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
 
   it("should stop propagation when clicking inner modal content", () => {
     const onClose = vi.fn();
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={onClose}
@@ -60,7 +60,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
     );
 
     // Click the inner content area (role=presentation)
-    const innerContent = container.querySelector('[role="presentation"]');
+    const innerContent = document.querySelector('[role="presentation"]');
     expect(innerContent).toBeTruthy();
     // biome-ignore lint/style/noNonNullAssertion: test assertion
     fireEvent.click(innerContent!);
@@ -71,7 +71,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
 
   it("should stop key propagation on inner content", () => {
     const onClose = vi.fn();
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={onClose}
@@ -80,7 +80,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
       />
     );
 
-    const innerContent = container.querySelector('[role="presentation"]');
+    const innerContent = document.querySelector('[role="presentation"]');
     // biome-ignore lint/style/noNonNullAssertion: test assertion
     fireEvent.keyDown(innerContent!, { key: "Escape" });
 
@@ -89,7 +89,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
   });
 
   it("should return null when not open", () => {
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={false}
         onClose={vi.fn()}
@@ -99,7 +99,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
     );
 
     expect(
-      container.querySelector('[data-streamdown="link-safety-modal"]')
+      document.querySelector('[data-streamdown="link-safety-modal"]')
     ).toBeNull();
   });
 
@@ -133,7 +133,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
   it("should call onConfirm and onClose when Open link is clicked", () => {
     const onClose = vi.fn();
     const onConfirm = vi.fn();
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={onClose}
@@ -142,7 +142,9 @@ describe("LinkSafetyModal keyboard and interaction", () => {
       />
     );
 
-    const buttons = container.querySelectorAll("button");
+    const buttons = document.querySelectorAll(
+      '[data-streamdown="link-safety-modal"] button'
+    );
     const openButton = Array.from(buttons).find((btn) =>
       btn.textContent?.includes("Open link")
     );
@@ -164,7 +166,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
       configurable: true,
     });
 
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={vi.fn()}
@@ -173,7 +175,9 @@ describe("LinkSafetyModal keyboard and interaction", () => {
       />
     );
 
-    const buttons = container.querySelectorAll("button");
+    const buttons = document.querySelectorAll(
+      '[data-streamdown="link-safety-modal"] button'
+    );
     const copyButton = Array.from(buttons).find((btn) =>
       btn.textContent?.includes("Copy link")
     );
@@ -193,7 +197,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
 
   it("should show long URL with scrollable container", () => {
     const longUrl = `https://example.com/${"a".repeat(150)}`;
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={vi.fn()}
@@ -203,7 +207,7 @@ describe("LinkSafetyModal keyboard and interaction", () => {
     );
 
     // URL display should have overflow class for long URLs
-    const urlDisplay = container.querySelector(".break-all");
+    const urlDisplay = document.querySelector(".break-all");
     expect(urlDisplay).toBeTruthy();
     expect(urlDisplay?.className).toContain("max-h-32");
     expect(urlDisplay?.className).toContain("overflow-y-auto");

--- a/packages/streamdown/__tests__/translations.test.tsx
+++ b/packages/streamdown/__tests__/translations.test.tsx
@@ -201,7 +201,7 @@ describe("ImageComponent translations", () => {
 
 describe("LinkSafetyModal translations", () => {
   it("should show default translations in link safety modal", () => {
-    const { container } = render(
+    render(
       <LinkSafetyModal
         isOpen={true}
         onClose={vi.fn()}
@@ -210,12 +210,12 @@ describe("LinkSafetyModal translations", () => {
       />
     );
 
-    expect(container.textContent).toContain("Open external link?");
-    expect(container.textContent).toContain(
+    expect(document.body.textContent).toContain("Open external link?");
+    expect(document.body.textContent).toContain(
       "You're about to visit an external website."
     );
-    expect(container.textContent).toContain("Copy link");
-    expect(container.textContent).toContain("Open link");
+    expect(document.body.textContent).toContain("Copy link");
+    expect(document.body.textContent).toContain("Open link");
   });
 
   it("should use custom translations in link safety modal", () => {
@@ -228,7 +228,7 @@ describe("LinkSafetyModal translations", () => {
       close: "Schließen",
     };
 
-    const { container } = render(
+    render(
       <TranslationsContext.Provider value={customTranslations}>
         <LinkSafetyModal
           isOpen={true}
@@ -239,12 +239,12 @@ describe("LinkSafetyModal translations", () => {
       </TranslationsContext.Provider>
     );
 
-    expect(container.textContent).toContain("Externen Link öffnen?");
-    expect(container.textContent).toContain(
+    expect(document.body.textContent).toContain("Externen Link öffnen?");
+    expect(document.body.textContent).toContain(
       "Sie besuchen eine externe Website."
     );
-    expect(container.textContent).toContain("Link kopieren");
-    expect(container.textContent).toContain("Link öffnen");
+    expect(document.body.textContent).toContain("Link kopieren");
+    expect(document.body.textContent).toContain("Link öffnen");
   });
 });
 

--- a/packages/streamdown/lib/link-modal.tsx
+++ b/packages/streamdown/lib/link-modal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useIcons } from "./icon-context";
 import { useCn } from "./prefix-context";
 import { lockBodyScroll, unlockBodyScroll } from "./scroll-lock";
@@ -55,11 +56,11 @@ export const LinkSafetyModal = ({
     }
   }, [isOpen, onClose]);
 
-  if (!isOpen) {
+  if (!isOpen || typeof document === "undefined") {
     return null;
   }
 
-  return (
+  const modal = (
     // biome-ignore lint/a11y/useSemanticElements: "div is used as a backdrop overlay"
     <div
       className={cn(
@@ -148,4 +149,6 @@ export const LinkSafetyModal = ({
       </div>
     </div>
   );
+
+  return createPortal(modal, document.body);
 };


### PR DESCRIPTION
## Summary

When `linkSafety` is enabled, the link component renders a `<button>` alongside the `LinkSafetyModal`. The modal's root is a `<div>` rendered inline, but markdown links live inside paragraph `<p>` elements — so the modal `<div>` ends up as a descendant of `<p>`.

This produces the React hydration error:

> In HTML, `<div>` cannot be a descendant of `<p>`. This will cause a hydration error.

### Fix

Render the default `LinkSafetyModal` through `createPortal` to `document.body`, so the modal `<div>` is no longer nested inside the paragraph. The inline `<button>` (valid inside `<p>`) stays where it is. The component also guards against SSR (`typeof document === "undefined"`).

## Test plan

- [x] `pnpm --filter streamdown test` — all 982 tests pass
- [x] Updated `link-modal-keyboard`, `link-safety`, and `translations` tests to query the portaled DOM (`document` / `document.body`) instead of the render `container`
- [ ] Manually verify no hydration warning when an external link appears inside a paragraph with link safety enabled

Made with [Cursor](https://cursor.com)