### PR TITLE
[Temp] Refresh Streamdown homepage description

### DIFF
--- a/apps/website/app/[lang]/(home)/page.tsx
+++ b/apps/website/app/[lang]/(home)/page.tsx
@@ -25,7 +25,7 @@ import VibeCodingPlatform from "./images/vibe-coding-platform.png";
 
 const title = "Streamdown";
 const description =
-  "A markdown renderer designed for streaming content from AI models. Highly interactive, customizable, and easy to use.";
+  "Beautiful, secure Markdown rendering built for streaming AI interfaces.";
 
 const COMMAND_FOR_HUMANS = "npm i streamdown";
 const COMMAND_FOR_AGENTS = "npx skills add vercel/streamdown@streamdown";


### PR DESCRIPTION
Tightens the Streamdown homepage description.

## Details
- Changes only the visible hero and metadata description copy.
- Temporary visual change for skill testing.
- Validation: `git diff --check`.

<!-- before-and-after:start -->
| Before | After |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/914942c6-7e21-4099-a969-ee2f25daac5f) | ![After](https://github.com/user-attachments/assets/28db87cf-e7e0-417e-a709-076eef19d2e2) |

<!-- before-and-after:end -->
