### PR TITLE
fix: improve accessibility for code block control buttons

### DIFF
--- a/.changeset/common-streets-unite.md
+++ b/.changeset/common-streets-unite.md
@@ -1,0 +1,5 @@
+---
+"streamdown": minor
+---
+
+Added accessibility improvements for code block controls by adding aria labels to copy/download buttons and announcing copy success state for screen readers.

--- a/.changeset/common-streets-unite.md
+++ b/.changeset/common-streets-unite.md
@@ -1,5 +1,5 @@
 ---
-"streamdown": minor
+"streamdown": patch
 ---
 
 Added accessibility improvements for code block controls by adding aria labels to copy/download buttons and announcing copy success state for screen readers.

--- a/packages/streamdown/lib/code-block/copy-button.tsx
+++ b/packages/streamdown/lib/code-block/copy-button.tsx
@@ -66,19 +66,27 @@ export const CodeBlockCopyButton = ({
   const Icon = isCopied ? icons.CheckIcon : icons.CopyIcon;
 
   return (
-    <button
-      className={cn(
-        "cursor-pointer p-1 text-muted-foreground transition-all hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
-        className
+    <>
+      <button
+        aria-label={t.copyCode}
+        className={cn(
+          "cursor-pointer p-1 text-muted-foreground transition-all hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        data-streamdown="code-block-copy-button"
+        disabled={isAnimating}
+        onClick={copyToClipboard}
+        title={t.copyCode}
+        type="button"
+        {...props}
+      >
+        {children ?? <Icon size={14} />}
+      </button>
+      {isCopied && (
+        <output aria-live="polite" className="sr-only">
+          {t.copied}
+        </output>
       )}
-      data-streamdown="code-block-copy-button"
-      disabled={isAnimating}
-      onClick={copyToClipboard}
-      title={t.copyCode}
-      type="button"
-      {...props}
-    >
-      {children ?? <Icon size={14} />}
-    </button>
+    </>
   );
 };

--- a/packages/streamdown/lib/code-block/download-button.tsx
+++ b/packages/streamdown/lib/code-block/download-button.tsx
@@ -356,6 +356,7 @@ export const CodeBlockDownloadButton = ({
 
   return (
     <button
+      aria-label={t.downloadFile}
       className={cn(
         "cursor-pointer p-1 text-muted-foreground transition-all hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Improves accessibility for built-in code block controls by adding explicit accessible labels and screen reader feedback for copy actions.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues using #issue-number -->

Fixes #556

## Changes Made

<!-- List the specific changes made in this PR -->

- Added `aria-label` to `CodeBlockCopyButton` and `CodeBlockDownloadButton`
- Added a screen-reader-only status announcement for successful copy actions
- Reused existing translation keys for localized accessibility labels and messages

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

<!-- If applicable, include test coverage information -->

Manually verified that:
- Code block copy and download buttons expose accessible labels
- Copy action announces success state to screen readers using a status region

## Screenshots/Demos

<!-- If applicable, add screenshots or demos to help explain the changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [x] I have created a changeset for these changes

## Additional Notes

Added accessibility improvements without changing existing button behavior or UI appearance.