### PR TITLE
fix: restore table copy and download actions in fullscreen mode

### DIFF
--- a/.changeset/shaggy-terms-grin.md
+++ b/.changeset/shaggy-terms-grin.md
@@ -1,5 +1,5 @@
 ---
-"streamdown": minor
+"streamdown": patch
 ---
 
 Fix table copy and download actions not working in fullscreen mode.

--- a/.changeset/shaggy-terms-grin.md
+++ b/.changeset/shaggy-terms-grin.md
@@ -1,0 +1,9 @@
+---
+"streamdown": minor
+---
+
+Fix table copy and download actions not working in fullscreen mode.
+
+- Support table lookup inside the fullscreen portal container.
+- Restore copy and download functionality for fullscreen tables.
+- Keep existing inline table controls behavior unchanged.

--- a/packages/streamdown/__tests__/table-dropdowns.test.tsx
+++ b/packages/streamdown/__tests__/table-dropdowns.test.tsx
@@ -114,6 +114,57 @@ describe("TableDownloadDropdown", () => {
     expect(onDownload).toHaveBeenCalledWith("markdown");
   });
 
+  it("should download when inside table-fullscreen", async () => {
+    const { save } = await import("../lib/utils");
+    const onDownload = vi.fn();
+
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: true,
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-fullscreen">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableDownloadDropdown onDownload={onDownload} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const toggleBtn = container.querySelector('button[title="Download table"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(toggleBtn!);
+
+    const csvBtn = container.querySelector(
+      'button[title="Download table as CSV"]'
+    );
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(csvBtn!);
+
+    expect(save).toHaveBeenCalledWith(
+      "table.csv",
+      expect.any(String),
+      "text/csv"
+    );
+    expect(onDownload).toHaveBeenCalledWith("csv");
+  });
+
   it("should call onError when save throws", async () => {
     const { save } = await import("../lib/utils");
     (save as any).mockImplementation(() => {
@@ -241,6 +292,44 @@ describe("TableDownloadButton with format='markdown'", () => {
     fireEvent.click(btn!);
 
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("should download when inside table-fullscreen", () => {
+    const onDownload = vi.fn();
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: true,
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-fullscreen">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableDownloadButton onDownload={onDownload} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const btn = container.querySelector("button");
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(btn!);
+
+    expect(onDownload).toHaveBeenCalled();
   });
 });
 
@@ -406,6 +495,51 @@ describe("TableCopyDropdown", () => {
     });
 
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("should copy when inside table-fullscreen", async () => {
+    const onCopy = vi.fn();
+    const { container } = render(
+      <StreamdownContext.Provider
+        value={{
+          shikiTheme: ["github-light", "github-dark"],
+          controls: true,
+          isAnimating: false,
+          mode: "streaming",
+        }}
+      >
+        <div data-streamdown="table-fullscreen">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>30</td>
+              </tr>
+            </tbody>
+          </table>
+          <TableCopyDropdown onCopy={onCopy} />
+        </div>
+      </StreamdownContext.Provider>
+    );
+
+    const toggleBtn = container.querySelector('button[title="Copy table"]');
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    fireEvent.click(toggleBtn!);
+
+    const csvBtn = container.querySelector('button[title="Copy table as CSV"]');
+    // biome-ignore lint/suspicious/useAwait: act needs async to flush clipboard promises
+    await act(async () => {
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      fireEvent.click(csvBtn!);
+    });
+
+    expect(onCopy).toHaveBeenCalledWith("csv");
   });
 
   it("should close dropdown on outside click", () => {

--- a/packages/streamdown/__tests__/table-fullscreen.test.tsx
+++ b/packages/streamdown/__tests__/table-fullscreen.test.tsx
@@ -1,6 +1,14 @@
-import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Streamdown } from "../index";
+
+vi.mock("../lib/utils", async () => {
+  const actual = await vi.importActual("../lib/utils");
+  return {
+    ...actual,
+    save: vi.fn(),
+  };
+});
 
 const markdownWithTable = `
 | Name | Age |
@@ -307,5 +315,151 @@ describe("TableFullscreenButton", () => {
     );
     const copyBtn = overlay?.querySelector('button[title="Copy table"]');
     expect(copyBtn).toBeFalsy();
+  });
+
+  it("should show copy format options in fullscreen", () => {
+    const { container } = render(<Streamdown>{markdownWithTable}</Streamdown>);
+
+    const btn = container.querySelector(
+      'button[title="View fullscreen"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    const overlay = document.querySelector(
+      '[data-streamdown="table-fullscreen"]'
+    );
+    const copyBtn = overlay?.querySelector(
+      'button[title="Copy table"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(copyBtn);
+
+    expect(
+      overlay?.querySelector('button[title="Copy table as CSV"]')
+    ).toBeTruthy();
+    expect(
+      overlay?.querySelector('button[title="Copy table as Markdown"]')
+    ).toBeTruthy();
+    expect(
+      overlay?.querySelector('button[title="Copy table as TSV"]')
+    ).toBeTruthy();
+  });
+
+  it("should show download format options in fullscreen", () => {
+    const { container } = render(<Streamdown>{markdownWithTable}</Streamdown>);
+
+    const btn = container.querySelector(
+      'button[title="View fullscreen"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    const overlay = document.querySelector(
+      '[data-streamdown="table-fullscreen"]'
+    );
+    const downloadBtn = overlay?.querySelector(
+      'button[title="Download table"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(downloadBtn);
+
+    expect(
+      overlay?.querySelector('button[title="Download table as CSV"]')
+    ).toBeTruthy();
+    expect(
+      overlay?.querySelector('button[title="Download table as Markdown"]')
+    ).toBeTruthy();
+  });
+});
+
+describe("TableFullscreenButton copy and download", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalClipboardItem = globalThis.ClipboardItem;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        write: vi.fn().mockResolvedValue(undefined),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+      configurable: true,
+    });
+    if (!globalThis.ClipboardItem) {
+      globalThis.ClipboardItem = class {
+        types: string[];
+        data: Record<string, Blob>;
+        constructor(data: Record<string, Blob>) {
+          this.types = Object.keys(data);
+          this.data = data;
+        }
+      } as any;
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+    if (originalClipboardItem) {
+      globalThis.ClipboardItem = originalClipboardItem;
+    }
+  });
+
+  it("should copy table as CSV in fullscreen", async () => {
+    const { container } = render(<Streamdown>{markdownWithTable}</Streamdown>);
+
+    const btn = container.querySelector(
+      'button[title="View fullscreen"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    const overlay = document.querySelector(
+      '[data-streamdown="table-fullscreen"]'
+    );
+    const copyBtn = overlay?.querySelector(
+      'button[title="Copy table"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(copyBtn);
+
+    const csvBtn = overlay?.querySelector(
+      'button[title="Copy table as CSV"]'
+    ) as HTMLButtonElement;
+    // biome-ignore lint/suspicious/useAwait: act needs async to flush clipboard promises
+    await act(async () => {
+      fireEvent.click(csvBtn);
+    });
+
+    expect(navigator.clipboard.write).toHaveBeenCalled();
+  });
+
+  it("should download table as CSV in fullscreen", async () => {
+    const { save } = await import("../lib/utils");
+    const { container } = render(<Streamdown>{markdownWithTable}</Streamdown>);
+
+    const btn = container.querySelector(
+      'button[title="View fullscreen"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    const overlay = document.querySelector(
+      '[data-streamdown="table-fullscreen"]'
+    );
+    const downloadBtn = overlay?.querySelector(
+      'button[title="Download table"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(downloadBtn);
+
+    const csvBtn = overlay?.querySelector(
+      'button[title="Download table as CSV"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(csvBtn);
+
+    expect(save).toHaveBeenCalledWith(
+      "table.csv",
+      expect.any(String),
+      "text/csv"
+    );
   });
 });

--- a/packages/streamdown/lib/table/copy-dropdown.tsx
+++ b/packages/streamdown/lib/table/copy-dropdown.tsx
@@ -41,7 +41,7 @@ export const TableCopyDropdown = ({
 
     try {
       const tableWrapper = dropdownRef.current?.closest(
-        '[data-streamdown="table-wrapper"]'
+        '[data-streamdown="table-wrapper"], [data-streamdown="table-fullscreen"]'
       );
       const tableElement = tableWrapper?.querySelector(
         "table"

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -36,7 +36,9 @@ export const TableDownloadButton = ({
     try {
       // Find the closest table element
       const button = event.currentTarget;
-      const tableWrapper = button.closest('[data-streamdown="table-wrapper"], [data-streamdown="table-fullscreen"]');
+      const tableWrapper = button.closest(
+        '[data-streamdown="table-wrapper"], [data-streamdown="table-fullscreen"]'
+      );
       const tableElement = tableWrapper?.querySelector(
         "table"
       ) as HTMLTableElement;

--- a/packages/streamdown/lib/table/download-dropdown.tsx
+++ b/packages/streamdown/lib/table/download-dropdown.tsx
@@ -36,7 +36,7 @@ export const TableDownloadButton = ({
     try {
       // Find the closest table element
       const button = event.currentTarget;
-      const tableWrapper = button.closest('[data-streamdown="table-wrapper"]');
+      const tableWrapper = button.closest('[data-streamdown="table-wrapper"], [data-streamdown="table-fullscreen"]');
       const tableElement = tableWrapper?.querySelector(
         "table"
       ) as HTMLTableElement;
@@ -117,7 +117,7 @@ export const TableDownloadDropdown = ({
   const downloadTableData = (format: "csv" | "markdown") => {
     try {
       const tableWrapper = dropdownRef.current?.closest(
-        '[data-streamdown="table-wrapper"]'
+        '[data-streamdown="table-wrapper"], [data-streamdown="table-fullscreen"]'
       );
       const tableElement = tableWrapper?.querySelector(
         "table"


### PR DESCRIPTION
## Description
This PR fixes an issue where the table **Copy** and **Download** controls silently failed when used from the fullscreen table view.

The fullscreen table is rendered using a React portal with a `data-streamdown="table-fullscreen"` container. The copy and download actions previously located the target table by searching for the nearest `data-streamdown="table-wrapper"` ancestor. Because portals break DOM ancestry, the lookup failed in fullscreen mode, causing the controls to report "Table not found" and perform no action.

This change broadens the table lookup to support both inline and fullscreen table containers, restoring copy and download functionality without changing the existing behavior for inline tables.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues using #issue-number -->

Fixes #567
Closes #567
Related to #567

## Changes Made

<!-- List the specific changes made in this PR -->

* Updated table lookup logic to support both inline and fullscreen table containers.
* Restored copy functionality for tables displayed in fullscreen mode.
* Restored download functionality for tables displayed in fullscreen mode.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

Manually tested the copy functionality using a local React app.

How I tested it locally:

I used the following test component to verify table rendering and copying behavior:

```tsx
import { Streamdown } from "streamdown";
import "streamdown/styles.css";

const App = () => {
  const markdown = `
| Feature | Status | Notes |
|:--------|:------:|------:|
| Markdown | Supported | CommonMark compliant |
| GFM | Supported | Tables, tasks, strikethrough |
| Code highlighting | Supported | 200+ languages via Shiki |
| Math | Supported | KaTeX rendering |
| Mermaid | Supported | Flowcharts, sequences, and more |
| CJK | Supported | Chinese, Japanese, Korean |

`;

  return (
    <div className="App">
      <div className="mx-auto mt-5 w-200">
        <Streamdown>{markdown}</Streamdown>
      </div>
    </div>
  );
};

export default App;
```

Verified that:

Copy actions work correctly from the inline table.
Copy actions work correctly from the fullscreen table.
Download actions work correctly from the inline table.
Download actions work correctly from the fullscreen table.

<!-- If applicable, include test coverage information -->

## Screenshots/Demos


https://github.com/user-attachments/assets/9ba87b07-b50a-4f43-9920-1e38cd15a428


<!-- If applicable, add screenshots or demos to help explain your changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [x] I have created a changeset for these changes

## Additional Notes

<!-- Add any additional notes, concerns, or discussion points -->
This fix intentionally takes the minimal approach by supporting table lookup within both `table-wrapper` and `table-fullscreen` containers.

A larger architectural refactor to pass table references directly (instead of relying on DOM traversal) was considered but is outside the scope of this bug fix. The current solution restores the expected functionality while preserving the existing implementation and API.
