### PR TITLE
fix: preserve <br> line breaks when copying table cells

### DIFF
--- a/packages/streamdown/__tests__/table-utils.test.ts
+++ b/packages/streamdown/__tests__/table-utils.test.ts
@@ -119,6 +119,66 @@ describe("Table Utils", () => {
       expect(result.headers).toEqual([]);
       expect(result.rows).toEqual([["Data"]]);
     });
+
+    it("should preserve line breaks from <br> tags in cells", () => {
+      tableElement.innerHTML = `
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Example</td>
+            <td>Paragraph one.<br>Paragraph two.</td>
+          </tr>
+        </tbody>
+      `;
+
+      const result = extractTableDataFromElement(tableElement);
+
+      expect(result.headers).toEqual(["Name", "Description"]);
+      expect(result.rows).toEqual([["Example", "Paragraph one.\nParagraph two."]]);
+    });
+
+    it("should preserve multiple <br> tags in cells", () => {
+      tableElement.innerHTML = `
+        <thead>
+          <tr>
+            <th>Content</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Line 1<br><br>Line 3</td>
+          </tr>
+        </tbody>
+      `;
+
+      const result = extractTableDataFromElement(tableElement);
+
+      expect(result.rows).toEqual([["Line 1\n\nLine 3"]]);
+    });
+
+    it("should preserve <br> tags in header cells", () => {
+      tableElement.innerHTML = `
+        <thead>
+          <tr>
+            <th>Header<br>Subtitle</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Value</td>
+          </tr>
+        </tbody>
+      `;
+
+      const result = extractTableDataFromElement(tableElement);
+
+      expect(result.headers).toEqual(["Header\nSubtitle"]);
+    });
   });
 
   describe("tableDataToCSV", () => {

--- a/packages/streamdown/lib/table/utils.ts
+++ b/packages/streamdown/lib/table/utils.ts
@@ -3,6 +3,30 @@ export interface TableData {
   rows: string[][];
 }
 
+/**
+ * Convert a cell's DOM content to text, preserving <br> as newlines.
+ * `textContent` collapses `<br>` tags into nothing, so we walk the DOM
+ * and insert a newline for each <br> element.
+ */
+const getCellText = (cell: Element): string => {
+  const parts: string[] = [];
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      parts.push(node.textContent ?? "");
+    } else if (node.nodeName === "BR") {
+      parts.push("\n");
+    } else if (node.childNodes) {
+      for (const child of node.childNodes) {
+        walk(child);
+      }
+    }
+  };
+
+  walk(cell);
+  return parts.join("").trim();
+};
+
 export const extractTableDataFromElement = (
   tableElement: HTMLElement
 ): TableData => {
@@ -12,7 +36,7 @@ export const extractTableDataFromElement = (
   // Extract headers
   const headerCells = tableElement.querySelectorAll("thead th");
   for (const cell of headerCells) {
-    headers.push(cell.textContent?.trim() || "");
+    headers.push(getCellText(cell));
   }
 
   // Extract rows
@@ -21,7 +45,7 @@ export const extractTableDataFromElement = (
     const rowData: string[] = [];
     const cells = row.querySelectorAll("td");
     for (const cell of cells) {
-      rowData.push(cell.textContent?.trim() || "");
+      rowData.push(getCellText(cell));
     }
     rows.push(rowData);
   }


### PR DESCRIPTION
## Summary

Fixes #553

When copying a rendered Markdown table as Markdown, CSV, or TSV, line breaks inside table cells were lost from the `text/plain` clipboard representation.

### Root Cause

`extractTableDataFromElement()` used `cell.textContent` which collapses `<br>` tags into nothing. For a rendered cell like:

```html
<td>Paragraph one.<br>Paragraph two.</td>
```

`textContent` returns `Paragraph one.Paragraph two.` — the line break is silently dropped.

### Fix

Replace `textContent` with a custom `getCellText()` helper that walks the DOM tree and inserts a newline character (`\n`) for each `<br>` element. This preserves line breaks through the full copy pipeline: extraction → CSV/TSV/Markdown serialization → clipboard.

The existing CSV/TSV/Markdown serializers already handle `\n` characters correctly (CSV wraps in quotes, TSV escapes as `\n`, Markdown passes through), so the fix only needs to happen at the extraction stage.

### Tests Added

- Single `<br>` in a data cell → produces `\n` in extracted text
- Multiple consecutive `<br>` tags → produces `\n\n`
- `<br>` in header cells → produces `\n` in headers

All existing tests continue to pass since `getCellText` produces the same output as `textContent.trim()` for cells without `<br>` tags.