### PR TITLE
fix: forward rest props through block code

### DIFF
--- a/.changeset/block-code-rest-props.md
+++ b/.changeset/block-code-rest-props.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Forward rest props through block code. The `code` component spread its rest props on the inline branch and dropped them on the block branch, so an attribute a consumer put on a fenced code element never reached the DOM. `CodeBlockBody` now takes part in that comparison, so a forwarded attribute updates instead of keeping the value it first rendered with.

--- a/packages/streamdown/__tests__/block-code-rest-props.test.tsx
+++ b/packages/streamdown/__tests__/block-code-rest-props.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * The `code` component forwards its rest props on the inline branch and not on
+ * the block branch, so an attribute a consumer puts on a fenced code element —
+ * via a rehype plugin, the supported way to annotate rendered output — reaches
+ * inline code and silently disappears on code blocks.
+ *
+ * Once it is forwarded, CodeBlockBody has to compare it too, or the first value
+ * it renders with is the only one it ever renders.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import type { Root } from "hast";
+import { visit } from "unist-util-visit";
+import { describe, expect, it } from "vitest";
+import { Streamdown } from "../index";
+
+/** Stamps every `code` element with the source offset it was parsed from. */
+const stampSourceOffset = () => (tree: Root) => {
+  visit(tree, "element", (node) => {
+    if (node.tagName !== "code") {
+      return;
+    }
+    const start = node.position?.start?.offset;
+    node.properties = {
+      ...node.properties,
+      "data-src-start": start === undefined ? "unknown" : String(start),
+    };
+  });
+};
+
+const findStamped = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll("[data-src-start]"));
+
+describe("rest props on block code", () => {
+  it("forwards a consumer attribute to a fenced code block", async () => {
+    const markdown = "Some `inline` code.\n\n```ts\nconst x = 1;\n```";
+
+    const { container } = render(
+      <Streamdown mode="static" rehypePlugins={[stampSourceOffset]}>
+        {markdown}
+      </Streamdown>
+    );
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("const x = 1;")
+    );
+
+    // Both code elements — the inline one and the fenced one — carry the stamp.
+    expect(findStamped(container)).toHaveLength(2);
+  });
+
+  it("lands the attribute on the element holding the code text", async () => {
+    const markdown = "```ts\nconst x = 1;\n```";
+
+    const { container } = render(
+      <Streamdown mode="static" rehypePlugins={[stampSourceOffset]}>
+        {markdown}
+      </Streamdown>
+    );
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("const x = 1;")
+    );
+
+    const stamped = findStamped(container);
+    expect(stamped).toHaveLength(1);
+    // The header label and the copy/download controls are siblings of the body,
+    // so a stamp that landed correctly describes exactly the code text.
+    expect(stamped[0].textContent).toContain("const x = 1;");
+    expect(stamped[0].textContent).not.toContain("ts\nconst");
+  });
+
+  it("updates the attribute when the code block moves", async () => {
+    // A paragraph inserted above pushes the fence down the document. The code
+    // itself is untouched, so the highlighted tokens keep their identity and
+    // only the forwarded attribute differs — which is the case a comparator
+    // that ignores forwarded props gets wrong.
+    const before = "Intro\n\n```ts\nconst x = 1;\n```";
+    const after = "Intro\n\nMore text\n\n```ts\nconst x = 1;\n```";
+
+    const { container, rerender } = render(
+      <Streamdown mode="static" rehypePlugins={[stampSourceOffset]}>
+        {before}
+      </Streamdown>
+    );
+    await waitFor(() =>
+      expect(container.textContent).toContain("const x = 1;")
+    );
+
+    const initial = Number(
+      findStamped(container)[0]?.getAttribute("data-src-start")
+    );
+    expect(Number.isNaN(initial)).toBe(false);
+
+    rerender(
+      <Streamdown mode="static" rehypePlugins={[stampSourceOffset]}>
+        {after}
+      </Streamdown>
+    );
+
+    await waitFor(() => {
+      const updated = Number(
+        findStamped(container)[0]?.getAttribute("data-src-start")
+      );
+      expect(updated).toBe(initial + (after.length - before.length));
+    });
+  });
+
+  it("does not leak the internal data-block marker into the DOM", async () => {
+    const { container } = render(
+      <Streamdown mode="static">{"```ts\nconst x = 1;\n```"}</Streamdown>
+    );
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("const x = 1;")
+    );
+    expect(container.querySelectorAll("[data-block]")).toHaveLength(0);
+  });
+});

--- a/packages/streamdown/lib/code-block/body.tsx
+++ b/packages/streamdown/lib/code-block/body.tsx
@@ -202,16 +202,9 @@ export const CodeBlockBody = memo(
         </pre>
       </div>
     );
-  },
-  (prevProps, nextProps) => {
-    // Custom comparison: only re-render if result tokens actually changed
-    return (
-      prevProps.maxHeight === nextProps.maxHeight &&
-      prevProps.result === nextProps.result &&
-      prevProps.language === nextProps.language &&
-      prevProps.className === nextProps.className &&
-      prevProps.startLine === nextProps.startLine &&
-      prevProps.lineNumbers === nextProps.lineNumbers
-    );
   }
+  // No custom comparator: React's default shallow comparison already compares
+  // `result` by reference — the tokens are memoized upstream, so an unchanged
+  // code string does not re-highlight — and, unlike a hand-written list of
+  // props, it also covers whatever the caller forwards through CodeBlock.
 );

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -968,6 +968,10 @@ const CodeComponent = ({
   const showDownload = shouldShowCodeControl(controlsConfig, "download");
   const showCopy = shouldShowCodeControl(controlsConfig, "copy");
 
+  // `data-block` is the marker the custom `pre` component sets to identify a
+  // fenced block. It is internal, so it is the one prop not forwarded on.
+  const { "data-block": _blockMarker, ...forwarded } = props;
+
   return (
     <CodeBlock
       className={className}
@@ -976,6 +980,7 @@ const CodeComponent = ({
       language={language}
       lineNumbers={showLineNumbers}
       startLine={startLine}
+      {...forwarded}
     >
       {showCodeControls ? (
         <>


### PR DESCRIPTION
## The asymmetry

`CodeComponent` has two branches. The inline branch spreads its rest props:

```tsx
return (
  <code className={cn(...)} data-streamdown="inline-code" {...props}>
```

The block branch passes a hand-picked six and drops the rest:

```tsx
return (
  <CodeBlock className={className} code={code} isIncomplete={...}
             language={language} lineNumbers={...} startLine={startLine}>
```

So an attribute a consumer puts on a `code` element — via a rehype plugin, which is the supported way to annotate rendered output — reaches inline code and silently disappears on code blocks. One component, two branches, disagreeing about whether consumer props exist.

On `main`, this document stamps two `code` elements and exactly one stamp survives:

```
Some `inline` code.

```ts
const x = 1;
```
```

## The change

Forward the rest props on the block branch too, minus `data-block` — the marker the custom `pre` component sets to identify a fenced block, which is internal and should not reach the DOM.

`CodeBlock` already spreads its rest onto the code-block **body**, whose text is exactly the code: the header label and the copy/download controls are siblings, and line numbers are a CSS counter rather than text nodes. So the props land on the element they describe, with no further plumbing.

Then `CodeBlockBody`'s comparator, which listed props by hand and ignored the rest, so a forwarded attribute kept whatever value it first rendered with. (#444 has since added a sixth entry, `maxHeight` — the list grows with each new prop, which is the shape of the problem.) Its custom comparator is removed rather than extended: React's default shallow comparison already compares `result` by reference — the tokens are memoized upstream, so an unchanged code string still does not re-highlight — and unlike a hand-written list it also covers the forwarded props.

## Tests

`__tests__/block-code-rest-props.test.tsx`, four cases, each hunk pinned by its own assertion:

- a consumer attribute reaches a fenced code block (fails on `main`)
- it lands on the element holding the code text, not the chrome (fails on `main`)
- it **updates** when the block moves (fails on `main`, and still fails with only the forwarding hunk applied — this is the one that pins the comparator)
- `data-block` does not leak into the DOM (passes on `main` trivially, guards this change)

Independent of #584: these pass against unmodified comparators, so the two can be reviewed and merged in either order.

## Related

- #583 covers the same code-block staleness from the content side. If this lands, `sameCodeContent` is not needed for the forwarded-props case; if you prefer that shape, the comparator hunk here can be dropped and rebuilt on top of it.
- Deliberately not included: the `pre` component takes only `children` and drops its own props entirely. That is the same class of bug, but fixing it changes what element gets emitted, so it seemed worth keeping separate. Happy to follow up.

---

Rebased onto `main` at `3327c18`. Verified with `pnpm build:packages`, `vitest run` (79 files, 1074 tests), `biome check` on the changed files.

