### PR TITLE
fix: remove animation spans after streaming ends

### DIFF
--- a/.changeset/clean-settled-animation-spans.md
+++ b/.changeset/clean-settled-animation-spans.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Fix animation spans not being removed from settled text when `isAnimating` goes false. Include `isAnimating` in block keys so React mounts fresh subtrees when the animate rehype plugin is removed from the pipeline, allowing the span-free reparse to commit.

--- a/packages/streamdown/__tests__/animate-integration.test.tsx
+++ b/packages/streamdown/__tests__/animate-integration.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Streamdown } from "../index";
+
+const FADE = {
+  animation: "fadeIn",
+  duration: 200,
+  easing: "ease-out",
+  sep: "word",
+  stagger: 0,
+} as const;
+
+const MD =
+  "First paragraph with several words here.\n\nSecond paragraph also has words.\n\nThird paragraph ends it.";
+
+describe("Animate integration", () => {
+  it("should remove animation spans when isAnimating goes false", () => {
+    const { container, rerender } = render(
+      <Streamdown animated={FADE} isAnimating>
+        {MD}
+      </Streamdown>
+    );
+    expect(
+      container.querySelectorAll("[data-sd-animate]").length
+    ).toBeGreaterThan(0);
+
+    // Stream ends: same children, animation off.
+    rerender(
+      <Streamdown animated={FADE} isAnimating={false}>
+        {MD}
+      </Streamdown>
+    );
+    expect(
+      container.querySelectorAll("[data-sd-animate]").length
+    ).toBe(0);
+  });
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -572,13 +572,19 @@ export const Streamdown = memo(
       [blocksToRender, dir]
     );
 
-    // Generate stable keys based on index only
-    // Don't use content hash - that causes unmount/remount when content changes
-    // React will handle content updates via props changes and memo comparison
+    // Generate stable keys based on index and animation state.
+    // Don't use content hash - that causes unmount/remount when content changes.
+    // Include isAnimating so that when streaming ends and the animate rehype
+    // plugin is removed from the pipeline, block keys change and React mounts
+    // fresh subtrees. Without this, memoized leaf components that compare only
+    // className + source position discard the span-free reparse.
     // biome-ignore lint/correctness/useExhaustiveDependencies: "we're using the blocksToRender length"
     const blockKeys = useMemo(
-      () => blocksToRender.map((_block, idx) => `${generatedId}-${idx}`),
-      [blocksToRender.length, generatedId]
+      () =>
+        blocksToRender.map(
+          (_block, idx) => `${generatedId}-${idx}-${isAnimating ? "a" : "s"}`
+        ),
+      [blocksToRender.length, generatedId, isAnimating]
     );
 
     // Stable key derived from animated option values. This prevents the

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -572,21 +572,6 @@ export const Streamdown = memo(
       [blocksToRender, dir]
     );
 
-    // Generate stable keys based on index and animation state.
-    // Don't use content hash - that causes unmount/remount when content changes.
-    // Include isAnimating so that when streaming ends and the animate rehype
-    // plugin is removed from the pipeline, block keys change and React mounts
-    // fresh subtrees. Without this, memoized leaf components that compare only
-    // className + source position discard the span-free reparse.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: "we're using the blocksToRender length"
-    const blockKeys = useMemo(
-      () =>
-        blocksToRender.map(
-          (_block, idx) => `${generatedId}-${idx}-${isAnimating ? "a" : "s"}`
-        ),
-      [blocksToRender.length, generatedId, isAnimating]
-    );
-
     // Stable key derived from animated option values. This prevents the
     // plugin from being recreated when the user passes an inline object
     // literal (e.g. animated={{ animation: 'fadeIn' }}) whose reference
@@ -611,6 +596,21 @@ export const Streamdown = memo(
       }
       return createAnimatePlugin(animated as AnimateOptions);
     }, [animatedKey]);
+
+    // Generate stable keys based on index. Don't use content hash — that
+    // causes unmount/remount when content changes. When the animate plugin is
+    // active, also key on isAnimating so that when streaming ends and the
+    // plugin is removed from the rehype pipeline, React mounts fresh subtrees.
+    // Without this, memoized leaf components that compare only className +
+    // source position discard the span-free reparse. When animated is absent,
+    // skip the extra suffix — no spans exist to discard.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: "we're using the blocksToRender length"
+    const blockKeys = useMemo(() => {
+      const suffix = animatePlugin ? (isAnimating ? "a" : "s") : "";
+      return blocksToRender.map(
+        (_block, idx) => `${generatedId}-${idx}-${suffix}`
+      );
+    }, [blocksToRender.length, generatedId, isAnimating, animatePlugin]);
 
     // Combined context value - single object reduces React tree overhead
     const contextValue = useMemo<StreamdownContextType>(


### PR DESCRIPTION
## Description

Fix animation spans (`data-sd-animate`) persisting in the DOM after `isAnimating` goes false. Memoized leaf components (`MemoParagraph`, `MemoLi`, etc.) compare only `className` + source position and never compare children, so they discard the span-free reparse that Block produces when the animate rehype plugin is removed from the pipeline.

## Root cause

`Block` comparator correctly detects the rehype pipeline change and re-parses without the animate plugin. But the resulting span-free HAST never commits because leaf memo comparators (`sameClassAndNode`) see identical class + position and return "equal" — React throws away the new children.

## Fix

Include `isAnimating` in block keys. When streaming ends, keys change and React mounts fresh subtrees, allowing the span-free reparse to commit. During streaming (`isAnimating` stays true), keys are stable — no hot-path penalty.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #570

## Changes Made

- `packages/streamdown/index.tsx`: Include `isAnimating` in block key computation so React remounts fresh subtrees when the animate rehype plugin is removed
- `packages/streamdown/__tests__/animate-integration.test.tsx`: New integration test verifying spans are removed when `isAnimating` goes false
- `.changeset/clean-settled-animation-spans.md`: Patch changeset

## Testing

- [x] All existing tests pass (983/983, 74 files)
- [x] Added new integration test: `animate-integration.test.tsx`
- [x] RED confirmed: test fails without fix (19 spans persist)
- [x] GREEN confirmed: test passes with fix (0 spans)
- [x] No regressions in full test suite

## Checklist

- [x] My code follows the project code style
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset for these changes

## Additional Notes

The fix only affects the transition when `isAnimating` flips. During active streaming (isAnimating stays true), block keys remain stable — no extra remounting on the hot path. The one-time remount cost when streaming ends is negligible compared to the persistent DOM pollution of stale animation spans.