### PR TITLE
fix(mermaid): normalize wide diagram SVG sizing and improve pan-zoom fit

### DIFF
--- a/.changeset/tidy-aliens-swim.md
+++ b/.changeset/tidy-aliens-swim.md
@@ -1,0 +1,10 @@
+---
+"streamdown": patch
+---
+
+Fix Mermaid diagrams so text is readable and diagrams auto-fit container.
+- Normalize SVG to remove responsive shrinking  
+- Extract intrinsic size from viewBox  
+- Add width-and-height auto-fit in PanZoom  
+- Preserve user zoom/pan after initial fit  
+- Add tests for SVG utilities and auto-fit behavior

--- a/packages/streamdown/__tests__/mermaid-utils.test.ts
+++ b/packages/streamdown/__tests__/mermaid-utils.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { serializeSvgForDownload, svgToPngBlob } from "../lib/mermaid/utils";
+import {
+  getMermaidSvgSize,
+  normalizeMermaidInlineSvg,
+  serializeSvgForDownload,
+  svgToPngBlob,
+} from "../lib/mermaid/utils";
 
 const BASE64_SVG_DATA_URL_REGEX = /^data:image\/svg\+xml;base64,/;
 const RAW_BR_TAG_REGEX = /<br(?:\s[^/>]*)?>/;
@@ -152,5 +157,49 @@ describe("svgToPngBlob", () => {
   it("should encode SVG as base64 data URL", () => {
     svgToPngBlob("<svg><text>Hello</text></svg>");
     expect(mockImage.src).toMatch(BASE64_SVG_DATA_URL_REGEX);
+  });
+});
+
+describe("normalizeMermaidInlineSvg", () => {
+  it("should preserve source when no SVG element exists", () => {
+    const input = "<div>not svg</div>";
+    expect(normalizeMermaidInlineSvg(input)).toBe(input);
+  });
+
+  it("should preserve source when viewBox is missing", () => {
+    const input = '<svg width="100%" height="100%"></svg>';
+    expect(normalizeMermaidInlineSvg(input)).toBe(input);
+  });
+
+  it("should normalize width/height/maxWidth from viewBox", () => {
+    const input =
+      '<svg width="100%" style="max-width: 3000px;" viewBox="0 0 3000 800"><text>Test</text></svg>';
+
+    const output = normalizeMermaidInlineSvg(input);
+    const doc = new DOMParser().parseFromString(output, "image/svg+xml");
+    const svg = doc.querySelector("svg");
+
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("width")).toBe("3000");
+    expect(svg?.getAttribute("height")).toBe("800");
+    const style = svg?.getAttribute("style") ?? "";
+    expect(style).toContain("width:3000px");
+    expect(style).toContain("height:800px");
+    expect(style).toContain("max-width:none");
+  });
+});
+
+describe("getMermaidSvgSize", () => {
+  it("should return null when svg is missing", () => {
+    expect(getMermaidSvgSize("<div></div>")).toBeNull();
+  });
+
+  it("should return null when viewBox is missing", () => {
+    expect(getMermaidSvgSize('<svg width="100%"></svg>')).toBeNull();
+  });
+
+  it("should parse width and height from viewBox", () => {
+    const size = getMermaidSvgSize('<svg viewBox="0 0 3400 1200"></svg>');
+    expect(size).toEqual({ height: 1200, width: 3400 });
   });
 });

--- a/packages/streamdown/__tests__/pan-zoom.test.tsx
+++ b/packages/streamdown/__tests__/pan-zoom.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PanZoom } from "../lib/mermaid/pan-zoom";
 
 describe("PanZoom", () => {
@@ -294,5 +294,171 @@ describe("PanZoom", () => {
 
     // Check the actual style property, not the attribute string
     expect(content?.style.touchAction).toBe("none");
+  });
+
+  it("should auto-fit large content to container width and size the viewport", async () => {
+    const widthSpy = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(500);
+
+    try {
+      const { container } = render(
+        <PanZoom contentSize={{ height: 1000, width: 1000 }} isAutoFit={true}>
+          <div>Content</div>
+        </PanZoom>
+      );
+
+      await waitFor(() => {
+        const root = container.firstElementChild as HTMLElement;
+        // widthFit = 500/1000 = 0.5 → viewport height = 1000 * 0.5 = 500
+        expect(root.style.height).toBe("500px");
+
+        const content = container.querySelector('[role="application"]');
+        const transform = content?.getAttribute("style") ?? "";
+        expect(transform).toContain("scale(0.5)");
+      });
+    } finally {
+      widthSpy.mockRestore();
+    }
+  });
+
+  it("should respect CSS max-height when sizing tall diagrams", async () => {
+    const widthSpy = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(500);
+
+    const originalGetComputedStyle = window.getComputedStyle;
+    window.getComputedStyle = ((element: Element) => {
+      const styles = originalGetComputedStyle(element);
+      if ((element as HTMLElement).className.includes("max-h-cap")) {
+        return new Proxy(styles, {
+          get(target, prop, receiver) {
+            if (prop === "maxHeight") {
+              return "200px";
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        });
+      }
+      return styles;
+    }) as typeof window.getComputedStyle;
+
+    try {
+      const { container } = render(
+        <PanZoom
+          className="max-h-cap"
+          contentSize={{ height: 1000, width: 1000 }}
+          isAutoFit={true}
+        >
+          <div>Content</div>
+        </PanZoom>
+      );
+
+      await waitFor(() => {
+        const root = container.firstElementChild as HTMLElement;
+        // width-fit height would be 500, but max-height caps at 200
+        expect(root.style.height).toBe("200px");
+
+        const content = container.querySelector('[role="application"]');
+        // fitZoom = min(0.5, 200/1000) = 0.2
+        expect(content?.getAttribute("style") ?? "").toContain("scale(0.2)");
+      });
+    } finally {
+      widthSpy.mockRestore();
+      window.getComputedStyle = originalGetComputedStyle;
+    }
+  });
+
+  it("should auto-fit to both dimensions in fullscreen", async () => {
+    const widthSpy = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(500);
+    const heightSpy = vi
+      .spyOn(HTMLElement.prototype, "clientHeight", "get")
+      .mockReturnValue(250);
+
+    try {
+      const { container } = render(
+        <PanZoom
+          contentSize={{ height: 1000, width: 1000 }}
+          fullscreen={true}
+          isAutoFit={true}
+        >
+          <div>Content</div>
+        </PanZoom>
+      );
+
+      await waitFor(() => {
+        const content = container.querySelector('[role="application"]');
+        const transform = content?.getAttribute("style") ?? "";
+        expect(transform).toContain("scale(0.25)");
+      });
+    } finally {
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
+    }
+  });
+
+  it("should re-fit when the container is resized", async () => {
+    let width = 500;
+    const widthSpy = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockImplementation(() => width);
+
+    const observers: Array<{
+      callback: ResizeObserverCallback;
+    }> = [];
+
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      private callback: ResizeObserverCallback;
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        observers.push({ callback });
+      }
+
+      observe() {
+        /* noop */
+      }
+
+      unobserve() {
+        /* noop */
+      }
+
+      disconnect() {
+        /* noop */
+      }
+    } as typeof ResizeObserver;
+
+    try {
+      const { container } = render(
+        <PanZoom contentSize={{ height: 1000, width: 1000 }} isAutoFit={true}>
+          <div>Content</div>
+        </PanZoom>
+      );
+
+      await waitFor(() => {
+        const content = container.querySelector('[role="application"]');
+        expect(content?.getAttribute("style") ?? "").toContain("scale(0.5)");
+      });
+
+      width = 250;
+      act(() => {
+        for (const observer of observers) {
+          observer.callback([], observer as unknown as ResizeObserver);
+        }
+      });
+
+      await waitFor(() => {
+        const content = container.querySelector('[role="application"]');
+        expect(content?.getAttribute("style") ?? "").toContain("scale(0.25)");
+        const root = container.firstElementChild as HTMLElement;
+        expect(root.style.height).toBe("250px");
+      });
+    } finally {
+      widthSpy.mockRestore();
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
   });
 });

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -957,7 +957,11 @@ const CodeComponent = ({
               </div>
             </div>
           ) : null}
-          <div className={cn("rounded-md border border-border bg-background")}>
+          <div
+            className={cn(
+              "overflow-hidden rounded-md border border-border bg-background"
+            )}
+          >
             <Mermaid
               chart={code}
               config={mermaidContext?.config}

--- a/packages/streamdown/lib/mermaid/index.tsx
+++ b/packages/streamdown/lib/mermaid/index.tsx
@@ -5,6 +5,7 @@ import { useMermaidPlugin } from "../plugin-context";
 import type { MermaidConfig } from "../plugin-types";
 import { useCn } from "../prefix-context";
 import { PanZoom } from "./pan-zoom";
+import { getMermaidSvgSize, normalizeMermaidInlineSvg } from "./utils";
 
 interface MermaidProps {
   chart: string;
@@ -25,6 +26,10 @@ export const Mermaid = ({
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [svgContent, setSvgContent] = useState<string>("");
+  const [svgSize, setSvgSize] = useState<{
+    height: number;
+    width: number;
+  } | null>(null);
   const [lastValidSvg, setLastValidSvg] = useState<string>("");
   const [retryCount, setRetryCount] = useState(0);
   const { mermaid: mermaidContext } = useContext(StreamdownContext);
@@ -67,10 +72,13 @@ export const Mermaid = ({
         const uniqueId = `mermaid-${Math.abs(chartHash)}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 
         const { svg } = await mermaid.render(uniqueId, chart);
+        const size = getMermaidSvgSize(svg);
+        const normalizedSvg = fullscreen ? svg : normalizeMermaidInlineSvg(svg);
 
         // Update both current and last valid SVG
-        setSvgContent(svg);
-        setLastValidSvg(svg);
+        setSvgContent(normalizedSvg);
+        setSvgSize(size);
+        setLastValidSvg(normalizedSvg);
       } catch (err) {
         // Silently fail and keep the last valid SVG
         // Don't update svgContent here - just keep what we have
@@ -161,18 +169,26 @@ export const Mermaid = ({
 
   return (
     <div
-      className={cn("size-full", className)}
+      className={cn(
+        fullscreen ? "size-full" : "max-h-[min(70vh,40rem)] w-full",
+        className
+      )}
       data-streamdown="mermaid"
       ref={containerRef}
     >
       <PanZoom
         className={cn(
-          fullscreen ? "size-full overflow-hidden" : "overflow-hidden",
+          fullscreen
+            ? "size-full overflow-hidden"
+            : "max-h-[min(70vh,40rem)] overflow-hidden",
           className
         )}
+        contentSize={svgSize}
+        fitKey={chart}
         fullscreen={fullscreen}
+        isAutoFit={true}
         maxZoom={3}
-        minZoom={0.5}
+        minZoom={0.1}
         showControls={showControls}
         zoomStep={0.1}
       >

--- a/packages/streamdown/lib/mermaid/pan-zoom.tsx
+++ b/packages/streamdown/lib/mermaid/pan-zoom.tsx
@@ -1,5 +1,11 @@
-import type { ReactNode } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useIcons } from "../icon-context";
 import { useCn } from "../prefix-context";
 import { useTranslations } from "../translations-context";
@@ -7,22 +13,172 @@ import { useTranslations } from "../translations-context";
 interface PanZoomProps {
   children: ReactNode;
   className?: string;
+  contentSize?: { height: number; width: number } | null;
+  fitKey?: string;
   fullscreen?: boolean;
   initialZoom?: number;
+  isAutoFit?: boolean;
   maxZoom?: number;
   minZoom?: number;
   showControls?: boolean;
   zoomStep?: number;
 }
 
+const positiveOrNull = (px: number): number | null => (px > 0 ? px : null);
+
+const parseLengthPx = (value: string, element: HTMLElement): number | null => {
+  if (value.endsWith("px")) {
+    return positiveOrNull(Number.parseFloat(value));
+  }
+
+  if (value.endsWith("rem")) {
+    const rootFontSize = Number.parseFloat(
+      getComputedStyle(document.documentElement).fontSize || "16"
+    );
+    return positiveOrNull(Number.parseFloat(value) * rootFontSize);
+  }
+
+  if (value.endsWith("em")) {
+    const fontSize = Number.parseFloat(
+      getComputedStyle(element).fontSize || "16"
+    );
+    return positiveOrNull(Number.parseFloat(value) * fontSize);
+  }
+
+  if (value.endsWith("vh")) {
+    return positiveOrNull(
+      (Number.parseFloat(value) / 100) * window.innerHeight
+    );
+  }
+
+  if (value.endsWith("%")) {
+    const parent = element.parentElement;
+    if (!(parent && parent.clientHeight > 0)) {
+      return null;
+    }
+    return positiveOrNull(
+      (Number.parseFloat(value) / 100) * parent.clientHeight
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Resolve CSS max-height to pixels when possible.
+ * Returns null when max-height does not constrain the element.
+ */
+const resolveMaxHeightPx = (
+  element: HTMLElement,
+  maxHeight: string
+): number | null => {
+  const value = maxHeight.trim().toLowerCase();
+  if (!value || value === "none" || value === "auto") {
+    return null;
+  }
+
+  return parseLengthPx(value, element);
+};
+
+const MIN_MAX_HEIGHT_REGEX = /^min\(\s*([^,]+)\s*,\s*([^)]+)\s*\)$/i;
+
+/**
+ * Evaluate simple `min(a, b)` max-height expressions used in Tailwind utilities
+ * like `max-h-[min(70vh,40rem)]`.
+ */
+const resolveComplexMaxHeightPx = (
+  element: HTMLElement,
+  maxHeight: string
+): number | null => {
+  const direct = resolveMaxHeightPx(element, maxHeight);
+  if (direct != null) {
+    return direct;
+  }
+
+  const minMatch = maxHeight.trim().match(MIN_MAX_HEIGHT_REGEX);
+  if (!minMatch) {
+    return null;
+  }
+
+  const left = resolveMaxHeightPx(element, minMatch[1].trim());
+  const right = resolveMaxHeightPx(element, minMatch[2].trim());
+  if (left == null || right == null) {
+    return null;
+  }
+  return Math.min(left, right);
+};
+
+const computeFit = (
+  contentSize: { height: number; width: number },
+  container: HTMLElement,
+  fullscreen: boolean
+): { fitZoom: number; viewportHeight: number | null } | null => {
+  const containerWidth = container.clientWidth;
+  if (!(containerWidth > 0)) {
+    return null;
+  }
+
+  if (fullscreen) {
+    const containerHeight = container.clientHeight;
+    if (!(containerHeight > 0)) {
+      return null;
+    }
+
+    const fitZoom = Math.min(
+      containerWidth / contentSize.width,
+      containerHeight / contentSize.height,
+      1
+    );
+
+    if (!(fitZoom > 0) || Number.isNaN(fitZoom)) {
+      return null;
+    }
+
+    return { fitZoom, viewportHeight: null };
+  }
+
+  // Fit to container width first so the card never expands past the text column.
+  const widthFit = Math.min(containerWidth / contentSize.width, 1);
+  if (!(widthFit > 0) || Number.isNaN(widthFit)) {
+    return null;
+  }
+
+  const heightAtWidthFit = contentSize.height * widthFit;
+
+  // Cap tall diagrams using CSS max-height on this viewport or its parents.
+  let maxHeightPx: number | null = null;
+  let node: HTMLElement | null = container;
+  while (node && maxHeightPx == null) {
+    const styles = getComputedStyle(node);
+    maxHeightPx = resolveComplexMaxHeightPx(node, styles.maxHeight);
+    node = node.parentElement;
+  }
+
+  const viewportHeight =
+    maxHeightPx != null
+      ? Math.min(heightAtWidthFit, maxHeightPx)
+      : heightAtWidthFit;
+
+  const fitZoom = Math.min(widthFit, viewportHeight / contentSize.height, 1);
+
+  if (!(fitZoom > 0) || Number.isNaN(fitZoom)) {
+    return null;
+  }
+
+  return { fitZoom, viewportHeight };
+};
+
 export const PanZoom = ({
   children,
   className,
+  contentSize,
+  fitKey,
   minZoom = 0.5,
   maxZoom = 3,
   zoomStep = 0.1,
   showControls = true,
   initialZoom = 1,
+  isAutoFit = false,
   fullscreen = false,
 }: PanZoomProps) => {
   const { RotateCcwIcon, ZoomInIcon, ZoomOutIcon } = useIcons();
@@ -30,20 +186,57 @@ export const PanZoom = ({
   const t = useTranslations();
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const hasUserInteractedRef = useRef(false);
+  const [baseZoom, setBaseZoom] = useState(initialZoom);
+  const [effectiveMinZoom, setEffectiveMinZoom] = useState(minZoom);
   const [zoom, setZoom] = useState(initialZoom);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
   const [panStart, setPanStart] = useState({ x: 0, y: 0 });
   const [panStartPosition, setPanStartPosition] = useState({ x: 0, y: 0 });
+  // Intrinsic height of the viewport once the diagram is scaled to container width.
+  // Height is independent of the fitted scale transform so the card doesn't balloon
+  // with the SVG's native size. Capped by max-height CSS when tall.
+  const [viewportHeight, setViewportHeight] = useState<number | null>(null);
+
+  const applyFit = useCallback(
+    (nextContentSize: { height: number; width: number }) => {
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+
+      const result = computeFit(nextContentSize, container, fullscreen);
+      if (!result) {
+        return;
+      }
+
+      const { fitZoom, viewportHeight: nextViewportHeight } = result;
+
+      setViewportHeight(nextViewportHeight);
+      setBaseZoom(fitZoom);
+      setEffectiveMinZoom(Math.min(minZoom, fitZoom));
+
+      if (!hasUserInteractedRef.current) {
+        setZoom(fitZoom);
+        setPan({ x: 0, y: 0 });
+      }
+    },
+    [fullscreen, minZoom]
+  );
 
   const handleZoom = useCallback(
     (delta: number) => {
       setZoom((prevZoom) => {
-        const newZoom = Math.max(minZoom, Math.min(maxZoom, prevZoom + delta));
+        const newZoom = Math.max(
+          effectiveMinZoom,
+          Math.min(maxZoom, prevZoom + delta)
+        );
         return newZoom;
       });
+      hasUserInteractedRef.current = true;
     },
-    [minZoom, maxZoom]
+    [effectiveMinZoom, maxZoom]
   );
 
   const handleZoomIn = useCallback(() => {
@@ -55,9 +248,10 @@ export const PanZoom = ({
   }, [handleZoom, zoomStep]);
 
   const handleReset = useCallback(() => {
-    setZoom(initialZoom);
+    setZoom(baseZoom);
     setPan({ x: 0, y: 0 });
-  }, [initialZoom]);
+    hasUserInteractedRef.current = false;
+  }, [baseZoom]);
 
   const handleWheel = useCallback(
     (e: WheelEvent) => {
@@ -75,6 +269,7 @@ export const PanZoom = ({
         return;
       }
       setIsPanning(true);
+      hasUserInteractedRef.current = true;
       setPanStart({ x: e.clientX, y: e.clientY });
       setPanStartPosition(pan);
       // Capture the pointer to track it even outside the element
@@ -111,6 +306,47 @@ export const PanZoom = ({
       target.releasePointerCapture(e.pointerId);
     }
   }, []);
+
+  useEffect(() => {
+    setEffectiveMinZoom(minZoom);
+    if (!isAutoFit) {
+      setBaseZoom(initialZoom);
+      setZoom(initialZoom);
+      setViewportHeight(null);
+    }
+  }, [initialZoom, isAutoFit, minZoom]);
+
+  useLayoutEffect(() => {
+    if (!(isAutoFit && contentSize)) {
+      return;
+    }
+
+    applyFit(contentSize);
+
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      applyFit(contentSize);
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [applyFit, contentSize, isAutoFit]);
+
+  // fitKey is an intentional trigger: new diagram identity should re-enable auto-fit.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fitKey resets interaction even though it is not read
+  useEffect(() => {
+    if (!isAutoFit) {
+      return;
+    }
+
+    hasUserInteractedRef.current = false;
+  }, [fitKey, isAutoFit]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -151,6 +387,11 @@ export const PanZoom = ({
     }
   }, [isPanning, handlePointerMove, handlePointerUp]);
 
+  const viewportStyle: CSSProperties | undefined =
+    !fullscreen && isAutoFit && viewportHeight != null
+      ? { height: viewportHeight }
+      : undefined;
+
   return (
     <div
       className={cn(
@@ -159,7 +400,10 @@ export const PanZoom = ({
         className
       )}
       ref={containerRef}
-      style={{ cursor: isPanning ? "grabbing" : "grab" }}
+      style={{
+        cursor: isPanning ? "grabbing" : "grab",
+        ...viewportStyle,
+      }}
     >
       {showControls ? (
         <div
@@ -185,7 +429,7 @@ export const PanZoom = ({
             className={cn(
               "flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
             )}
-            disabled={zoom <= minZoom}
+            disabled={zoom <= effectiveMinZoom}
             onClick={handleZoomOut}
             title={t.zoomOut}
             type="button"
@@ -207,10 +451,7 @@ export const PanZoom = ({
       ) : null}
       <div
         className={cn(
-          "flex-1 origin-center transition-transform duration-150 ease-out",
-          fullscreen
-            ? "flex h-full w-full items-center justify-center"
-            : "flex w-full items-center justify-center"
+          "flex h-full w-full flex-1 origin-center items-center justify-center transition-transform duration-150 ease-out"
         )}
         onPointerDown={handlePointerDown}
         ref={contentRef}

--- a/packages/streamdown/lib/mermaid/utils.ts
+++ b/packages/streamdown/lib/mermaid/utils.ts
@@ -1,3 +1,119 @@
+const SVG_TAG_REGEX = /<svg\b[^>]*>/i;
+const VIEW_BOX_REGEX = /\bviewBox=(['"])(.*?)\1/i;
+const VIEW_BOX_SPLIT_REGEX = /[\s,]+/;
+const WIDTH_ATTR_REGEX = /\swidth=(['"]).*?\1/gi;
+const HEIGHT_ATTR_REGEX = /\sheight=(['"]).*?\1/gi;
+const STYLE_ATTR_REGEX = /\sstyle=(['"])(.*?)\1/i;
+const WIDTH_DECL_REGEX = /^width\s*:/i;
+const HEIGHT_DECL_REGEX = /^height\s*:/i;
+const MAX_WIDTH_DECL_REGEX = /^max-width\s*:/i;
+const SVG_OPEN_TAG_REGEX = /^<svg/i;
+
+/**
+ * Normalize Mermaid SVG dimensions for inline rendering.
+ * Mermaid emits width="100%" with max-width style, which can shrink very wide
+ * diagrams until text becomes unreadable.
+ */
+export const getMermaidSvgSize = (
+  svgString: string
+): { height: number; width: number } | null => {
+  const svgTagMatch = svgString.match(SVG_TAG_REGEX);
+  if (!svgTagMatch) {
+    return null;
+  }
+
+  const svgTag = svgTagMatch[0];
+  const viewBoxMatch = svgTag.match(VIEW_BOX_REGEX);
+  const viewBox = viewBoxMatch?.[2];
+
+  if (!viewBox) {
+    return null;
+  }
+
+  const values = viewBox
+    .trim()
+    .split(VIEW_BOX_SPLIT_REGEX)
+    .map((value) => Number.parseFloat(value));
+
+  if (values.length < 4 || values.slice(0, 4).some(Number.isNaN)) {
+    return null;
+  }
+
+  const width = values[2];
+  const height = values[3];
+  if (!(width > 0 && height > 0)) {
+    return null;
+  }
+
+  return { height, width };
+};
+
+/**
+ * Normalize Mermaid SVG dimensions for inline rendering.
+ * Mermaid emits width="100%" with max-width style, which can shrink very wide
+ * diagrams until text becomes unreadable.
+ */
+export const normalizeMermaidInlineSvg = (svgString: string): string => {
+  const svgTagMatch = svgString.match(SVG_TAG_REGEX);
+  if (!svgTagMatch) {
+    return svgString;
+  }
+
+  try {
+    const svgTag = svgTagMatch[0];
+    const size = getMermaidSvgSize(svgString);
+    if (!size) {
+      return svgString;
+    }
+    const { width, height } = size;
+
+    let updatedSvgTag = svgTag
+      .replace(WIDTH_ATTR_REGEX, "")
+      .replace(HEIGHT_ATTR_REGEX, "");
+
+    const styleMatch = updatedSvgTag.match(STYLE_ATTR_REGEX);
+    const sizeDeclarations = `width:${width}px;height:${height}px;max-width:none;`;
+
+    if (styleMatch) {
+      const styleQuote = styleMatch[1];
+      const styleValue = styleMatch[2];
+      const filtered = styleValue
+        .split(";")
+        .map((decl) => decl.trim())
+        .filter(Boolean)
+        .filter(
+          (decl) =>
+            !(
+              WIDTH_DECL_REGEX.test(decl) ||
+              HEIGHT_DECL_REGEX.test(decl) ||
+              MAX_WIDTH_DECL_REGEX.test(decl)
+            )
+        )
+        .join(";");
+
+      const mergedStyle = `${sizeDeclarations}${filtered ? `${filtered};` : ""}`;
+      updatedSvgTag = updatedSvgTag.replace(
+        STYLE_ATTR_REGEX,
+        ` style=${styleQuote}${mergedStyle}${styleQuote}`
+      );
+    } else {
+      updatedSvgTag = updatedSvgTag.replace(
+        SVG_OPEN_TAG_REGEX,
+        `<svg style="${sizeDeclarations}"`
+      );
+    }
+
+    updatedSvgTag = updatedSvgTag.replace(
+      SVG_OPEN_TAG_REGEX,
+      `<svg width="${width}" height="${height}"`
+    );
+
+    return svgString.replace(svgTag, updatedSvgTag);
+  } catch {
+    return svgString;
+  }
+};
+
 /**
  * Mermaid render output may be HTML-serialized. Serialize the SVG node as XML
  * before downloading so embedded HTML like <br> becomes valid SVG markup.


### PR DESCRIPTION
Originally created on #480  due to conflict and unsigned commit history I did cherry pick all changes here.

Fixes https://github.com/vercel/streamdown/issues/479
Closes https://github.com/vercel/streamdown/issues/479
Related to https://github.com/vercel/streamdown/issues/479

