### PR TITLE
Enable Renovate for @vercel/geistdocs updates

### DIFF
--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -1,0 +1,42 @@
+// Self-hosted Renovate config for keeping @vercel/geistdocs current.
+// Policy mirrors vercel/geistdocs//renovate/consumer (the canonical source);
+// it's inlined here because geistdocs is private and this repo's scoped CI
+// token can't read a cross-repo preset. Keep in sync with that preset.
+module.exports = {
+  onboarding: false,
+  requireConfig: "optional",
+  repositories: ["vercel/streamdown"],
+  enabledManagers: ["npm"],
+  dependencyDashboard: true,
+
+  packageRules: [
+    // Manage only @vercel/geistdocs; leave every other dependency alone.
+    {
+      matchPackageNames: ["!@vercel/geistdocs"],
+      enabled: false,
+    },
+    {
+      matchPackageNames: ["@vercel/geistdocs"],
+      groupName: "geistdocs",
+      // Batch overnight to avoid mid-day churn.
+      schedule: ["after 1am and before 6am"],
+    },
+    // Auto-merge patch once required CI is green (nothing merges on red);
+    // minor and major open a review PR.
+    {
+      matchPackageNames: ["@vercel/geistdocs"],
+      matchUpdateTypes: ["patch"],
+      automerge: true,
+      automergeType: "pr",
+      platformAutomerge: true,
+    },
+  ],
+
+  hostRules: [
+    {
+      hostType: "npm",
+      matchHost: "registry.npmjs.org",
+      token: process.env.RENOVATE_NPM_TOKEN,
+    },
+  ],
+};

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,77 @@
+name: Renovate
+
+on:
+  # Daily within the overnight window used by the packageRules schedule.
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      repoCache:
+        description: "Reset or disable the cache?"
+        type: choice
+        default: enabled
+        options:
+          - enabled
+          - disabled
+          - reset
+
+env:
+  cache_dir: /tmp/renovate/cache/renovate/repository
+  cache_key: renovate-cache
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Restore Renovate cache
+        id: cache-restore
+        if: github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.cache_dir }}
+          key: ${{ env.cache_key }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ env.cache_key }}-
+
+      - name: Fix restored cache ownership
+        if: steps.cache-restore.outputs.cache-matched-key != ''
+        run: |
+          sudo chown -R 12021:0 /tmp/renovate/
+          ls -R $cache_dir
+
+      - name: Generate scoped GitHub token
+        id: github-sts
+        uses: vercel/gh-sts-action@56f891d4076b9f908ce459eb475d4c1884f75ada
+        with:
+          repos: vercel/streamdown
+          permissions: '{"contents":"write","issues":"write","pull_requests":"write","statuses":"write"}'
+
+      - name: Renovate
+        uses: renovatebot/github-action@22e0a16091fc706b04affe6ae53d5e3358ac4023 # v46.1.19
+        with:
+          configurationFile: .github/renovate.js
+          token: ${{ steps.github-sts.outputs.token }}
+        env:
+          RENOVATE_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
+          LOG_LEVEL: debug
+
+      - name: Save Renovate cache
+        if: github.event.inputs.repoCache != 'disabled' && steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.cache_dir }}
+          key: ${{ env.cache_key }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>vercel/geistdocs//renovate/consumer"]
-}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>vercel/geistdocs//renovate/consumer"]
+}


### PR DESCRIPTION
Enables automated `@vercel/geistdocs` updates via **self-hosted Renovate**, mirroring `vercel/agents` (the Renovate SaaS app isn't approved for org use).

## What this adds
- **`.github/workflows/renovate.yml`** — scheduled job running `renovatebot/github-action`, authenticated with a scoped token from `vercel/gh-sts-action` + `RENOVATE_NPM_TOKEN`.
- **`.github/renovate.js`** — self-hosted config scoped to this repo. Manages **only** `@vercel/geistdocs`: patch auto-merges once required CI is green, minor and major open a review PR. Every other dependency is left alone.

The policy is **inlined** (rather than extending `vercel/geistdocs//renovate/consumer`) because geistdocs is private and this repo's scoped CI token can't read a cross-repo preset. The canonical policy lives in [`vercel/geistdocs` `renovate/`](https://github.com/vercel/geistdocs/tree/main/renovate) — keep them in sync.

## Prerequisites to activate
1. This repo must be authorized to use **`vercel/gh-sts-action`**.
2. An **`NPM_TOKEN`** secret must be available to the repo.
3. **Branch protection with required status checks** — the gate patch auto-merge relies on (without it, a patch bump merges with no CI gate).

## Testing
Once merged, trigger the workflow manually (Actions → Renovate → Run workflow). Expect a Dependency Dashboard issue plus a review PR bumping `@vercel/geistdocs` 1.11.0 → 1.12.0 (minor → not auto-merged, by design).
