### PR TITLE
fix: re-render memoized components when their output changes

### DIFF
--- a/.changeset/memo-render-equivalence.md
+++ b/.changeset/memo-render-equivalence.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Re-render memoized markdown components when their rendered output changes. The comparators compared source position, so a replacement of the same length — occupying the same lines and columns — was treated as unchanged and the component kept rendering the previous text.

--- a/packages/streamdown/__benchmarks__/streaming-rerender.bench.tsx
+++ b/packages/streamdown/__benchmarks__/streaming-rerender.bench.tsx
@@ -1,0 +1,71 @@
+/**
+ * The markdown components are memoized, so the cost of their comparators shows
+ * up on the streaming path — mount once, then re-render as the text grows — and
+ * not in the parse benchmarks. This measures that path directly.
+ */
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { bench, describe } from "vitest";
+import { Streamdown } from "../index";
+
+const PROSE = `# Quarterly review
+
+Revenue grew across every region this quarter, with **enterprise** leading and
+*self-serve* close behind. See the [summary](https://example.com) for detail.
+
+- Enterprise: up 18%
+- Self-serve: up 11%
+- Partner: flat
+
+> Retention held at 94%.
+
+| Region | Growth |
+| ------ | ------ |
+| NA     | 14%    |
+| EMEA   | 9%     |
+`;
+
+const WITH_CODE = `${PROSE}
+\`\`\`ts
+export const rate = (a: number, b: number) => a / b;
+\`\`\`
+`;
+
+const TAIL_WORDS =
+  "and the trailing narrative continues to arrive one token at a time until the block is finally complete".split(
+    " "
+  );
+
+function streamInto(document: string, steps: number) {
+  const host = window.document.createElement("div");
+  window.document.body.appendChild(host);
+  const root = createRoot(host);
+
+  flushSync(() => {
+    root.render(<Streamdown>{document}</Streamdown>);
+  });
+
+  let tail = "";
+  for (let i = 0; i < steps; i++) {
+    tail += `${TAIL_WORDS[i % TAIL_WORDS.length]} `;
+    flushSync(() => {
+      root.render(<Streamdown>{`${document}\n\n${tail}`}</Streamdown>);
+    });
+  }
+
+  flushSync(() => {
+    root.unmount();
+  });
+  host.remove();
+}
+
+describe("Streaming re-render", () => {
+  bench("prose document, 20 streaming appends", () => {
+    streamInto(PROSE, 20);
+  });
+
+  bench("document with a code block, 20 streaming appends", () => {
+    streamInto(WITH_CODE, 20);
+  });
+});

--- a/packages/streamdown/__tests__/list-animation-retrigger.test.tsx
+++ b/packages/streamdown/__tests__/list-animation-retrigger.test.tsx
@@ -7,12 +7,16 @@
  * for ALL text — including already-visible content — causing those characters to
  * re-run their CSS entry animation.
  *
- * Fix: two layers of protection:
- * 1. Memo'd list components (MemoLi, MemoUl, etc.) prevent re-rendering when
- *    the node position hasn't changed — existing spans stay in the DOM.
- * 2. When the node position DOES change (e.g., during streaming as text grows),
- *    the animate plugin tracks prevContentLength and sets --sd-duration:0ms for
- *    text-node positions that were already rendered in the previous pass.
+ * Fix: the animate plugin tracks prevContentLength and sets --sd-duration:0ms for
+ * text-node positions that were already rendered in the previous pass, so
+ * already-visible characters do not re-run their entry animation even when the
+ * spans around them are rebuilt.
+ *
+ * This used to be described as two layers, the first being that the memo'd list
+ * components skipped re-rendering while the node position was unchanged. That
+ * layer was not sound: a list whose shape changes (tight -> loose) keeps its
+ * source positions, so skipping meant rendering markup that no longer matched the
+ * markdown. The suppression layer is what the reported symptom actually needs.
  */
 
 import { act, render } from "@testing-library/react";
@@ -57,16 +61,37 @@ describe("list animation retrigger fix (#410)", () => {
 
     const afterSpans = Array.from(
       container.querySelectorAll("[data-sd-animate]")
-    );
+    ) as HTMLElement[];
 
     // There should be MORE spans after (new item appeared)
     expect(afterSpans.length).toBeGreaterThan(initialSpans.length);
 
-    // All original spans should still be in the document (not remounted)
-    const remountedCount = initialSpans.filter(
-      (s) => !container.contains(s)
-    ).length;
-    expect(remountedCount).toBe(0);
+    // The list is loose once a second group appears, so the items are rebuilt
+    // around a <p>. What must not happen is the already-visible text re-running
+    // its entry animation: those characters carry --sd-duration:0ms.
+    expect(container.querySelector("li > p")).toBeTruthy();
+
+    // One character at the transition boundary is not suppressed:
+    // prevContentLength counts inter-element whitespace, and the tight -> loose
+    // change alters how much of it the block contains, so the boundary lands one
+    // character early. That accounting lives in lib/animate.ts and is unchanged
+    // here; before this test was updated the transition was never rendered at
+    // all, so it could not be observed.
+    const previouslyVisible = afterSpans.slice(0, initialSpans.length - 1);
+    for (const span of previouslyVisible) {
+      expect(
+        (span as HTMLElement).style.getPropertyValue("--sd-duration")
+      ).toBe("0ms");
+    }
+
+    // And the newly arrived text does animate.
+    const arrived = afterSpans.slice(initialSpans.length);
+    expect(arrived.length).toBeGreaterThan(0);
+    for (const span of arrived) {
+      expect(
+        (span as HTMLElement).style.getPropertyValue("--sd-duration")
+      ).toBe("700ms");
+    }
   });
 
   it("sets --sd-duration:0ms on already-rendered content when item text grows", async () => {

--- a/packages/streamdown/__tests__/memo-render-equivalence.test.tsx
+++ b/packages/streamdown/__tests__/memo-render-equivalence.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * The default markdown components are memoized. The contract those comparators
+ * have to honour is:
+ *
+ *   a memoized markup component may skip rendering only when every prop capable
+ *   of changing its rendered output is equivalent.
+ *
+ * Comparing source position instead is not equivalent. A replacement of the same
+ * length occupies the same lines and columns, so a position-based comparator
+ * reports "unchanged" for content that changed and the component keeps rendering
+ * the previous text.
+ *
+ * These tests assert BOTH directions: changed output must commit, and an
+ * unchanged block must still skip, so a correctness fix here cannot quietly
+ * become "always re-render".
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import type { Root } from "hast";
+import type { ReactNode } from "react";
+import { visit } from "unist-util-visit";
+import { describe, expect, it, vi } from "vitest";
+import { Streamdown } from "../index";
+
+describe("memoized components re-render when their output changes", () => {
+  it("updates paragraph text after a same-length edit", async () => {
+    const before = "Revenue grew";
+    const after = "Booking grew";
+    expect(after).toHaveLength(before.length);
+
+    const { container, rerender } = render(<Streamdown>{before}</Streamdown>);
+    await waitFor(() => expect(container.textContent).toContain("Revenue"));
+
+    rerender(<Streamdown>{after}</Streamdown>);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Booking");
+    });
+    expect(container.textContent).not.toContain("Revenue");
+  });
+
+  it("updates heading text after a same-length edit", async () => {
+    const before = "# Revenue growth\n\nUnchanged body";
+    const after = "# Booking growth\n\nUnchanged body";
+    expect(after).toHaveLength(before.length);
+
+    const { container, rerender } = render(<Streamdown>{before}</Streamdown>);
+    await waitFor(() =>
+      expect(container.querySelector("h1")?.textContent).toBe("Revenue growth")
+    );
+
+    rerender(<Streamdown>{after}</Streamdown>);
+
+    await waitFor(() => {
+      expect(container.querySelector("h1")?.textContent).toBe("Booking growth");
+    });
+  });
+
+  it("updates list item and strong text after a same-length edit", async () => {
+    const before = "- **Revenue** is up\n- Unchanged";
+    const after = "- **Booking** is up\n- Unchanged";
+    expect(after).toHaveLength(before.length);
+
+    const { container, rerender } = render(<Streamdown>{before}</Streamdown>);
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-streamdown="strong"]')?.textContent
+      ).toBe("Revenue")
+    );
+
+    rerender(<Streamdown>{after}</Streamdown>);
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-streamdown="strong"]')?.textContent
+      ).toBe("Booking");
+    });
+  });
+
+  it("drops animation spans once the stream settles (issue #570)", async () => {
+    // The animate plugin is excluded from the pipeline when isAnimating goes
+    // false, so the block re-parses without the per-word spans. The source text
+    // is identical, so every element keeps its position — which is why a
+    // position-based comparator discards the span-free re-parse and the spans
+    // stay in the DOM for the life of the page.
+    const animated = {
+      animation: "fadeIn",
+      duration: 200,
+      easing: "ease-out",
+      sep: "word",
+      stagger: 0,
+    } as const;
+    const markdown =
+      "First paragraph with several words here.\n\nSecond paragraph also has words.";
+
+    const { container, rerender } = render(
+      <Streamdown animated={animated} isAnimating>
+        {markdown}
+      </Streamdown>
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll("[data-sd-animate]").length
+      ).toBeGreaterThan(0)
+    );
+
+    rerender(
+      <Streamdown animated={animated} isAnimating={false}>
+        {markdown}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(0);
+    });
+  });
+
+  it("keeps every element describing the version on screen after an insertion above it", async () => {
+    // An insertion earlier in the document moves everything below it. The text
+    // is unchanged, so nothing below may be re-rendered from the previous pass
+    // while carrying attributes derived from the new parse.
+    const offsets = () => (tree: Root) => {
+      visit(tree, "element", (node) => {
+        const start = node.position?.start?.offset;
+        if (start !== undefined) {
+          node.properties = { ...node.properties, "data-start": String(start) };
+        }
+      });
+    };
+    const head = "Intro paragraph";
+    const tail = "\n\n## Section\n\n> Quote here";
+
+    const { container, rerender } = render(
+      <Streamdown mode="static" rehypePlugins={[offsets]}>
+        {head + tail}
+      </Streamdown>
+    );
+    await waitFor(() => expect(container.querySelector("h2")).toBeTruthy());
+
+    const startBefore = Number(
+      container.querySelector("h2")?.getAttribute("data-start")
+    );
+
+    const inserted = "0123456789"; // ten bytes, no new lines
+    rerender(
+      <Streamdown mode="static" rehypePlugins={[offsets]}>
+        {head + inserted + tail}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      const startAfter = Number(
+        container.querySelector("h2")?.getAttribute("data-start")
+      );
+      expect(startAfter).toBe(startBefore + inserted.length);
+    });
+  });
+});
+
+describe("memoized components still skip when their output is unchanged", () => {
+  it("does not re-render a code block while a different block streams", async () => {
+    let renders = 0;
+    vi.doMock("../lib/code-block", () => ({
+      CodeBlock: ({
+        code,
+        children,
+      }: {
+        code: string;
+        children?: ReactNode;
+      }) => {
+        renders += 1;
+        return (
+          <div data-testid="mock-code-block">
+            <pre>{code}</pre>
+            {children}
+          </div>
+        );
+      },
+    }));
+    vi.resetModules();
+    const { Streamdown: Fresh } = await import("../index");
+
+    const code = "```js\nconst a = 1;\n```\n\n";
+    const { container, rerender } = render(<Fresh>{`${code}Streaming`}</Fresh>);
+    await waitFor(() =>
+      expect(container.textContent).toContain("const a = 1;")
+    );
+
+    const baseline = renders;
+    expect(baseline).toBeGreaterThan(0);
+
+    for (const suffix of [
+      " one",
+      " one two",
+      " one two three",
+      " one two three four",
+    ]) {
+      rerender(<Fresh>{`${code}Streaming${suffix}`}</Fresh>);
+      await waitFor(() =>
+        expect(container.textContent).toContain(`Streaming${suffix}`)
+      );
+    }
+
+    expect(renders).toBe(baseline);
+    vi.doUnmock("../lib/code-block");
+  });
+});

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -39,22 +39,8 @@ const Mermaid = lazy(() =>
 
 const LANGUAGE_REGEX = /language-([^\s]+)/;
 
-interface MarkdownPoint {
-  column?: number;
-  line?: number;
-}
-interface MarkdownPosition {
-  end?: MarkdownPoint;
-  start?: MarkdownPoint;
-}
 interface MarkdownNode {
-  position?: MarkdownPosition;
-  properties?: {
-    className?: string;
-    /** Present while the animate plugin is wrapping this node's text. */
-    "data-sd-animated"?: boolean | string | null;
-    metastring?: string;
-  };
+  properties?: { className?: string; metastring?: string };
 }
 
 type WithNode<T> = T & {
@@ -63,40 +49,62 @@ type WithNode<T> = T & {
   className?: string;
 };
 
-function sameNodePosition(prev?: MarkdownNode, next?: MarkdownNode): boolean {
-  if (!(prev?.position || next?.position)) {
-    return true;
-  }
-  if (!(prev?.position && next?.position)) {
+// Shared comparators
+
+/**
+ * The `node` prop is a fresh object on every parse, so comparing it by identity
+ * would defeat memoization entirely. Nothing here renders it directly; the one
+ * value read off it that reaches the output — a code fence's meta string — is
+ * compared explicitly by `sameCodeMeta` below.
+ */
+const IGNORED_PROP = "node";
+
+/**
+ * A memoized markup component may skip rendering only when every prop capable of
+ * changing its rendered output is equivalent.
+ *
+ * This is React's own shallow prop comparison — what `memo` does with no
+ * comparator at all — minus the `node` prop. Source position is not a substitute:
+ * a replacement of the same length occupies the same lines and columns, so a
+ * position-based comparator reports "unchanged" for content that changed and the
+ * component keeps rendering the previous text.
+ *
+ * The skip that matters is not lost. An unchanged block is memoized a level up
+ * and is never re-rendered, so these comparators only run for a block that was
+ * re-parsed — exactly the case where the output can differ.
+ */
+function sameRenderedProps(prev: object, next: object): boolean {
+  const prevKeys = Object.keys(prev);
+
+  if (prevKeys.length !== Object.keys(next).length) {
     return false;
   }
 
-  const prevStart = prev.position.start;
-  const nextStart = next.position.start;
-  const prevEnd = prev.position.end;
-  const nextEnd = next.position.end;
+  const prevRecord = prev as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
 
-  return (
-    prevStart?.line === nextStart?.line &&
-    prevStart?.column === nextStart?.column &&
-    prevEnd?.line === nextEnd?.line &&
-    prevEnd?.column === nextEnd?.column
-  );
+  for (const key of prevKeys) {
+    if (key === IGNORED_PROP) {
+      continue;
+    }
+    if (!Object.is(prevRecord[key], nextRecord[key])) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
-// Shared comparators. Also compares data-sd-animated so that turning the
-// animate plugin off (isAnimating→false) commits the span-free reparse
-// without a subtree remount key on Markdown (#570).
-function sameClassAndNode(
-  prev: { className?: string; node?: MarkdownNode },
-  next: { className?: string; node?: MarkdownNode }
-) {
-  return (
-    prev.className === next.className &&
-    sameNodePosition(prev.node, next.node) &&
-    !!prev.node?.properties?.["data-sd-animated"] ===
-      !!next.node?.properties?.["data-sd-animated"]
-  );
+/**
+ * A code fence's meta string (```ts startLine=10) changes the rendered output
+ * without changing the code element's children or className, so it is the one
+ * part of `node` that has to participate in the comparison.
+ */
+function sameCodeMeta(
+  prev?: { properties?: { metastring?: unknown } },
+  next?: { properties?: { metastring?: unknown } }
+): boolean {
+  return prev?.properties?.metastring === next?.properties?.metastring;
 }
 
 const shouldShowControls = (
@@ -211,7 +219,7 @@ const MemoOl = memo<OlProps>(
       </ol>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoOl.displayName = "MarkdownOl";
 
@@ -230,7 +238,7 @@ const MemoLi = memo<LiProps>(
       </li>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoLi.displayName = "MarkdownLi";
 
@@ -251,7 +259,7 @@ const MemoUl = memo<UlProps>(
       </ul>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoUl.displayName = "MarkdownUl";
 
@@ -267,7 +275,7 @@ const MemoHr = memo<HrProps>(
       />
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoHr.displayName = "MarkdownHr";
 
@@ -285,7 +293,7 @@ const MemoStrong = memo<StrongProps>(
       </span>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoStrong.displayName = "MarkdownStrong";
 
@@ -384,10 +392,7 @@ const LinkComponent = ({
   );
 };
 
-const MemoA = memo<AProps>(
-  LinkComponent,
-  (p, n) => sameClassAndNode(p, n) && p.href === n.href
-);
+const MemoA = memo<AProps>(LinkComponent, (p, n) => sameRenderedProps(p, n));
 MemoA.displayName = "MarkdownA";
 
 type HeadingProps<TTag extends keyof JSX.IntrinsicElements> = WithNode<
@@ -407,7 +412,7 @@ const MemoH1 = memo<HeadingProps<"h1">>(
       </h1>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoH1.displayName = "MarkdownH1";
 
@@ -424,7 +429,7 @@ const MemoH2 = memo<HeadingProps<"h2">>(
       </h2>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoH2.displayName = "MarkdownH2";
 
@@ -441,7 +446,7 @@ const MemoH3 = memo<HeadingProps<"h3">>(
       </h3>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoH3.displayName = "MarkdownH3";
 
@@ -458,7 +463,7 @@ const MemoH4 = memo<HeadingProps<"h4">>(
       </h4>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoH4.displayName = "MarkdownH4";
 
@@ -475,7 +480,7 @@ const MemoH5 = memo<HeadingProps<"h5">>(
       </h5>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoH5.displayName = "MarkdownH5";
 
@@ -492,7 +497,7 @@ const MemoH6 = memo<HeadingProps<"h6">>(
       </h6>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoH6.displayName = "MarkdownH6";
 
@@ -520,7 +525,7 @@ const MemoTable = memo<TableComponentProps>(
       </Table>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoTable.displayName = "MarkdownTable";
 
@@ -538,7 +543,7 @@ const MemoThead = memo<TheadProps>(
       </thead>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoThead.displayName = "MarkdownThead";
 
@@ -556,7 +561,7 @@ const MemoTbody = memo<TbodyProps>(
       </tbody>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoTbody.displayName = "MarkdownTbody";
 
@@ -574,7 +579,7 @@ const MemoTr = memo<TrProps>(
       </tr>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoTr.displayName = "MarkdownTr";
 
@@ -595,7 +600,7 @@ const MemoTh = memo<ThProps>(
       </th>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoTh.displayName = "MarkdownTh";
 
@@ -613,7 +618,7 @@ const MemoTd = memo<TdProps>(
       </td>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoTd.displayName = "MarkdownTd";
 
@@ -634,7 +639,7 @@ const MemoBlockquote = memo<BlockquoteProps>(
       </blockquote>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoBlockquote.displayName = "MarkdownBlockquote";
 
@@ -652,7 +657,7 @@ const MemoSup = memo<SupProps>(
       </sup>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoSup.displayName = "MarkdownSup";
 
@@ -670,7 +675,7 @@ const MemoSub = memo<SubProps>(
       </sub>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoSub.displayName = "MarkdownSub";
 
@@ -804,7 +809,7 @@ const MemoSection = memo<SectionProps>(
       </section>
     );
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoSection.displayName = "MarkdownSection";
 
@@ -993,7 +998,7 @@ const MemoCode = memo<
   DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & ExtraProps
 >(
   CodeComponent,
-  (p, n) => p.className === n.className && sameNodePosition(p.node, n.node)
+  (p, n) => sameRenderedProps(p, n) && sameCodeMeta(p.node, n.node)
 );
 MemoCode.displayName = "MarkdownCode";
 
@@ -1020,10 +1025,7 @@ const ImageWrapper = ({ node, className, ...props }: ImgProps) => {
   );
 };
 
-const MemoImg = memo<ImgProps>(
-  ImageWrapper,
-  (p, n) => p.className === n.className && sameNodePosition(p.node, n.node)
-);
+const MemoImg = memo<ImgProps>(ImageWrapper, (p, n) => sameRenderedProps(p, n));
 
 MemoImg.displayName = "MarkdownImg";
 
@@ -1065,7 +1067,7 @@ const MemoParagraph = memo<ParagraphProps>(
 
     return <p {...props}>{children}</p>;
   },
-  (p, n) => sameClassAndNode(p, n)
+  (p, n) => sameRenderedProps(p, n)
 );
 MemoParagraph.displayName = "MarkdownParagraph";
 


### PR DESCRIPTION
## The contract

A memoized markup component may skip rendering only when every prop capable of changing its rendered output is equivalent.

The default components memoize on `className` plus the source position of their hast node. Source position is a proxy for render state, and it is not a sound one.

## The bug

A replacement of the same length occupies the same lines and the same columns, so the comparator reports "unchanged" for content that changed. The component keeps rendering the previous text. No plugins, no custom components — this is `<Streamdown>` with default settings, on `main` at `3327c18`:

```tsx
const { container, rerender } = render(<Streamdown>{"Revenue grew"}</Streamdown>);
rerender(<Streamdown>{"Booking grew"}</Streamdown>);   // same length

container.textContent; // "Revenue grew"
```

Same for a heading, a list item and a `<strong>` run — I re-ran all four against `main` after #581 landed, and all four are still stale. Table cells and blockquotes behave the same way. `p` is not exempt either: the paragraph above is a `MemoParagraph`.

## Relation to #581

#581 fixed #570 by having the animate plugin stamp `data-sd-animated` on ancestors and adding that stamp as a third conjunct to `sameClassAndNode`. That closes the animation-state transition it targets, and this PR keeps it closed — `__tests__/animate-issues.test.tsx` passes here **unmodified**, because the stamp is delivered as a prop and a shallow prop comparison therefore includes it for free.

What #581 does not change is the proxy itself. Position is still standing in for render state for every non-animated path, which is why the repro above survives it. #570 was one manifestation of that class; this PR closes the class.

## The change

`sameClassAndNode` becomes React's own shallow prop comparison — what `memo` does with no comparator at all — minus the `node` prop, which is a fresh object on every parse and would defeat memoization if compared by identity. The one value read off `node` that reaches the output, a code fence's meta string, is compared explicitly by `MemoCode`.

Three components inlined the position expression instead of calling the helper (`MemoLi`, `MemoCode`, `MemoImg`); they now use it too. `MemoA` no longer needs its extra `href` conjunct, because `href` is a prop.

## This is not "removing the memo"

The skip that matters is a level up. An unchanged block is memoized by `Block` and is never re-rendered, so these comparators only run for a block that was re-parsed — exactly the case where the output can differ. `__tests__/code-block-memo.test.tsx` is unmodified and still green.

The new tests assert both directions, so this cannot quietly become "always re-render":

| Case | Expectation | On `main` |
|---|---|---|
| Same position, different rendered text | re-renders | ❌ stale |
| Same position, animate plugin removed (#570) | spans come off | ✅ since #581 |
| Insertion above shifts positions below | attributes describe the current parse | ❌ stale |
| Edit in a *different* block | code block does **not** re-render | ✅ (unchanged) |

## Benchmarks

Added `__benchmarks__/streaming-rerender.bench.tsx`, because the existing benchmarks measure parsing and this change does not touch the parser — the comparators only cost anything on the mount-then-re-render path.

Interleaved A/B against `main` at `3327c18`, 5 pairs each, medians of hz (higher is better):

| Benchmark | `main` | this branch |
|---|---|---|
| prose document, 20 streaming appends | 98.0 | 96.5 |
| document with a code block, 20 streaming appends | 128.5 | 128.1 |

Run-to-run spread within a single arm was larger than the gap between arms, so I would read this as no measurable difference rather than as a win or a loss.

The comparator itself is slower per call, as expected — it allocates a key list where the old one compared four scalars:

| Comparator | equal props (skip path) | changed children |
|---|---|---|
| old, position-based | 8.7M ops/s | 11.4M ops/s |
| new, shallow props | 5.0M ops/s | 8.7M ops/s |

That is ~0.1µs more per comparison. A document with fifty elements re-rendering twenty times a second spends about 100µs/s more in comparators, which is why it does not show up end to end.

## One test changed, and it is worth a look

`__tests__/list-animation-retrigger.test.tsx` (#410) asserted that the `data-sd-animate` span objects survive a tight → loose list transition. They survived because the transition was **never rendered**: the list keeps its source positions, so `MemoLi` skipped and the DOM kept a tight list for markdown that had become loose.

With this change the transition renders, so the spans are rebuilt. What #410 actually reported — already-visible characters re-running their entry animation — is still prevented, by the second layer the same file documents: `prevContentLength` sets `--sd-duration: 0ms` for text already rendered. So the test now asserts durations rather than object identity, and additionally asserts the loose list actually renders.

One caveat I would rather flag than bury: at that transition, one character at the boundary is **not** suppressed and re-animates. The character accounting in `lib/animate.ts` counts inter-element whitespace, and tight → loose changes how much of it the block contains, so the boundary lands one character early. Ordinary streaming appends are unaffected. That accounting is untouched here; it was simply unreachable before, because the block never re-rendered — and I re-confirmed it is still one character off on top of #581's rewritten animate pipeline.

## Relation to other open work

- #538 — same defect, and adding `offset` to the position comparison does not cover it: a same-length replacement moves no offset either.
- Happy to split, reshape, or drop the `MemoImg`/`MemoLi` consolidation if you would rather keep those comparators inline.

---

Rebased onto `main` at `3327c18` (post-#581). Verified with `pnpm build:packages`, `vitest run` (79 files, 1076 tests, all green including #581's animation suites), `biome check` on the changed files.
