### PR TITLE
test: cover in-place streamed code block content updates

### DIFF
--- a/packages/streamdown/__tests__/code-block-memo.test.tsx
+++ b/packages/streamdown/__tests__/code-block-memo.test.tsx
@@ -18,6 +18,30 @@ vi.mock("../lib/code-block", () => ({
 }));
 
 describe("MemoCode in streaming mode", () => {
+  it("should re-render code blocks when their content changes in place", async () => {
+    codeBlockRenderCount = 0;
+
+    const initial = "```js\nfirst\n```";
+    const updated = "```js\nsecond\n```";
+
+    const { container, rerender } = render(<Streamdown>{initial}</Streamdown>);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("first");
+    });
+
+    const initialRenderCount = codeBlockRenderCount;
+
+    rerender(<Streamdown>{updated}</Streamdown>);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("second");
+    });
+
+    expect(container.textContent).not.toContain("first");
+    expect(codeBlockRenderCount).toBeGreaterThan(initialRenderCount);
+  });
+
   it("should not re-render unchanged code blocks on streaming updates", async () => {
     codeBlockRenderCount = 0;
 


### PR DESCRIPTION
## Summary

- Adds a regression test from #583 ensuring fenced code blocks re-render when their content changes without moving in the document (e.g. `first` to `second` at the same source position).
- The underlying fix already landed via #584 (`sameRenderedProps`); this keeps the coverage so it does not regress.

## Test plan

- [x] `pnpm --filter streamdown exec vitest run __tests__/code-block-memo.test.tsx`
