### PR TITLE
fix(ci): allow numbers in changeset filenames

### DIFF
--- a/.github/workflows/actions/verify-changesets/index.js
+++ b/.github/workflows/actions/verify-changesets/index.js
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 const BYPASS_LABELS = ["minor", "major"];
 
 // Regex patterns moved to top level for performance
-const CHANGESET_FILE_PATTERN = /^\.changeset\/[a-z-]+\.md/;
+const CHANGESET_FILE_PATTERN = /^\.changeset\/[a-z0-9-]+\.md/;
 const FRONTMATTER_PATTERN = /---\n([\s\S]+?)\n---/;
 
 // Helper function to validate changeset file path

--- a/.github/workflows/actions/verify-changesets/test.js
+++ b/.github/workflows/actions/verify-changesets/test.js
@@ -27,6 +27,30 @@ test("happy path", async () => {
   ]);
 });
 
+test("allows numbers in changeset filename", async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: ".changeset/fix-icons-aria-hidden.md",
+  };
+
+  const readFile = mock.fn(
+    async (_path) =>
+      "---\nai: patch\n@ai-sdk/provider: patch\n---\n## Test changeset"
+  );
+
+  await verifyChangesets(event, env, readFile);
+
+  assert.strictEqual(readFile.mock.callCount(), 1);
+  assert.deepStrictEqual(readFile.mock.calls[0].arguments, [
+    "../../../../.changeset/fix-icons-aria-hidden.md",
+    "utf-8",
+  ]);
+});
+
 test("ignores .changeset/README.md", async () => {
   const event = {
     pull_request: {


### PR DESCRIPTION
## Summary
- Allow digits in changeset filenames in the verify-changesets path regex (`[a-z0-9-]` instead of `[a-z-]`)
- Add a regression test for names like `fix-icons-aria-hidden.md`

Descriptive changeset names that include numbers (common in manual naming) were being rejected as invalid paths.

## Test plan
- [x] `node --test .github/workflows/actions/verify-changesets/test.js` (8 passed)
- [ ] Confirm CI verify-changesets job accepts a PR with a numbered changeset filename