### PR TITLE
fix(ci): use github-api commit mode for signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           version: pnpm changeset version
           publish: pnpm changeset publish
+          # github-api creates verified commits (required by repo rules);
+          # git-cli commits are unsigned and get rejected on push.
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: "" # Workaround for https://github.com/changesets/action/pull/545


### PR DESCRIPTION
## Summary

- Set `commitMode: github-api` on `changesets/action` so Version Packages commits are created via the GitHub API (verified / signed)
- Fixes Release failure after switching to `secrets.GITHUB_TOKEN`: repo rules reject unsigned `git-cli` commits (`Commits must have verified signatures`)

## Test plan

- [ ] Merge and confirm Release workflow pushes `changeset-release/main`
- [ ] Confirm Version Packages PR opens
- [ ] Confirm commit on that branch is verified