### PR TITLE
fix: update streamed code block content

### DIFF
--- a/.changeset/fresh-code-blocks-update.md
+++ b/.changeset/fresh-code-blocks-update.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Fix streamed code blocks remaining stale when their content changes without moving in the document.

--- a/packages/streamdown/__tests__/code-block-memo.test.tsx
+++ b/packages/streamdown/__tests__/code-block-memo.test.tsx
@@ -18,6 +18,30 @@ vi.mock("../lib/code-block", () => ({
 }));
 
 describe("MemoCode in streaming mode", () => {
+  it("should re-render code blocks when their content changes in place", async () => {
+    codeBlockRenderCount = 0;
+
+    const initial = "```js\nfirst\n```";
+    const updated = "```js\nsecond\n```";
+
+    const { container, rerender } = render(<Streamdown>{initial}</Streamdown>);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("first");
+    });
+
+    const initialRenderCount = codeBlockRenderCount;
+
+    rerender(<Streamdown>{updated}</Streamdown>);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("second");
+    });
+
+    expect(container.textContent).not.toContain("first");
+    expect(codeBlockRenderCount).toBeGreaterThan(initialRenderCount);
+  });
+
   it("should not re-render unchanged code blocks on streaming updates", async () => {
     codeBlockRenderCount = 0;
 

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -89,6 +89,38 @@ function sameClassAndNode(
   );
 }
 
+function getCodeContent(children: React.ReactNode): string | undefined {
+  if (typeof children === "string") {
+    return children;
+  }
+
+  if (
+    isValidElement(children) &&
+    children.props &&
+    typeof children.props === "object" &&
+    "children" in children.props &&
+    typeof children.props.children === "string"
+  ) {
+    return children.props.children;
+  }
+
+  return undefined;
+}
+
+function sameCodeContent(
+  prev: React.ReactNode,
+  next: React.ReactNode
+): boolean {
+  const prevContent = getCodeContent(prev);
+  const nextContent = getCodeContent(next);
+
+  if (prevContent === undefined && nextContent === undefined) {
+    return prev === next;
+  }
+
+  return prevContent === nextContent;
+}
+
 const shouldShowControls = (
   config: ControlsConfig,
   type: "table" | "code" | "mermaid" | "image"
@@ -852,19 +884,7 @@ const CodeComponent = ({
     : false;
   const showLineNumbers = !metaNoLineNumbers && contextLineNumbers !== false;
 
-  // Extract code content from children safely
-  let code = "";
-  if (
-    isValidElement(children) &&
-    children.props &&
-    typeof children.props === "object" &&
-    "children" in children.props &&
-    typeof children.props.children === "string"
-  ) {
-    code = children.props.children;
-  } else if (typeof children === "string") {
-    code = children;
-  }
+  const code = getCodeContent(children) ?? "";
 
   if (customRenderer) {
     const CustomComponent = customRenderer.component;
@@ -981,7 +1001,10 @@ const MemoCode = memo<
   DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & ExtraProps
 >(
   CodeComponent,
-  (p, n) => p.className === n.className && sameNodePosition(p.node, n.node)
+  (p, n) =>
+    p.className === n.className &&
+    sameNodePosition(p.node, n.node) &&
+    sameCodeContent(p.children, n.children)
 );
 MemoCode.displayName = "MarkdownCode";
 


### PR DESCRIPTION
## Summary

- include rendered code content in the Markdown code memo comparison
- reuse the same content extraction for rendering and memoization
- add a regression test for replacing a streamed fenced block in place

## Why

`MemoCode` previously compared only `className` and source position. Replacing a streamed code block without moving it in the document, such as changing `first` to `second`, kept the same source position and caused React to retain the stale rendered code. Comparing the extracted code text preserves the existing optimization for unchanged blocks while allowing changed blocks to update.

## Validation

- `pnpm build:packages`
- `pnpm --filter streamdown test` (73 files, 1,019 tests)
- `pnpm check`
- `pnpm --filter streamdown build`
