### PR TITLE
fix(remend): handle intraword asterisk closers

### DIFF
--- a/.changeset/fix-remend-intraword-asterisks.md
+++ b/.changeset/fix-remend-intraword-asterisks.md
@@ -1,0 +1,5 @@
+---
+"remend": patch
+---
+
+Preserve complete italic emphasis when a closing asterisk is followed by word text.

--- a/packages/remend/__tests__/intraword-asterisk.test.ts
+++ b/packages/remend/__tests__/intraword-asterisk.test.ts
@@ -7,15 +7,37 @@ describe("intraword asterisk emphasis", () => {
     "this is *real*ly good",
     "이것은 *기울임*으로 표시",
     "5*6*78",
+    // Trailing * after a closed run stays literal
+    "*foo*bar*", // preserve trailing * - same behavior as before
+    "a *b*c*", // preserve trailing * - same behavior as before
+    "a *b*c* d", // preserve trailing * - same behavior as before
+    "*b*c*", // preserve trailing * - same behavior as before
+    "*a* b*",
+    "a *b* c*",
+    "*a*b*c*d",
+    "x *y*z w",
+    "before *a*b after *c*",
   ])("keeps complete emphasis unchanged: %s", (text) => {
     expect(remend(text)).toBe(text);
   });
 
   it("leaves a lone intraword asterisk literal", () => {
     expect(remend("foo*bar")).toBe("foo*bar");
+    expect(remend("hello*world")).toBe("hello*world");
+    expect(remend("test*123*test")).toBe("test*123*test");
   });
 
   it("continues an active intraword emphasis chain", () => {
     expect(remend("*foo*bar*baz")).toBe("*foo*bar*baz*");
+    expect(remend("*file*name*ext")).toBe("*file*name*ext*");
+  });
+
+  it("completes a later incomplete run after a closed intraword pair", () => {
+    expect(remend("before *a*b after *c")).toBe("before *a*b after *c*");
+    expect(remend("*기울임*으로 *another")).toBe("*기울임*으로 *another*");
+  });
+
+  it("does not reopen after whitespace following a closed intraword pair", () => {
+    expect(remend("*foo* bar*baz")).toBe("*foo* bar*baz");
   });
 });

--- a/packages/remend/__tests__/intraword-asterisk.test.ts
+++ b/packages/remend/__tests__/intraword-asterisk.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import remend from "../src";
+
+describe("intraword asterisk emphasis", () => {
+  it.each([
+    "*foo*bar",
+    "this is *real*ly good",
+    "이것은 *기울임*으로 표시",
+    "5*6*78",
+  ])("keeps complete emphasis unchanged: %s", (text) => {
+    expect(remend(text)).toBe(text);
+  });
+
+  it("leaves a lone intraword asterisk literal", () => {
+    expect(remend("foo*bar")).toBe("foo*bar");
+  });
+
+  it("continues an active intraword emphasis chain", () => {
+    expect(remend("*foo*bar*baz")).toBe("*foo*bar*baz*");
+  });
+});

--- a/packages/remend/src/emphasis-handlers.ts
+++ b/packages/remend/src/emphasis-handlers.ts
@@ -73,13 +73,46 @@ const shouldSkipAsterisk = (
   return false;
 };
 
+const isWhitespaceChar = (char: string): boolean =>
+  char === " " || char === "\t" || char === "\n";
+
 const isWordInternalAsterisk = (prevChar: string, nextChar: string): boolean =>
   Boolean(prevChar && nextChar && isWordChar(prevChar) && isWordChar(nextChar));
 
+// Decide whether a candidate single-asterisk delimiter should participate in the
+// open/close parity count used by incomplete-italic completion.
+//
+// Intraword asterisks only count while resolving an active emphasis chain:
+// they can close an open run and may reopen within the same word after a close.
+// Cold (unmatched) intraword asterisks stay literal (hello*world / #189).
+// Trailing right-flanking-only markers after a closed run also stay literal
+// (*foo*bar* / a *b*c*).
+const shouldCountSingleAsterisk = (
+  prevChar: string,
+  nextChar: string,
+  count: number,
+  inWordAsteriskChain: boolean
+): { count: true; inWordAsteriskChain: boolean } | { count: false } => {
+  const isWordInternal = isWordInternalAsterisk(prevChar, nextChar);
+  const canOpen = Boolean(nextChar) && !isWhitespaceChar(nextChar);
+  const canClose = Boolean(prevChar) && !isWhitespaceChar(prevChar);
+
+  // Do not start emphasis from a cold word-internal asterisk.
+  if (isWordInternal && count % 2 === 0 && !inWordAsteriskChain) {
+    return { count: false };
+  }
+
+  // Prefer closing an active run; only open when left-flanking.
+  if ((canClose && count % 2 === 1) || canOpen) {
+    return { count: true, inWordAsteriskChain: isWordInternal };
+  }
+
+  return { count: false };
+};
+
 // OPTIMIZATION: Counts single asterisks without split("").reduce()
-// Counts single asterisks that are not part of double asterisks, escaped, or list markers.
-// Intraword asterisks are counted only while resolving an active emphasis chain,
-// and not inside fenced code blocks
+// Counts single asterisks that are not part of double asterisks, escaped, or list markers,
+// and not inside fenced code blocks.
 export const countSingleAsterisks = (text: string): number => {
   let count = 0;
   let inCodeBlock = false;
@@ -114,18 +147,19 @@ export const countSingleAsterisks = (text: string): number => {
     const prevChar = index > 0 ? text[index - 1] : "";
     const nextChar = index < len - 1 ? text[index + 1] : "";
 
-    const isWordInternal = isWordInternalAsterisk(prevChar, nextChar);
-
-    // An intraword asterisk can close an open emphasis run. Once it does,
-    // another intraword asterisk in the same word can start a new run.
-    // A lone intraword asterisk remains literal.
-    if (isWordInternal && count % 2 === 0 && !inWordAsteriskChain) {
+    if (shouldSkipAsterisk(text, index, prevChar, nextChar)) {
       continue;
     }
 
-    if (!shouldSkipAsterisk(text, index, prevChar, nextChar)) {
+    const decision = shouldCountSingleAsterisk(
+      prevChar,
+      nextChar,
+      count,
+      inWordAsteriskChain
+    );
+    if (decision.count) {
       count += 1;
-      inWordAsteriskChain = isWordInternal;
+      inWordAsteriskChain = decision.inWordAsteriskChain;
     }
   }
 
@@ -496,21 +530,25 @@ const findFirstSingleAsteriskIndex = (text: string): number => {
       const nextChar = i < text.length - 1 ? text[i + 1] : "";
 
       // Skip if flanked by whitespace on both sides (not a valid emphasis delimiter)
-      const prevIsWs =
-        !prevChar || prevChar === " " || prevChar === "\t" || prevChar === "\n";
-      const nextIsWs =
-        !nextChar || nextChar === " " || nextChar === "\t" || nextChar === "\n";
+      const prevIsWs = !prevChar || isWhitespaceChar(prevChar);
+      const nextIsWs = !nextChar || isWhitespaceChar(nextChar);
       if (prevIsWs && nextIsWs) {
         continue;
       }
 
-      // Check if asterisk is word-internal (between word characters)
+      // Skip cold word-internal asterisks; they are not openers for completion.
+      // (Active-run closers are still counted in countSingleAsterisks.)
       if (
         prevChar &&
         nextChar &&
         isWordChar(prevChar) &&
         isWordChar(nextChar)
       ) {
+        continue;
+      }
+
+      // A right-flanking-only marker cannot open incomplete italic.
+      if (nextIsWs) {
         continue;
       }
 

--- a/packages/remend/src/emphasis-handlers.ts
+++ b/packages/remend/src/emphasis-handlers.ts
@@ -60,11 +60,6 @@ const shouldSkipAsterisk = (
     return true;
   }
 
-  // Skip if asterisk is word-internal (between word characters)
-  if (prevChar && nextChar && isWordChar(prevChar) && isWordChar(nextChar)) {
-    return true;
-  }
-
   // Skip if flanked by whitespace on both sides (not a valid emphasis delimiter per CommonMark)
   // This also catches list markers (e.g., "* item") since they have whitespace on both sides
   const prevIsWhitespace =
@@ -78,12 +73,17 @@ const shouldSkipAsterisk = (
   return false;
 };
 
+const isWordInternalAsterisk = (prevChar: string, nextChar: string): boolean =>
+  Boolean(prevChar && nextChar && isWordChar(prevChar) && isWordChar(nextChar));
+
 // OPTIMIZATION: Counts single asterisks without split("").reduce()
-// Counts single asterisks that are not part of double asterisks, not escaped, not list markers, not word-internal,
+// Counts single asterisks that are not part of double asterisks, escaped, or list markers.
+// Intraword asterisks are counted only while resolving an active emphasis chain,
 // and not inside fenced code blocks
 export const countSingleAsterisks = (text: string): number => {
   let count = 0;
   let inCodeBlock = false;
+  let inWordAsteriskChain = false;
   const len = text.length;
 
   for (let index = 0; index < len; index += 1) {
@@ -105,14 +105,27 @@ export const countSingleAsterisks = (text: string): number => {
     }
 
     if (text[index] !== "*") {
+      if (!isWordChar(text[index])) {
+        inWordAsteriskChain = false;
+      }
       continue;
     }
 
     const prevChar = index > 0 ? text[index - 1] : "";
     const nextChar = index < len - 1 ? text[index + 1] : "";
 
+    const isWordInternal = isWordInternalAsterisk(prevChar, nextChar);
+
+    // An intraword asterisk can close an open emphasis run. Once it does,
+    // another intraword asterisk in the same word can start a new run.
+    // A lone intraword asterisk remains literal.
+    if (isWordInternal && count % 2 === 0 && !inWordAsteriskChain) {
+      continue;
+    }
+
     if (!shouldSkipAsterisk(text, index, prevChar, nextChar)) {
       count += 1;
+      inWordAsteriskChain = isWordInternal;
     }
   }
 


### PR DESCRIPTION
## Description

Fixes `remend`'s emphasis counter when a valid closing `*` is followed immediately by word text, as in `*foo*bar`.

Previously, every word-internal asterisk was skipped. That left a valid emphasis run counted as open and caused `remend` to append a spurious trailing `*`. Word-internal asterisks now remain literal when no run is active, but can close an active run and continue a same-word streaming emphasis chain.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #577

## Changes Made

- Count a word-internal `*` when it closes an active emphasis run.
- Preserve unmatched word-internal asterisks as literal text.
- Add English, Korean, CommonMark, literal-marker, and streaming-chain regression cases.
- Add a patch changeset for `remend`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [ ] Manually tested the changes

### Test Coverage

Fresh GitHub Actions validation passed on `9dcb540b51620b9f72c2cec1c90d728ed3e8eb5c`:

- Verify Changesets
- Install dependencies
- Build packages
- Build website
- Run tests
- Check linting and formatting

## Screenshots/Demos

Not applicable; this change is covered at the string-processing layer.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] I have created a changeset for these changes

## Additional Notes

Prepared with OpenAI assistance. The issue context, final diff, regression coverage, and fresh CI results were reviewed before submission.