### PR TITLE
fix(remend): drop lookbehind from single-tilde pattern for Safari < 16.3

### DIFF
--- a/.changeset/fix-lookbehind-safari-16-crash.md
+++ b/.changeset/fix-lookbehind-safari-16-crash.md
@@ -1,0 +1,7 @@
+---
+"remend": patch
+---
+
+Fix crash on iOS 16.0-16.2 / Safari < 16.3 by removing the lookbehind assertion from the single-tilde escape pattern (#519).
+
+JSCore on those versions doesn't support lookbehind (`(?<=...)`) and throws a `SyntaxError` while the module is being evaluated, before any user code runs, so there is no way to catch it. The preceding word character is now captured and written back in the replacement instead.

--- a/packages/remend/__tests__/single-tilde.test.ts
+++ b/packages/remend/__tests__/single-tilde.test.ts
@@ -42,4 +42,18 @@ describe("single tilde escape (#445)", () => {
   it("can be disabled via options", () => {
     expect(remend("20~25°C", { singleTilde: false })).toBe("20~25°C");
   });
+
+  it("should preserve Unicode letters around single ~", () => {
+    expect(remend("日本~語")).toBe("日本\\~語");
+    expect(remend("α~β")).toBe("α\\~β");
+    expect(remend("é~x")).toBe("é\\~x");
+  });
+
+  it("should preserve supplementary-plane Unicode letters around single ~", () => {
+    expect(remend("𐐀~a")).toBe("𐐀\\~a");
+  });
+
+  it("should escape multiple single tildes between letters", () => {
+    expect(remend("foo~bar~baz")).toBe("foo\\~bar\\~baz");
+  });
 });

--- a/packages/remend/src/single-tilde-handler.ts
+++ b/packages/remend/src/single-tilde-handler.ts
@@ -12,7 +12,9 @@ import { isInsideCodeBlock } from "./code-block-utils";
 // - NOT followed by another ~ (to avoid matching ~~)
 // - followed by a word character
 // Uses Unicode-aware \p{L} and \p{N} for CJK and other scripts
-const SINGLE_TILDE_PATTERN = /(?<=[\p{L}\p{N}_])~(?!~)(?=[\p{L}\p{N}_])/gu;
+// Captures the preceding char instead of using a lookbehind: Safari < 16.3
+// throws on lookbehind, which would crash at module evaluation (#519).
+const SINGLE_TILDE_PATTERN = /([\p{L}\p{N}_])~(?!~)(?=[\p{L}\p{N}_])/gu;
 
 export const handleSingleTildeEscape = (text: string): string => {
   if (!text || typeof text !== "string") {
@@ -24,12 +26,14 @@ export const handleSingleTildeEscape = (text: string): string => {
     return text;
   }
 
-  return text.replace(SINGLE_TILDE_PATTERN, (match, offset) => {
+  return text.replace(SINGLE_TILDE_PATTERN, (match, precedingChar, offset) => {
+    const tildeOffset = offset + precedingChar.length;
+
     // Don't escape inside code blocks
-    if (isInsideCodeBlock(text, offset)) {
+    if (isInsideCodeBlock(text, tildeOffset)) {
       return match;
     }
 
-    return "\\~";
+    return `${precedingChar}\\~`;
   });
 };


### PR DESCRIPTION
Refs #519.

## What

Removes the lookbehind assertion from `remend`'s single-tilde escape pattern:

```diff
-const SINGLE_TILDE_PATTERN = /(?<=[\p{L}\p{N}_])~(?!~)(?=[\p{L}\p{N}_])/gu;
+const SINGLE_TILDE_PATTERN = /([\p{L}\p{N}_])~(?!~)(?=[\p{L}\p{N}_])/gu;
```

The preceding word character is now captured and written back in the replacement, and the offset handed to `isInsideCodeBlock` is shifted by its length so it still points at the `~`. Semantics are unchanged — Unicode support (`\p{L}`, `\p{N}`, so CJK and other scripts) is fully preserved.

## Why

JSCore on iOS 16.0–16.2 / Safari < 16.3 does not support lookbehind and throws `SyntaxError: Invalid regular expression: invalid group specifier name`. Because the pattern is a module-level constant, this throws during module evaluation — before any user code runs — so the whole chunk fails to export and the page goes blank. There is no way for a consumer to catch it. Safari only shipped lookbehind in 16.4 ([caniuse](https://caniuse.com/js-regexp-lookbehind)).

## Scope

This PR deliberately only fixes `remend`. #519 identifies a second lookbehind in `mdast-util-gfm-autolink-literal@2`, pulled in via `remark-gfm@4`. That one is **not** addressed here, because the maintainer has stated the lookbehind is intentional and will not be changed: [syntax-tree/mdast-util-gfm-autolink-literal#10 (comment)](https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/issues/10#issuecomment-3330083240). Projects needing full iOS 16.0–16.2 support will have to patch that dependency themselves (`pnpm patch` / `patch-package`).

So this change does not single-handedly close #519 for every `streamdown` consumer. It does fix it outright for anyone depending on `remend` directly, without dragging in `remark-gfm` — which is my own use case, and the one bit of this that is squarely this repo's own code rather than a third party's.

## Testing

- `pnpm --filter remend test` — 458/458 pass, no changes needed to existing tests (behaviour is identical)
- `pnpm --filter streamdown test` — 991/991 pass
- `pnpm check` — clean
- Built `dist` output verified free of any `(?<` occurrences

Changeset included (`remend`, patch).
