### PR TITLE
fix(streamdown): re-render memoized components when node offset changes

### DIFF
--- a/.changeset/fair-balloons-share.md
+++ b/.changeset/fair-balloons-share.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Compare position.start.offset and position.end.offset in sameNodePosition so mid-block markdown updates aren't skipped by React.memo.

--- a/.changeset/fair-balloons-share.md
+++ b/.changeset/fair-balloons-share.md
@@ -2,4 +2,4 @@
 "streamdown": patch
 ---
 
-Compare position.start.offset and position.end.offset in sameNodePosition so mid-block markdown updates aren't skipped by React.memo.
+Fix stale rendering when in-block markdown content changes during streaming updates.

--- a/packages/streamdown/__tests__/components-rerender.test.tsx
+++ b/packages/streamdown/__tests__/components-rerender.test.tsx
@@ -422,6 +422,39 @@ describe("sameNodePosition edge cases", () => {
 
     expect(container.querySelector("ol")).toBeTruthy();
   });
+
+  it("should re-render when only offset changes", () => {
+    const nodeV1 = {
+      position: {
+        start: { line: 1, column: 1, offset: 0 },
+        end: { line: 2, column: 5, offset: 20 },
+      },
+    };
+    const nodeV2 = {
+      position: {
+        start: { line: 1, column: 1, offset: 0 },
+        end: { line: 2, column: 5, offset: 35 },
+      },
+    };
+
+    const { container, rerender } = render(
+      <ReRenderWrapper count={0}>
+        <Ol node={nodeV1 as any}>
+          <li>item</li>
+        </Ol>
+      </ReRenderWrapper>
+    );
+
+    rerender(
+      <ReRenderWrapper count={1}>
+        <Ol node={nodeV2 as any}>
+          <li>item</li>
+        </Ol>
+      </ReRenderWrapper>
+    );
+
+    expect(container.querySelector("ol")).toBeTruthy();
+  });
 });
 
 describe("MemoParagraph block code unwrapping with data-block", () => {

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -42,6 +42,7 @@ const LANGUAGE_REGEX = /language-([^\s]+)/;
 interface MarkdownPoint {
   column?: number;
   line?: number;
+  offset?: number;
 }
 interface MarkdownPosition {
   end?: MarkdownPoint;
@@ -74,8 +75,10 @@ function sameNodePosition(prev?: MarkdownNode, next?: MarkdownNode): boolean {
   return (
     prevStart?.line === nextStart?.line &&
     prevStart?.column === nextStart?.column &&
+    prevStart?.offset === nextStart?.offset &&
     prevEnd?.line === nextEnd?.line &&
-    prevEnd?.column === nextEnd?.column
+    prevEnd?.column === nextEnd?.column &&
+    prevEnd?.offset === nextEnd?.offset
   );
 }
 


### PR DESCRIPTION
## Description

Fixes stale DOM when markdown is updated in the middle of an existing block. Memoized leaf components (`ol`, `ul`, `p`, headings, etc.) use `sameNodePosition` to skip re-renders, but it only compared `line` and `column`. When content changed without updating line/column (only `offset`, e.g. injecting a link mid-line), React kept stale output until Streamdown remounted.

`sameNodePosition` is shared by all memoized markdown components via `sameClassAndNode`, so this fix applies broadly rather than to a single element type.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `offset?: number` to `MarkdownPoint` and compare `position.start.offset` / `position.end.offset` in `sameNodePosition` ([`packages/streamdown/lib/components.tsx`](packages/streamdown/lib/components.tsx))
- Added regression test `"should re-render when only offset changes"` ([`packages/streamdown/__tests__/components-rerender.test.tsx`](packages/streamdown/__tests__/components-rerender.test.tsx))
- Added patch changeset ([`.changeset/fair-balloons-share.md`](.changeset/fair-balloons-share.md))

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

```bash
pnpm exec vitest run __tests__/components-rerender.test.tsx
```

All 18 tests in that file pass.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Additional Notes

No documentation or inline comment changes — this is an internal comparator fix with no API surface change. The new test documents the edge case.
