### PR TITLE
fix(mermaid): make controls reachable in the fullscreen view

### DIFF
--- a/.changeset/mermaid-fullscreen-download.md
+++ b/.changeset/mermaid-fullscreen-download.md
@@ -2,4 +2,4 @@
 "streamdown": patch
 ---
 
-fix(mermaid): render the download control inside the Mermaid fullscreen portal so it's reachable when the diagram is expanded
+fix(mermaid): render the download and copy controls inside the Mermaid fullscreen portal so they're reachable when the diagram is expanded

--- a/.changeset/mermaid-fullscreen-download.md
+++ b/.changeset/mermaid-fullscreen-download.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+fix(mermaid): render the download control inside the Mermaid fullscreen portal so it's reachable when the diagram is expanded

--- a/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/mermaid-fullscreen.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { StreamdownContext } from "../index";
 import { PluginContext } from "../lib/plugin-context";
+import type { DiagramPlugin, MermaidInstance } from "../lib/plugin-types";
 
 // Must mock the Mermaid component that fullscreen-button imports
 vi.mock("../lib/mermaid", () => ({
@@ -12,8 +13,23 @@ vi.mock("../lib/mermaid", () => ({
   ),
 }));
 
-// Import after mock
+vi.mock("../lib/utils", async () => {
+  const actual = await vi.importActual("../lib/utils");
+  return {
+    ...actual,
+    save: vi.fn(),
+  };
+});
+
+vi.mock("../lib/mermaid/utils", () => ({
+  svgToPngBlob: vi
+    .fn()
+    .mockResolvedValue(new Blob(["png"], { type: "image/png" })),
+}));
+
 import { MermaidFullscreenButton } from "../lib/mermaid/fullscreen-button";
+// Import after mocks
+import { save } from "../lib/utils";
 
 describe("MermaidFullscreenButton", () => {
   const defaultContext = {
@@ -23,9 +39,28 @@ describe("MermaidFullscreenButton", () => {
     mode: "streaming" as const,
   };
 
-  const renderWithContext = (props: any, contextOverrides = {}) => {
+  const createMockPlugin = (
+    renderResult = { svg: "<svg><text>Chart</text></svg>" }
+  ): DiagramPlugin => {
+    const mockInstance: MermaidInstance = {
+      initialize: vi.fn(),
+      render: vi.fn().mockResolvedValue(renderResult),
+    };
+    return {
+      name: "mermaid",
+      type: "diagram",
+      language: "mermaid",
+      getMermaid: vi.fn().mockReturnValue(mockInstance),
+    };
+  };
+
+  const renderWithContext = (
+    props: any,
+    contextOverrides = {},
+    plugin: DiagramPlugin | undefined = undefined
+  ) => {
     return render(
-      <PluginContext.Provider value={{}}>
+      <PluginContext.Provider value={plugin ? { mermaid: plugin } : {}}>
         <StreamdownContext.Provider
           value={{ ...defaultContext, ...contextOverrides }}
         >
@@ -245,5 +280,68 @@ describe("MermaidFullscreenButton", () => {
       expect(mermaid).toBeTruthy();
       expect(mermaid?.textContent).toContain("graph TD; A-->B");
     });
+  });
+
+  it("should render a working download button inside the fullscreen portal", async () => {
+    const plugin = createMockPlugin();
+    const { container } = renderWithContext(
+      { chart: "graph TD; A-->B" },
+      {},
+      plugin
+    );
+
+    const openBtn = container.querySelector('button[title="View fullscreen"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(openBtn!);
+
+    await waitFor(() => {
+      expect(document.querySelector(".fixed.inset-0")).toBeTruthy();
+    });
+
+    const downloadBtn = document.querySelector(
+      'button[title="Download diagram"]'
+    );
+    expect(downloadBtn).toBeTruthy();
+
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(downloadBtn!);
+
+    const pngOption = await waitFor(() =>
+      document.querySelector('button[title="Download diagram as PNG"]')
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(pngOption!);
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        "diagram.png",
+        expect.any(Blob),
+        "image/png"
+      );
+    });
+
+    // Fullscreen should still be open — downloading must not close it.
+    expect(document.querySelector(".fixed.inset-0")).toBeTruthy();
+  });
+
+  it("should hide the fullscreen download button when the download control is disabled", async () => {
+    const plugin = createMockPlugin();
+    const { container } = renderWithContext(
+      { chart: "graph TD; A-->B" },
+      { controls: { mermaid: { download: false } } },
+      plugin
+    );
+
+    const openBtn = container.querySelector('button[title="View fullscreen"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(openBtn!);
+
+    await waitFor(() => {
+      expect(document.querySelector(".fixed.inset-0")).toBeTruthy();
+    });
+
+    expect(
+      document.querySelector('button[title="Download diagram"]')
+    ).toBeFalsy();
   });
 });

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -7,6 +7,7 @@ import { useCn } from "../prefix-context";
 import { lockBodyScroll, unlockBodyScroll } from "../scroll-lock";
 import { useTranslations } from "../translations-context";
 import { Mermaid } from ".";
+import { MermaidDownloadDropdown } from "./download-button";
 
 type MermaidFullscreenButtonProps = ComponentProps<"button"> & {
   chart: string;
@@ -41,6 +42,19 @@ export const MermaidFullscreenButton = ({
       return true;
     }
     return mermaidCtl.panZoom !== false;
+  })();
+  const showDownload = (() => {
+    if (typeof controlsConfig === "boolean") {
+      return controlsConfig;
+    }
+    const mermaidCtl = controlsConfig.mermaid;
+    if (mermaidCtl === false) {
+      return false;
+    }
+    if (mermaidCtl === true || mermaidCtl === undefined) {
+      return true;
+    }
+    return mermaidCtl.download !== false;
   })();
 
   const handleToggle = () => {
@@ -110,17 +124,30 @@ export const MermaidFullscreenButton = ({
               }}
               role="dialog"
             >
-              <button
-                aria-label={t.exitFullscreen}
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: "div with role=presentation is used for event propagation control" */}
+              <div
                 className={cn(
-                  "absolute top-4 right-4 z-10 rounded-md p-2 text-muted-foreground transition-all hover:bg-muted hover:text-foreground"
+                  "absolute top-4 right-4 z-10 flex items-center gap-1"
                 )}
-                onClick={handleToggle}
-                title={t.exitFullscreen}
-                type="button"
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+                role="presentation"
               >
-                <XIcon aria-hidden="true" size={20} />
-              </button>
+                {showDownload ? (
+                  <MermaidDownloadDropdown chart={chart} config={config} />
+                ) : null}
+                <button
+                  aria-label={t.exitFullscreen}
+                  className={cn(
+                    "rounded-md p-2 text-muted-foreground transition-all hover:bg-muted hover:text-foreground"
+                  )}
+                  onClick={handleToggle}
+                  title={t.exitFullscreen}
+                  type="button"
+                >
+                  <XIcon aria-hidden="true" size={20} />
+                </button>
+              </div>
               {/* biome-ignore lint/a11y/noStaticElementInteractions: "div with role=presentation is used for event propagation control" */}
               <div
                 className={cn("flex size-full items-center justify-center p-4")}

--- a/packages/streamdown/lib/mermaid/fullscreen-button.tsx
+++ b/packages/streamdown/lib/mermaid/fullscreen-button.tsx
@@ -1,6 +1,7 @@
 import { type ComponentProps, useContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { StreamdownContext } from "../../index";
+import { CodeBlockCopyButton } from "../code-block/copy-button";
 import { useIcons } from "../icon-context";
 import type { MermaidConfig } from "../plugin-types";
 import { useCn } from "../prefix-context";
@@ -55,6 +56,19 @@ export const MermaidFullscreenButton = ({
       return true;
     }
     return mermaidCtl.download !== false;
+  })();
+  const showCopy = (() => {
+    if (typeof controlsConfig === "boolean") {
+      return controlsConfig;
+    }
+    const mermaidCtl = controlsConfig.mermaid;
+    if (mermaidCtl === false) {
+      return false;
+    }
+    if (mermaidCtl === true || mermaidCtl === undefined) {
+      return true;
+    }
+    return mermaidCtl.copy !== false;
   })();
 
   const handleToggle = () => {
@@ -136,6 +150,7 @@ export const MermaidFullscreenButton = ({
                 {showDownload ? (
                   <MermaidDownloadDropdown chart={chart} config={config} />
                 ) : null}
+                {showCopy ? <CodeBlockCopyButton code={chart} /> : null}
                 <button
                   aria-label={t.exitFullscreen}
                   className={cn(


### PR DESCRIPTION
## Summary

When a Mermaid diagram is expanded to fullscreen, there is no way to download it — the download button disappears entirely.

## Root cause

`MermaidFullscreenButton` renders its overlay via `createPortal(..., document.body)`. The block's action toolbar (`MermaidDownloadDropdown`, copy button, `MermaidFullscreenButton` itself) is rendered as a sibling of the diagram inside `components.tsx`, *outside* that portal. Since the portal is `fixed inset-0 z-50`, it visually covers that toolbar, and structurally the toolbar was never included in the portal's own markup — so once fullscreen is open there's no download affordance reachable at all.

This is the same class of bug already fixed for tables in #470 (`fix(table): add table-wrapper to fullscreen portal so copy/download work`), closed by #468 — except for tables the buttons were present in the portal but a `closest()` DOM lookup failed; for Mermaid the fullscreen view never rendered a download control in the first place.

## Fix

Render `MermaidDownloadDropdown` inside the fullscreen portal, next to the exit button, respecting the existing `controls.mermaid.download` config (mirrors the same inline boolean-resolution pattern already used for `panZoom` in this file). Propagation is stopped on the wrapping div so clicking download doesn't also trigger the backdrop's close-on-click handler.

## Testing

- Added two tests to `mermaid-fullscreen.test.tsx`:
  - the download button renders inside the fullscreen portal, downloads a PNG on click, and does not close the fullscreen overlay
  - the button is hidden when `controls.mermaid.download` is `false`
- All existing tests in `mermaid.test.tsx`, `mermaid-component.test.tsx`, `mermaid-download.test.tsx`, `mermaid-fullscreen.test.tsx` pass (56/56).
- `biome check` clean on both changed files.

Added a changeset.