### PR TITLE
fix(ci): drop GitHub App token from verify-changesets

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -1,4 +1,4 @@
-# vercel/ai uses https://github.com/changesets/changesets for versioning and changelogs,
+# vercel/streamdown uses https://github.com/changesets/changesets for versioning and changelogs,
 # but is not following semantic versioning. Instead, it uses `patch` for both fixes
 # and features. It uses `minor` for "marketing releases", accompanied by a blog post and migration guide.
 # This workflow verifies that all `.changeset/*.md` files use `patch` unless a `minor-release` label is present.
@@ -21,17 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Generate GitHub App Token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.STREAMDOWN_APP_ID }}
-          private-key: ${{ secrets.STREAMDOWN_APP_PRIVATE_KEY }}
-      
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token }}
       
       - uses: actions/setup-node@v4
         with:
@@ -50,5 +42,4 @@ jobs:
         run: |
           node index.js
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CHANGED_FILES: ${{ steps.changeset-files.outputs.changed-files }}


### PR DESCRIPTION
## Summary

- Remove `actions/create-github-app-token` from `verify-changesets.yml`
- Checkout and verify with the default Actions token instead

## Why

Fork PRs run this workflow with `Secret source: None`, so:

```
Error: Input required and not supplied: app-id
```

That fails the job before checkout. The script only needs:

1. checkout of the PR branch
2. `CHANGED_FILES` from `git diff`
3. labels from `GITHUB_EVENT_PATH`

It never uses `GITHUB_TOKEN` / the GitHub API. The app token is only needed in `release.yml` (open Version Packages PRs, push, publish).

## Test plan

- [x] `node .github/workflows/actions/verify-changesets/test.js` (7/7)
- [ ] CI Verify Changesets passes on this PR (or is skipped if no changeset file changed — expected)
- [ ] Open/re-run a PR that touches `.changeset/*.md` and confirm verify-changesets succeeds without app secrets