### PR TITLE
fix: add missing xmlns:xlink namespace for Mermaid PNG export

### DIFF
--- a/packages/streamdown/lib/mermaid/utils.ts
+++ b/packages/streamdown/lib/mermaid/utils.ts
@@ -1,4 +1,14 @@
 /**
+ * Ensure SVG string has required XML namespaces for canvas rendering
+ */
+function normalizeSvg(svg: string): string {
+  if (svg.includes("xlink:href") && !svg.includes("xmlns:xlink")) {
+    return svg.replace("<svg", '<svg xmlns:xlink="http://www.w3.org/1999/xlink"');
+  }
+  return svg;
+}
+
+/**
  * Convert SVG string to PNG blob for export
  */
 export const svgToPngBlob = (
@@ -8,9 +18,11 @@ export const svgToPngBlob = (
   const scale = options?.scale ?? 5;
 
   return new Promise((resolve, reject) => {
+    const normalized = normalizeSvg(svgString);
+
     const encoded =
       "data:image/svg+xml;base64," +
-      btoa(unescape(encodeURIComponent(svgString)));
+      btoa(unescape(encodeURIComponent(normalized)));
 
     const img = new Image();
     img.crossOrigin = "anonymous";


### PR DESCRIPTION
Mermaid SVG output sometimes uses `xlink:href` attributes without declaring the required `xmlns:xlink` namespace on the root `<svg>` element. When converting SVG to PNG via canvas in `svgToPngBlob`, browsers require valid XML and fail to load the image if the namespace is missing, causing PNG export to silently fail.

**Fix**: Added a `normalizeSvg` helper that detects `xlink:href` usage and injects `xmlns:xlink=http://www.w3.org/1999/xlink` on the root SVG element when missing.

Closes #541