### PR TITLE
fix(streamdown): disable singleTilde in remark-gfm to prevent ~ from rendering as strikethrough

### DIFF
--- a/.changeset/fix-single-tilde-545.md
+++ b/.changeset/fix-single-tilde-545.md
@@ -1,0 +1,12 @@
+---
+"streamdown": patch
+---
+
+fix: disable singleTilde in remark-gfm to prevent single ~ from rendering as strikethrough
+
+Single tilde (`~foo~`) should not be interpreted as strikethrough markup.
+This aligns with GitHub GFM behavior where only double tildes (`~~text~~`)
+create strikethrough. Set `singleTilde: false` in the default remark-gfm
+configuration.
+
+Fixes #545

--- a/packages/streamdown/__tests__/single-tilde.test.tsx
+++ b/packages/streamdown/__tests__/single-tilde.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Streamdown } from "../index";
+
+describe("Single tilde handling (#545)", () => {
+  it("should not render single tilde as strikethrough", () => {
+    const content = "~foo~ is not strikethrough";
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    // Single tilde should NOT create a <del> element
+    const del = container.querySelector("del");
+    expect(del).toBeNull();
+
+    // Text content should contain the tilde characters
+    const text = container.textContent;
+    expect(text).toContain("~foo~");
+  });
+
+  it("should still render double tilde as strikethrough", () => {
+    const content = "~~strikethrough~~";
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    // Double tilde SHOULD create a <del> element
+    const del = container.querySelector("del");
+    expect(del).not.toBeNull();
+    expect(del?.textContent).toBe("strikethrough");
+  });
+
+  it("should not render single ~ between words as strikethrough", () => {
+    const content = "Temperature range is 20~25°C";
+    const { container } = render(<Streamdown>{content}</Streamdown>);
+
+    const del = container.querySelector("del");
+    expect(del).toBeNull();
+
+    const text = container.textContent;
+    expect(text).toContain("20~25");
+  });
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -263,7 +263,7 @@ export const defaultRehypePlugins: Record<string, Pluggable> = {
 } as const;
 
 export const defaultRemarkPlugins: Record<string, Pluggable> = {
-  gfm: [remarkGfm, {}],
+  gfm: [remarkGfm, { singleTilde: false }],
   codeMeta: remarkCodeMeta,
 } as const;
 


### PR DESCRIPTION
## Summary

Fixes #545

Single tilde (`~foo~`) was incorrectly rendered as strikethrough because `remark-gfm` defaults to `singleTilde: true`. This PR sets `singleTilde: false` in the default `remark-gfm` configuration, consistent with GitHub GFM behavior where only double tildes (`~~text~~`) create strikethrough.

## Changes

- **`packages/streamdown/index.tsx`**: Changed default `remarkGfm` options from `{}` to `{ singleTilde: false }`
- **`packages/streamdown/__tests__/single-tilde.test.tsx`**: Added tests verifying single `~` is not rendered as strikethrough while `~~` still works
- **`.changeset/fix-single-tilde-545.md`**: Changeset for patch release

## Testing

- All 985 existing tests pass
- 3 new tests added specifically for single tilde behavior