### PR TITLE
feat: support separate mermaid export config

### DIFF
--- a/.changeset/short-points-marry.md
+++ b/.changeset/short-points-marry.md
@@ -1,0 +1,7 @@
+---
+"streamdown": minor
+---
+
+Add `mermaid.exportConfig` to support separate Mermaid configuration for SVG/PNG downloads.
+
+This allows applications to render diagrams with one theme on screen while exporting with another theme (for example, dark-mode display with light-mode downloads) without custom renderers.

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -187,6 +187,11 @@ The `mermaid` prop accepts an object with the following properties:
       description: "Custom configuration for Mermaid diagrams",
       type: "MermaidConfig",
     },
+    exportConfig: {
+      description:
+        "Optional Mermaid configuration used only for SVG/PNG downloads. Falls back to config when omitted.",
+      type: "MermaidConfig",
+    },
     errorComponent: {
       description:
         "Custom React component for handling Mermaid rendering errors",

--- a/apps/website/content/docs/plugins/mermaid.mdx
+++ b/apps/website/content/docs/plugins/mermaid.mdx
@@ -366,6 +366,22 @@ Customize specific diagram types:
 </Streamdown>
 ```
 
+### Separate export theme
+
+Use `mermaid.exportConfig` when you want downloaded SVG/PNG files to use a different Mermaid theme than on-screen diagrams:
+
+```tsx
+<Streamdown
+  plugins={{ mermaid }}
+  mermaid={{
+    config: { theme: "dark" }, // Display theme
+    exportConfig: { theme: "default" }, // Download theme (SVG/PNG)
+  }}
+>
+  {markdown}
+</Streamdown>
+```
+
 ### Factory Function
 
 For advanced configuration, use `createMermaidPlugin`:

--- a/packages/streamdown/__tests__/mermaid-download.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-download.test.tsx
@@ -138,6 +138,31 @@ describe("MermaidDownloadDropdown", () => {
     });
   });
 
+  it("should use exportConfig for image downloads", async () => {
+    const plugin = createMockPlugin();
+    const config = { theme: "dark" as const };
+    const exportConfig = { theme: "default" as const };
+    const { container } = renderWithContext(
+      { chart: "graph TD; A-->B", config, exportConfig },
+      plugin
+    );
+
+    // Open dropdown
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(container.querySelector("button")!);
+
+    // Click SVG option
+    const svgButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent === "SVG"
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(svgButton!);
+
+    await waitFor(() => {
+      expect(plugin.getMermaid).toHaveBeenCalledWith(exportConfig);
+    });
+  });
+
   it("should download as PNG format", async () => {
     const { save } = await import("../lib/utils");
     const { svgToPngBlob } = await import("../lib/mermaid/utils");

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -179,9 +179,9 @@ export interface MermaidErrorComponentProps {
 
 export interface MermaidOptions {
   config?: MermaidConfig;
+  errorComponent?: React.ComponentType<MermaidErrorComponentProps>;
   /** Optional config used only for SVG/PNG downloads. Falls back to `config` when omitted. */
   exportConfig?: MermaidConfig;
-  errorComponent?: React.ComponentType<MermaidErrorComponentProps>;
 }
 
 export type AllowedTags = Record<string, string[]>;

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -179,6 +179,8 @@ export interface MermaidErrorComponentProps {
 
 export interface MermaidOptions {
   config?: MermaidConfig;
+  /** Optional config used only for SVG/PNG downloads. Falls back to `config` when omitted. */
+  exportConfig?: MermaidConfig;
   errorComponent?: React.ComponentType<MermaidErrorComponentProps>;
 }
 

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -907,6 +907,7 @@ const CodeComponent = ({
                   <MermaidDownloadDropdown
                     chart={code}
                     config={mermaidContext?.config}
+                    exportConfig={mermaidContext?.exportConfig}
                   />
                 ) : null}
                 {showCopy ? <CodeBlockCopyButton code={code} /> : null}

--- a/packages/streamdown/lib/mermaid/download-button.tsx
+++ b/packages/streamdown/lib/mermaid/download-button.tsx
@@ -13,6 +13,7 @@ interface MermaidDownloadDropdownProps {
   children?: React.ReactNode;
   className?: string;
   config?: MermaidConfig;
+  exportConfig?: MermaidConfig;
   onDownload?: (format: "mmd" | "png" | "svg") => void;
   onError?: (error: Error) => void;
 }
@@ -23,6 +24,7 @@ export const MermaidDownloadDropdown = ({
   className,
   onDownload,
   config,
+  exportConfig,
   onError,
 }: MermaidDownloadDropdownProps) => {
   const cn = useCn();
@@ -50,7 +52,8 @@ export const MermaidDownloadDropdown = ({
         return;
       }
 
-      const mermaid = mermaidPlugin.getMermaid(config);
+      const renderConfig = format === "mmd" ? config : (exportConfig ?? config);
+      const mermaid = mermaidPlugin.getMermaid(renderConfig);
 
       // Use a stable ID based on chart content hash and timestamp to ensure uniqueness
       const chartHash = chart.split("").reduce((acc, char) => {

--- a/packages/streamdown/lib/mermaid/download-button.tsx
+++ b/packages/streamdown/lib/mermaid/download-button.tsx
@@ -52,7 +52,7 @@ export const MermaidDownloadDropdown = ({
         return;
       }
 
-      const renderConfig = format === "mmd" ? config : (exportConfig ?? config);
+      const renderConfig = exportConfig ?? config;
       const mermaid = mermaidPlugin.getMermaid(renderConfig);
 
       // Use a stable ID based on chart content hash and timestamp to ensure uniqueness

--- a/skills/streamdown/references/api.md
+++ b/skills/streamdown/references/api.md
@@ -181,6 +181,7 @@ interface LinkSafetyModalProps {
 ```tsx
 interface MermaidOptions {
   config?: MermaidConfig;
+  exportConfig?: MermaidConfig;
   errorComponent?: React.ComponentType<MermaidErrorComponentProps>;
 }
 


### PR DESCRIPTION
## Summary
- add a new `mermaid.exportConfig` option so Mermaid SVG/PNG downloads can use a different config from on-screen rendering
- wire Mermaid download controls to use `exportConfig ?? config` for image exports while preserving existing `.mmd` source export behavior
- add tests and docs covering the new option, plus a changeset for the `streamdown` package

## Why
Apps often need dark-mode Mermaid diagrams in UI but light-theme files for sharing/export. This change supports that directly without custom renderers or DOM workarounds.

## Test plan
- [x] `corepack pnpm --filter streamdown test -- __tests__/mermaid-download.test.tsx`
- [x] `corepack pnpm check`
- [x] `corepack pnpm --filter streamdown test -- __tests__/mermaid-download.test.tsx`