### PR TITLE
fix: allow remend incomplete-link sentinel through sanitize

### DIFF
--- a/.changeset/fix-incomplete-link-sanitize-protocol.md
+++ b/.changeset/fix-incomplete-link-sanitize-protocol.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Allow remend's `streamdown:` incomplete-link sentinel through the default sanitize schema so streamed incomplete links render as pending instead of harden `[blocked]`.

--- a/packages/streamdown/__tests__/incomplete-link-sanitize.test.tsx
+++ b/packages/streamdown/__tests__/incomplete-link-sanitize.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { defaultRehypePlugins, Streamdown } from "../index";
+import { Markdown } from "../lib/markdown";
+
+const rehypePlugins = Object.values(defaultRehypePlugins);
+
+describe("Incomplete streaming links (#551)", () => {
+  it("should keep the remend sentinel href through the default sanitize schema", () => {
+    const { container } = render(
+      <Markdown
+        children="[the docs](streamdown:incomplete-link)"
+        rehypePlugins={rehypePlugins}
+      />
+    );
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe("streamdown:incomplete-link");
+    expect(link?.textContent).toBe("the docs");
+    expect(container.textContent).not.toContain("[blocked]");
+  });
+
+  it("should render incomplete markdown links via MarkdownA instead of harden [blocked]", () => {
+    const { container } = render(
+      <Streamdown mode="streaming">{"see [the docs"}</Streamdown>
+    );
+
+    const blocked = container.querySelector('[title="Blocked URL: undefined"]');
+    expect(blocked).toBeNull();
+    expect(container.textContent).not.toContain("[blocked]");
+
+    const link = container.querySelector('[data-streamdown="link"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("data-incomplete")).toBe("true");
+    expect(link?.textContent).toBe("the docs");
+  });
+
+  it("should render incomplete URL tails via MarkdownA instead of harden [blocked]", () => {
+    const { container } = render(
+      <Streamdown mode="streaming">{"see [the docs](https://exam"}</Streamdown>
+    );
+
+    expect(
+      container.querySelector('[title="Blocked URL: undefined"]')
+    ).toBeNull();
+    expect(container.textContent).not.toContain("[blocked]");
+
+    const link = container.querySelector('[data-streamdown="link"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("data-incomplete")).toBe("true");
+    expect(link?.textContent).toBe("the docs");
+  });
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -267,7 +267,7 @@ const defaultSanitizeSchema = {
   clobberPrefix: "",
   protocols: {
     ...defaultSchema.protocols,
-    href: [...(defaultSchema.protocols?.href ?? []), "tel"],
+    href: [...(defaultSchema.protocols?.href ?? []), "tel", "streamdown"],
   },
   attributes: {
     ...defaultSchema.attributes,


### PR DESCRIPTION
Default sanitize dropped the remend streamdown:incomplete-link href, so streamed incomplete links always became harden [blocked]. Allow the streamdown protocol so MarkdownA data-incomplete can run. Fixes #551.