### PR TITLE
fix(code-block): apply block display to line spans when lineNumbers={false}

### DIFF
--- a/packages/streamdown/__tests__/code-block-line-numbers.test.tsx
+++ b/packages/streamdown/__tests__/code-block-line-numbers.test.tsx
@@ -31,6 +31,14 @@ describe("line numbers", () => {
       );
     });
 
+    it("applies block display class to spans when lineNumbers={false}", () => {
+      const { container } = render(
+        <CodeBlockBody language="js" lineNumbers={false} result={baseResult} />
+      );
+      const span = container.querySelector("code span");
+      expect(span?.className).toContain("block");
+    });
+
     it("applies counter CSS classes to <code> when lineNumbers={true}", () => {
       const { container } = render(
         <CodeBlockBody language="js" lineNumbers={true} result={baseResult} />

--- a/packages/streamdown/lib/code-block/body.tsx
+++ b/packages/streamdown/lib/code-block/body.tsx
@@ -11,6 +11,9 @@ type CodeBlockBodyProps = ComponentProps<"div"> & {
   lineNumbers?: boolean;
 };
 
+// Base line class string for all line spans (ensures block display)
+const LINE_CLASSES_BASE = baseCn("block");
+
 // Base line numbers class string (merged without prefix for memoization)
 const LINE_NUMBER_CLASSES_BASE = baseCn(
   "block",
@@ -57,6 +60,8 @@ export const CodeBlockBody = memo(
   }: CodeBlockBodyProps) => {
     const cn = useCn();
 
+    // Prefix the pre-computed base line classes (block display for all spans)
+    const lineClasses = useMemo(() => cn(LINE_CLASSES_BASE), [cn]);
     // Prefix the pre-computed line number classes
     const lineNumberClasses = useMemo(() => cn(LINE_NUMBER_CLASSES_BASE), [cn]);
 
@@ -113,7 +118,7 @@ export const CodeBlockBody = memo(
           >
             {result.tokens.map((row, index) => (
               <span
-                className={lineNumbers ? lineNumberClasses : undefined}
+                className={lineNumbers ? lineNumberClasses : lineClasses}
                 // biome-ignore lint/suspicious/noArrayIndexKey: "This is a stable key."
                 key={index}
               >


### PR DESCRIPTION
## Problem

When `lineNumbers={false}`, code block line spans had no `className` applied, leaving them with the browser default `display: inline`. This caused all code lines to collapse onto the same visual line instead of each appearing on its own line.

## Root Cause

In `body.tsx`, the `className` prop on each line `<span>` was:
```tsx
className={lineNumbers ? lineNumberClasses : undefined}
```

The `LINE_NUMBER_CLASSES_BASE` includes `'block'` as its first class, but when `lineNumbers` is `false`, that class was never applied.

## Fix

- Add a `LINE_CLASSES_BASE = baseCn('block')` constant for the minimal base class all line spans need
- Add a `lineClasses` memo (prefix-aware, like `lineNumberClasses`)
- Change the ternary to `lineNumbers ? lineNumberClasses : lineClasses` so all spans always get `display: block`

## Test

Added a test case to `code-block-line-numbers.test.tsx` that asserts spans have the `block` class when `lineNumbers={false}`.

Fixes #532