### PR TITLE
fix(sanitize): prevent double `user-content-` prefix on footnote ids

### DIFF
--- a/.changeset/fix-footnote-double-user-content-prefix.md
+++ b/.changeset/fix-footnote-double-user-content-prefix.md
@@ -1,0 +1,7 @@
+---
+"streamdown": patch
+---
+
+Fix doubled `user-content-` prefix on footnote ids
+
+Footnote list items were rendered with `id="user-content-user-content-fn-1"` because both `remark-rehype` and `rehype-sanitize` default their `clobberPrefix` to `user-content-`, so the prefix was applied twice. Disabled `clobberPrefix` on `rehype-sanitize` so `remark-rehype` remains the single, consistent prefixer of both footnote ids and backref hrefs — restoring working footnote navigation.

--- a/packages/streamdown/__tests__/allowed-tags.test.tsx
+++ b/packages/streamdown/__tests__/allowed-tags.test.tsx
@@ -193,13 +193,10 @@ Content for snippet 2
       </Streamdown>
     );
 
-    // rehype-sanitize prefixes id attributes with "user-content-"
-    const snippet1 = container.querySelector(
-      '[data-testid="snippet-user-content-1"]'
-    );
-    const snippet2 = container.querySelector(
-      '[data-testid="snippet-user-content-2"]'
-    );
+    // Sanitizer's clobberPrefix is disabled to keep footnote backref hrefs in
+    // sync with their targets, so user-provided ids are preserved as-is.
+    const snippet1 = container.querySelector('[data-testid="snippet-1"]');
+    const snippet2 = container.querySelector('[data-testid="snippet-2"]');
     expect(snippet1).toBeTruthy();
     expect(snippet2).toBeTruthy();
     // Ensure snippet 2's content isn't absorbed into snippet 1

--- a/packages/streamdown/__tests__/footnotes.test.tsx
+++ b/packages/streamdown/__tests__/footnotes.test.tsx
@@ -149,6 +149,35 @@ GFM extends standard Markdown with powerful features[^1]. Here's a comprehensive
     }
   });
 
+  it("should not double-prefix footnote ids with user-content-", () => {
+    const markdown = `First[^1] and second[^note2].
+
+[^1]: First footnote content.
+[^note2]: Second footnote content.`;
+
+    const { container } = render(<Streamdown>{markdown}</Streamdown>);
+
+    // Footnote list item ids should be prefixed with `user-content-` exactly once
+    // (not `user-content-user-content-fn-1`).
+    expect(container.querySelector("#user-content-fn-1")).toBeTruthy();
+    expect(container.querySelector("#user-content-fn-note2")).toBeTruthy();
+    expect(
+      container.querySelector("#user-content-user-content-fn-1")
+    ).toBeNull();
+    expect(
+      container.querySelector("#user-content-user-content-fn-note2")
+    ).toBeNull();
+
+    // Footnote label heading id should also not be doubled.
+    const labelIds = Array.from(container.querySelectorAll("[id]"))
+      .map((el) => el.id)
+      .filter((id) => id.includes("footnote-label"));
+    expect(labelIds.length).toBeGreaterThan(0);
+    for (const id of labelIds) {
+      expect(id.startsWith("user-content-user-content-")).toBe(false);
+    }
+  });
+
   it("should show footnotes once content arrives", () => {
     // Simulate streaming where definition has partial content
     const markdown = `Text with footnote[^1].

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -237,6 +237,12 @@ export type StreamdownProps = Options & {
 
 const defaultSanitizeSchema = {
   ...defaultSchema,
+  // remark-rehype already prefixes footnote ids and backref hrefs with
+  // `user-content-` (its default `clobberPrefix`). hast-util-sanitize's default
+  // `clobberPrefix` is also `user-content-`, which would double-prefix ids like
+  // `user-content-user-content-fn-1` while leaving the (already-prefixed) href
+  // pointing at the un-doubled anchor. Disable it here to avoid the mismatch.
+  clobberPrefix: "",
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "tel"],


### PR DESCRIPTION
Footnote and heading ids were rendered with a doubled prefix (e.g. `user-content-user-content-fn-1`) because both `remark-rehype` and `rehype-sanitize` default their `clobberPrefix` to `user-content-`, so
the prefix was applied twice in the pipeline.

remark-rehype emits footnote backref hrefs (`href="#fn-1"`) coordinated with its own `clobberPrefix`, so disabling the prefix upstream would desync hrefs from their targets and break footnote navigation. Disable `clobberPrefix` on rehype-sanitize instead, letting remark-rehype own the single, consistent prefixing of both hrefs and ids.

- index.tsx: set `clobberPrefix: ""` on `defaultSanitizeSchema`
- __tests__/footnotes.test.tsx: add regression test asserting footnote
  ids are prefixed exactly once
- __tests__/allowed-tags.test.tsx: update assertions — user-provided
  ids on custom tags are no longer clobbered by sanitize

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues using #issue-number -->

Fixes #
Closes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

<!-- If applicable, include test coverage information -->

## Screenshots/Demos

<!-- If applicable, add screenshots or demos to help explain your changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [x] I have created a changeset for these changes

## Additional Notes

<!-- Add any additional notes, concerns, or discussion points -->