### PR TITLE
fix: detect static text direction per block

### DIFF
--- a/.changeset/calm-taxis-smile.md
+++ b/.changeset/calm-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Detect text direction per semantic block in static mode, keep code LTR, and use content-majority direction for mixed-script prose.

--- a/.changeset/calm-taxis-smile.md
+++ b/.changeset/calm-taxis-smile.md
@@ -2,4 +2,4 @@
 "streamdown": patch
 ---
 
-Detect text direction per semantic block in static mode, keep code LTR, and use content-majority direction for mixed-script prose.
+Fix `dir="auto"` in static mode to detect text direction per semantic block (instead of once for the whole document), keep code LTR, and use content-majority direction for mixed-script prose.

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -54,11 +54,34 @@ Streamdown can be configured to suit your needs. This guide will walk you throug
     },
     dir: {
       description:
-        "Text direction. 'auto' detects per-block using the first strong character algorithm.",
+        "Text direction. 'ltr'/'rtl' force a single direction. 'auto' detects per block (content-majority strong characters, first-strong on ties). Code is always LTR.",
       type: '"auto" | "ltr" | "rtl"',
     },
   }}
 />
+
+### Text direction (`dir`)
+
+Use `dir` when rendering RTL languages (Persian, Arabic, Hebrew, etc.) or mixed-script content:
+
+```tsx title="app/page.tsx"
+<Streamdown dir="auto" mode="static">
+  {markdown}
+</Streamdown>
+```
+
+| Value | Behavior |
+| --- | --- |
+| `"ltr"` / `"rtl"` | Applies that direction to the root (static) or each streaming block |
+| `"auto"` | Detects direction independently per block |
+| omitted | No `dir` attribute is set |
+
+With `dir="auto"`:
+
+- **Streaming mode** — direction is resolved once per parsed markdown block (same unit used for memoized streaming updates).
+- **Static mode** — a rehype pass assigns `dir` on each semantic block (headings, paragraphs, list items, blockquotes, definition terms/descriptions, captions, and table cells) so mixed Persian/Hebrew/Arabic/English documents keep the correct base direction without splitting the document (footnotes and cross-block references still resolve).
+- **Detection** — counts Unicode strong letters after stripping common markdown syntax. The majority wins; equal counts fall back to the first strong character. Fenced and inline code are excluded from the count so LTR identifiers do not skew surrounding RTL prose.
+- **Code** — fenced code blocks and code-related elements are always LTR so line numbers and syntax highlighting stay correct inside RTL documents.
 
 ## Styling Props
 

--- a/apps/website/content/docs/internationalization.mdx
+++ b/apps/website/content/docs/internationalization.mdx
@@ -1,8 +1,8 @@
 ---
 title: Internationalization
-description: Override default English labels with your own translations.
+description: Localize UI labels and set text direction for RTL and mixed-script content.
 type: reference
-summary: Localize all UI labels in Streamdown controls and modals.
+summary: Localize UI labels and configure text direction (dir) for RTL content.
 prerequisites:
   - /docs/getting-started
 related:
@@ -240,6 +240,20 @@ function CustomCodeBlock({ children }) {
   );
 }
 ```
+
+## Text direction
+
+For right-to-left languages or mixed-script Markdown, set the `dir` prop. Prefer `dir="auto"` so each block gets its own base direction:
+
+```tsx title="app/page.tsx"
+<Streamdown dir="auto">
+  {markdown}
+</Streamdown>
+```
+
+In static mode, Streamdown keeps the document as one Markdown parse (so footnotes and references still resolve) and assigns `dir` per heading, paragraph, list item, quote, and table cell. Code blocks stay LTR. Detection uses a majority count of strong Unicode letters, with first-strong as the tie-breaker.
+
+See [Configuration → Text direction](/docs/configuration#text-direction-dir) for the full behavior matrix.
 
 ## Exported types and values
 

--- a/packages/streamdown/__tests__/detect-direction.test.ts
+++ b/packages/streamdown/__tests__/detect-direction.test.ts
@@ -42,6 +42,20 @@ describe("detectTextDirection", () => {
     expect(detectTextDirection("مرحبا Hello")).toBe("rtl");
   });
 
+  it("uses the content majority when an RTL sentence starts with an English identifier", () => {
+    expect(
+      detectTextDirection("React یک کتابخانه جاوااسکریپت بسیار محبوب است.")
+    ).toBe("rtl");
+  });
+
+  it("does not let fenced code skew the direction of surrounding prose", () => {
+    expect(
+      detectTextDirection(
+        "این یک نمونه است.\n\n```js\nconst example = true;\n```"
+      )
+    ).toBe("rtl");
+  });
+
   it("handles Thaana script", () => {
     expect(detectTextDirection("ދިވެހި")).toBe("rtl");
   });

--- a/packages/streamdown/__tests__/rtl-support.test.tsx
+++ b/packages/streamdown/__tests__/rtl-support.test.tsx
@@ -178,6 +178,26 @@ Mixed paragraph: Hello مرحبا World عالم.
       expect(wrapper?.getAttribute("dir")).toBe("ltr");
     });
 
+    it("applies auto direction per semantic block in static mode", () => {
+      const content =
+        "# שלום עולם\n\nEnglish paragraph.\n\nReact یک کتابخانه جاوااسکریپت بسیار محبوب است.\n\n```js\nconsole.log('hello');\n```";
+      const { container } = render(
+        <Streamdown dir="auto" mode="static">
+          {content}
+        </Streamdown>
+      );
+
+      const heading = container.querySelector("h1");
+      const paragraphs = container.querySelectorAll("p");
+      const code = container.querySelector('[data-streamdown="code-block"]');
+
+      expect(container.firstElementChild?.hasAttribute("dir")).toBe(false);
+      expect(heading?.getAttribute("dir")).toBe("rtl");
+      expect(paragraphs[0]?.getAttribute("dir")).toBe("ltr");
+      expect(paragraphs[1]?.getAttribute("dir")).toBe("rtl");
+      expect(code?.getAttribute("dir")).toBe("ltr");
+    });
+
     it('applies per-block dir in streaming mode with dir="auto"', () => {
       const content = "مرحبا بالعالم\n\nHello world";
       const { container } = render(

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -40,6 +40,7 @@ import type {
 import { PrefixContext } from "./lib/prefix-context";
 import { preprocessCustomTags } from "./lib/preprocess-custom-tags";
 import { preprocessLiteralTagContent } from "./lib/preprocess-literal-tag-content";
+import { rehypeBlockDirection } from "./lib/rehype/block-direction";
 import { rehypeLiteralTagContent } from "./lib/rehype/literal-tag-content";
 import { remarkCodeMeta } from "./lib/remark/code-meta";
 import {
@@ -735,6 +736,10 @@ export const Streamdown = memo(
         result = [...result, animatePlugin.rehypePlugin];
       }
 
+      if (dir === "auto" && mode === "static") {
+        result = [...result, rehypeBlockDirection];
+      }
+
       return result;
     }, [
       rehypePlugins,
@@ -743,6 +748,8 @@ export const Streamdown = memo(
       isAnimating,
       allowedTags,
       literalTagContent,
+      dir,
+      mode,
     ]);
 
     const shouldHideCaret = useMemo(() => {
@@ -777,11 +784,7 @@ export const Streamdown = memo(
                       "space-y-4 whitespace-normal [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
                       className
                     )}
-                    dir={
-                      dir === "auto"
-                        ? detectTextDirection(processedChildren)
-                        : dir
-                    }
+                    dir={dir === "auto" ? undefined : dir}
                   >
                     <Markdown
                       components={mergedComponents}

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -189,7 +189,15 @@ export type AllowedTags = Record<string, string[]>;
 
 export type StreamdownProps = Options & {
   mode?: "static" | "streaming";
-  /** Text direction for blocks. "auto" detects per-block using first strong character algorithm. */
+  /**
+   * Text direction. `"ltr"` / `"rtl"` force a single direction.
+   * `"auto"` detects direction per block: in streaming mode via parsed
+   * markdown blocks, in static mode via a rehype pass on each semantic
+   * block (headings, paragraphs, list items, table cells, etc.).
+   * Detection uses a content-majority strong-character count with
+   * first-strong as the tie-breaker; fenced/inline code is excluded from
+   * the evidence and code blocks are always rendered LTR.
+   */
   dir?: "auto" | "ltr" | "rtl";
   BlockComponent?: React.ComponentType<BlockProps>;
   parseMarkdownIntoBlocksFn?: (markdown: string) => string[];

--- a/packages/streamdown/lib/code-block/index.tsx
+++ b/packages/streamdown/lib/code-block/index.tsx
@@ -65,7 +65,11 @@ export const CodeBlock = ({
 
   return (
     <CodeBlockContext.Provider value={{ code }}>
-      <CodeBlockContainer isIncomplete={isIncomplete} language={language}>
+      <CodeBlockContainer
+        dir="ltr"
+        isIncomplete={isIncomplete}
+        language={language}
+      >
         <CodeBlockHeader language={language} />
         {children ? (
           <div

--- a/packages/streamdown/lib/detect-direction.ts
+++ b/packages/streamdown/lib/detect-direction.ts
@@ -8,36 +8,48 @@ const RTL_PATTERN = /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/;
 const LETTER_PATTERN = /\p{L}/u;
 
 /**
- * Detect text direction using the "first strong character" algorithm.
- * Strips common markdown syntax then finds the first Unicode letter
- * with strong directionality.
+ * Detect text direction by counting strong characters in the text.
+ * Ties use the first strong character, preserving intuitive behavior for
+ * short mixed labels while allowing RTL-majority prose that starts with an
+ * English identifier to remain RTL.
  *
- * Note: markdown stripping is best-effort — nested formatting,
- * multi-line fenced code blocks, and raw HTML are not fully handled.
- * This is acceptable since the algorithm only needs to reach the first
- * strong character, which is almost always in plain prose.
+ * Markdown stripping is best-effort. Fenced and inline code are excluded
+ * because code is always rendered LTR and should not influence surrounding
+ * prose.
  *
- * @returns "rtl" if first strong char is RTL, "ltr" otherwise
+ * @returns "rtl" if RTL strong characters are the majority, "ltr" otherwise
  */
 export function detectTextDirection(text: string): "ltr" | "rtl" {
-  // Strip common markdown syntax to get to actual text content
   const stripped = text
+    .replace(/(```|~~~)[\s\S]*?\1/g, "") // fenced code
     .replace(/^#{1,6}\s+/gm, "") // headings
     .replace(/(\*{1,3}|_{1,3})/g, "") // bold/italic
     .replace(/`[^`]*`/g, "") // inline code
     .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links (keep text)
     .replace(/^[\s>*\-+\d.]+/gm, ""); // list markers, blockquotes
 
-  // Find first strong directional character (any Unicode letter)
+  let firstStrong: "ltr" | "rtl" | undefined;
+  let ltrCount = 0;
+  let rtlCount = 0;
+
   for (const char of stripped) {
     if (RTL_PATTERN.test(char)) {
-      return "rtl";
+      firstStrong ??= "rtl";
+      rtlCount += 1;
+      continue;
     }
-    // Latin, CJK, Cyrillic, etc. — any letter that's not RTL is LTR
+    // Latin, CJK, Cyrillic, etc. — any letter that's not RTL is LTR.
     if (LETTER_PATTERN.test(char)) {
-      return "ltr";
+      firstStrong ??= "ltr";
+      ltrCount += 1;
     }
   }
 
-  return "ltr";
+  if (rtlCount > ltrCount) {
+    return "rtl";
+  }
+  if (ltrCount > rtlCount) {
+    return "ltr";
+  }
+  return firstStrong ?? "ltr";
 }

--- a/packages/streamdown/lib/rehype/block-direction.ts
+++ b/packages/streamdown/lib/rehype/block-direction.ts
@@ -1,0 +1,64 @@
+import type { Element, Root } from "hast";
+import { visit } from "unist-util-visit";
+import { detectTextDirection } from "../detect-direction";
+
+const DIRECTIONAL_BLOCKS = new Set([
+  "blockquote",
+  "dd",
+  "dt",
+  "figcaption",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "p",
+  "td",
+  "th",
+]);
+
+const CODE_ELEMENTS = new Set(["code", "kbd", "pre", "samp", "var"]);
+
+function textContent(node: Element): string {
+  return node.children
+    .map((child) => {
+      if (child.type === "text") {
+        return child.value;
+      }
+      if (child.type === "element" && !CODE_ELEMENTS.has(child.tagName)) {
+        return textContent(child);
+      }
+      return "";
+    })
+    .join("");
+}
+
+/**
+ * Assign direction to each rendered semantic block without splitting the
+ * Markdown document, so references and footnotes continue to resolve across
+ * block boundaries.
+ */
+export function rehypeBlockDirection() {
+  return (tree: Root) => {
+    visit(tree, "element", (node: Element) => {
+      if (CODE_ELEMENTS.has(node.tagName)) {
+        node.properties ??= {};
+        node.properties.dir = "ltr";
+        return;
+      }
+
+      if (!DIRECTIONAL_BLOCKS.has(node.tagName)) {
+        return;
+      }
+
+      node.properties ??= {};
+      if (typeof node.properties.dir === "string") {
+        return;
+      }
+
+      node.properties.dir = detectTextDirection(textContent(node));
+    });
+  };
+}


### PR DESCRIPTION
## Description

Static mode currently resolves dir=auto once for the complete Markdown string. A mixed Hebrew/Arabic/Persian and English response therefore gives every block the same base direction, while code can inherit RTL.

This change keeps static content as one Markdown document but adds a rehype pass that assigns direction to each semantic block. Keeping one parse preserves cross-block references and footnotes. The public detector now uses strong-character content majority, with first-strong as the tie-breaker, so RTL-majority technical prose such as an answer beginning with an English identifier is not forced LTR. Rendered code-block containers are explicitly LTR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #509

## Changes Made

- Detect static Markdown direction per heading, paragraph, list item, quote, definition, caption, and table cell.
- Use content-majority direction with first-strong tie-breaking and exclude inline/fenced code from prose evidence.
- Keep code LTR at both HAST and custom code-block rendering layers.
- Add Hebrew, Persian/English, English, and fenced-code regression coverage.

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [ ] Manually tested the changes

### Test Coverage

- `pnpm --filter streamdown test`: 73 files, 985 tests passed
- `pnpm --filter streamdown build`: ESM and declaration build passed
- Ultracite check on all six touched TypeScript/TSX files: passed
- `git diff --check`: passed

## Screenshots/Demos

Not included. The regression is asserted against the rendered DOM: no document-level auto direction in static mode, per-block `dir` values, and an LTR code-block container.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] I have created a changeset for these changes

## Additional Notes

I maintain the MIT-licensed BidiLens project and used its per-semantic-block/content-majority model as design input. This PR intentionally implements the small policy natively instead of adding BidiLens as a dependency: Streamdown supports Node 18, while BidiLens 0.3 declares Node 22.12+, so a direct dependency would unnecessarily raise the host's runtime floor.

The Vercel preview check requires authorization from a Vercel team member because this PR comes from an external fork. Socket security and Vercel Agent Review passed; the preview authorization state is not a build or test failure in this patch.