### PR TITLE
feat: support disableAutolinkProtocols to opt out of GFM autolinks per protocol

### DIFF
--- a/.changeset/disable-autolink-protocols.md
+++ b/.changeset/disable-autolink-protocols.md
@@ -1,0 +1,15 @@
+---
+"streamdown": minor
+---
+
+Add a `disableAutolinkProtocols` prop to `<Streamdown>` for disabling GFM autolinking of specific URL protocols (e.g. `mailto`).
+
+```tsx
+<Streamdown disableAutolinkProtocols={["mailto"]}>
+  {"Contact us at hello@example.com"}
+</Streamdown>
+```
+
+Bare emails and bare URLs whose protocol matches the list (case-insensitive, `"mailto"` and `"mailto:"` are equivalent) are unwrapped back to plain text. Explicit markdown links (`[text](mailto:...)`) are left as links. When the prop is omitted, autolinking behavior is completely unchanged.
+
+Closes #607.

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -129,6 +129,11 @@ With `dir="auto"`:
       type: "Pluggable[]",
       default: "Object.values(defaultRemarkPlugins)",
     },
+    disableAutolinkProtocols: {
+      description:
+        "Disable GFM autolinking for specific URL protocols (e.g. ['mailto'] stops bare email addresses from becoming links). Accepts protocol names with or without a trailing colon, case-insensitive. Only affects literal autolinks created by remark-gfm; explicit [text](url) links are unaffected.",
+      type: "string[]",
+    },
   }}
 />
 

--- a/packages/streamdown/__tests__/disable-autolink-protocols.test.tsx
+++ b/packages/streamdown/__tests__/disable-autolink-protocols.test.tsx
@@ -1,0 +1,148 @@
+import { render } from "@testing-library/react";
+import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vitest";
+import { defaultRehypePlugins, Streamdown } from "../index";
+import { Markdown } from "../lib/markdown";
+import { remarkDisableAutolinkProtocols } from "../lib/remark/disable-autolink-protocols";
+
+const rehypePlugins = Object.values(defaultRehypePlugins);
+
+describe("Disable Autolink Protocols (#607)", () => {
+  describe("remarkPlugins wiring (remarkDisableAutolinkProtocols)", () => {
+    it("does not link a bare email when mailto is disabled", () => {
+      const content = "Contact me at foo@example.com for details";
+      const { container } = render(
+        <Markdown
+          children={content}
+          rehypePlugins={rehypePlugins}
+          remarkPlugins={[
+            remarkGfm,
+            [remarkDisableAutolinkProtocols, ["mailto"]],
+          ]}
+        />
+      );
+
+      expect(container.querySelector("a")).toBeNull();
+      expect(container.textContent).toBe(content);
+    });
+
+    it("keeps default autolink behavior when the plugin is not added", () => {
+      const content = "Contact me at foo@example.com for details";
+      const { container } = render(
+        <Markdown
+          children={content}
+          rehypePlugins={rehypePlugins}
+          remarkPlugins={[remarkGfm]}
+        />
+      );
+
+      const link = container.querySelector("a");
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute("href")).toBe("mailto:foo@example.com");
+      expect(link?.textContent).toBe("foo@example.com");
+      expect(container.textContent).toBe(content);
+    });
+
+    it("keeps explicit markdown mailto links even when mailto is disabled", () => {
+      const content = "[Email us](mailto:foo@example.com) any time";
+      const { container } = render(
+        <Markdown
+          children={content}
+          rehypePlugins={rehypePlugins}
+          remarkPlugins={[
+            remarkGfm,
+            [remarkDisableAutolinkProtocols, ["mailto"]],
+          ]}
+        />
+      );
+
+      const link = container.querySelector("a");
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute("href")).toBe("mailto:foo@example.com");
+      expect(link?.textContent).toBe("Email us");
+    });
+
+    it("still links http/https autolinks when only mailto is disabled", () => {
+      const content = "Visit https://example.com for more";
+      const { container } = render(
+        <Markdown
+          children={content}
+          rehypePlugins={rehypePlugins}
+          remarkPlugins={[
+            remarkGfm,
+            [remarkDisableAutolinkProtocols, ["mailto"]],
+          ]}
+        />
+      );
+
+      const link = container.querySelector("a");
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute("href")).toBe("https://example.com/");
+    });
+
+    it("is case-insensitive and accepts a trailing colon", () => {
+      for (const protocol of ["mailto", "MAILTO", "mailto:", "MailTo:"]) {
+        const content = "foo@example.com";
+        const { container } = render(
+          <Markdown
+            children={content}
+            rehypePlugins={rehypePlugins}
+            remarkPlugins={[
+              remarkGfm,
+              [remarkDisableAutolinkProtocols, [protocol]],
+            ]}
+          />
+        );
+
+        expect(container.querySelector("a")).toBeNull();
+      }
+    });
+
+    it("disables http(s) autolinks when https is disabled, leaving mailto untouched", () => {
+      const content = "See https://example.com or email foo@example.com";
+      const { container } = render(
+        <Markdown
+          children={content}
+          rehypePlugins={rehypePlugins}
+          remarkPlugins={[
+            remarkGfm,
+            [remarkDisableAutolinkProtocols, ["https"]],
+          ]}
+        />
+      );
+
+      const links = container.querySelectorAll("a");
+      expect(links.length).toBe(1);
+      expect(links[0]?.getAttribute("href")).toBe("mailto:foo@example.com");
+      expect(container.textContent).toBe(content);
+    });
+  });
+
+  describe("Streamdown disableAutolinkProtocols prop", () => {
+    it("unwraps disabled bare-email autolinks to plain text", () => {
+      const content = "Contact foo@example.com now";
+      const { container } = render(
+        <Streamdown
+          disableAutolinkProtocols={["mailto"]}
+          linkSafety={{ enabled: false }}
+        >
+          {content}
+        </Streamdown>
+      );
+
+      expect(container.querySelector('[data-streamdown="link"]')).toBeNull();
+      expect(container.textContent).toBe(content);
+    });
+
+    it("leaves autolinks unchanged when the prop is not provided", () => {
+      const content = "Contact foo@example.com now";
+      const { container } = render(
+        <Streamdown linkSafety={{ enabled: false }}>{content}</Streamdown>
+      );
+
+      const link = container.querySelector('[data-streamdown="link"]');
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute("href")).toBe("mailto:foo@example.com");
+    });
+  });
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -44,6 +44,7 @@ import { preprocessLiteralTagContent } from "./lib/preprocess-literal-tag-conten
 import { rehypeBlockDirection } from "./lib/rehype/block-direction";
 import { rehypeLiteralTagContent } from "./lib/rehype/literal-tag-content";
 import { remarkCodeMeta } from "./lib/remark/code-meta";
+import { remarkDisableAutolinkProtocols } from "./lib/remark/disable-autolink-protocols";
 import type { CSVSeparator } from "./lib/table/utils";
 import {
   defaultTranslations,
@@ -254,6 +255,22 @@ export type StreamdownProps = Options & {
    * ```
    */
   literalTagContent?: string[];
+  /**
+   * Disable GFM autolinking for specific URL protocols (e.g. bare email
+   * addresses become `mailto:` autolinks). Accepts protocol names with or
+   * without a trailing colon, case-insensitive (`"mailto"` and `"mailto:"`
+   * are equivalent). Only affects literal autolinks created by `remark-gfm`
+   * (bare URLs/emails) — explicit markdown links (`[text](url)`) are left
+   * as links.
+   *
+   * @example
+   * ```tsx
+   * <Streamdown disableAutolinkProtocols={["mailto"]}>
+   *   {"Contact us at hello@example.com"}
+   * </Streamdown>
+   * ```
+   */
+  disableAutolinkProtocols?: string[];
   /** Override UI strings for i18n / custom labels */
   translations?: Partial<StreamdownTranslations>;
   /** Custom icons to override the default icons used in controls */
@@ -511,6 +528,7 @@ export const Streamdown = memo(
     lineNumbers = true,
     allowedTags,
     literalTagContent,
+    disableAutolinkProtocols,
     translations,
     icons: iconOverrides,
     prefix,
@@ -764,6 +782,16 @@ export const Streamdown = memo(
       }
       // Default plugins (includes remarkGfm)
       result = [...result, ...remarkPlugins];
+      // Optionally strip GFM autolink-literal links for disabled protocols
+      // (e.g. mailto). Runs right after remarkGfm since it inspects the
+      // link nodes remarkGfm's autolink-literal extension creates. Skipped
+      // entirely when unset so default behavior/pipeline is unchanged.
+      if (disableAutolinkProtocols && disableAutolinkProtocols.length > 0) {
+        result = [
+          ...result,
+          [remarkDisableAutolinkProtocols, disableAutolinkProtocols],
+        ];
+      }
       // CJK plugins that must run AFTER remarkGfm (e.g., autolink boundary)
       if (plugins?.cjk) {
         result = [...result, ...plugins.cjk.remarkPluginsAfter];
@@ -773,7 +801,7 @@ export const Streamdown = memo(
         result = [...result, plugins.math.remarkPlugin];
       }
       return result;
-    }, [remarkPlugins, plugins?.math, plugins?.cjk]);
+    }, [remarkPlugins, plugins?.math, plugins?.cjk, disableAutolinkProtocols]);
 
     const mergedRehypePlugins = useMemo(() => {
       let result = rehypePlugins;
@@ -997,6 +1025,7 @@ export const Streamdown = memo(
     prevProps.tableMaxHeight === nextProps.tableMaxHeight &&
     prevProps.normalizeHtmlIndentation === nextProps.normalizeHtmlIndentation &&
     prevProps.literalTagContent === nextProps.literalTagContent &&
+    prevProps.disableAutolinkProtocols === nextProps.disableAutolinkProtocols &&
     JSON.stringify(prevProps.translations) ===
       JSON.stringify(nextProps.translations) &&
     prevProps.prefix === nextProps.prefix &&

--- a/packages/streamdown/lib/remark/disable-autolink-protocols.ts
+++ b/packages/streamdown/lib/remark/disable-autolink-protocols.ts
@@ -1,0 +1,103 @@
+import type { Link, Root } from "mdast";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+// Matches the URI scheme at the start of a link's `url` (e.g. "mailto:", "http:").
+const PROTOCOL_PATTERN = /^([a-zA-Z][a-zA-Z\d+\-.]*:)/;
+
+/**
+ * Normalizes a list of user-supplied protocol names into a lowercase set of
+ * `"scheme:"` strings. Accepts protocols with or without a trailing colon
+ * (e.g. `"mailto"` and `"mailto:"` are equivalent) and is case-insensitive.
+ */
+export const normalizeAutolinkProtocols = (protocols: string[]): Set<string> =>
+  new Set(
+    protocols
+      .map((protocol) => protocol.trim().toLowerCase())
+      .filter((protocol) => protocol.length > 0)
+      .map((protocol) => (protocol.endsWith(":") ? protocol : `${protocol}:`))
+  );
+
+/**
+ * Determines whether a `link` node is a GFM autolink-literal (created by
+ * `remark-gfm`'s autolink-literal extension for bare URLs/emails) whose
+ * protocol is in the disabled set.
+ *
+ * `mdast-util-gfm-autolink-literal` does not tag the nodes it creates, so
+ * autolinks are identified structurally: they have exactly one `text` child
+ * whose visible value reconstructs the node's `url`. Bare emails become
+ * `{ url: "mailto:<email>", children: [{ type: "text", value: "<email>" }] }`;
+ * bare http(s)/www URLs become a link whose single text child equals the URL
+ * (optionally without the `http://` prefix that GFM adds for `www.` links).
+ *
+ * Explicit markdown links (`[text](url)`) are intentionally left untouched
+ * unless their visible text happens to exactly reconstruct the URL, in which
+ * case they are indistinguishable from an autolink at the mdast level.
+ */
+function isDisabledAutolink(
+  node: Link,
+  disabledProtocols: Set<string>
+): boolean {
+  if (node.children.length !== 1) {
+    return false;
+  }
+
+  const [child] = node.children;
+  if (child.type !== "text") {
+    return false;
+  }
+
+  const protocolMatch = PROTOCOL_PATTERN.exec(node.url);
+  if (!protocolMatch) {
+    return false;
+  }
+
+  const protocol = protocolMatch[1].toLowerCase();
+  if (!disabledProtocols.has(protocol)) {
+    return false;
+  }
+
+  if (protocol === "mailto:") {
+    return node.url === `mailto:${child.value}`;
+  }
+
+  return node.url === child.value || node.url === `${protocol}//${child.value}`;
+}
+
+/**
+ * Remark plugin that removes GFM autolink-literal links whose protocol
+ * matches one of the configured `protocols`, unwrapping them back to plain
+ * text. Must run AFTER `remark-gfm` in the plugin pipeline so the autolink
+ * nodes exist for it to inspect.
+ *
+ * Uses the standard unified `[plugin, options]` tuple form (rather than a
+ * plugin factory) so Streamdown's internal processor cache — which keys
+ * processors by plugin name plus `JSON.stringify(options)` — can tell
+ * different `protocols` configurations apart. A factory returning a fresh
+ * closure per call would always serialize to the same anonymous-function
+ * key and silently reuse a stale cached processor.
+ *
+ * A no-op (no protocols configured) skips the tree traversal entirely.
+ */
+export const remarkDisableAutolinkProtocols: Plugin<[string[]?], Root> = (
+  protocols = []
+) => {
+  const disabledProtocols = normalizeAutolinkProtocols(protocols);
+
+  return (tree: Root) => {
+    if (disabledProtocols.size === 0) {
+      return;
+    }
+
+    visit(tree, "link", (node, index, parent) => {
+      if (!parent || index === undefined) {
+        return;
+      }
+      if (!isDisabledAutolink(node, disabledProtocols)) {
+        return;
+      }
+      parent.children.splice(index, 1, ...node.children);
+      return index;
+    });
+  };
+};


### PR DESCRIPTION
Closes #607.

## What

Adds an optional `disableAutolinkProtocols` prop to `<Streamdown>` that disables GFM autolink-literal linking for specific URL protocols (e.g. `mailto`), as requested in #607.

```tsx
<Streamdown disableAutolinkProtocols={["mailto"]}>
  {"Contact us at hello@example.com"}
</Streamdown>
```

Before:

```html
<p>Contact us at <a href="mailto:hello@example.com">hello@example.com</a></p>
```

After (with `disableAutolinkProtocols={["mailto"]}`):

```html
<p>Contact us at hello@example.com</p>
```

- Protocol names are case-insensitive and accept an optional trailing colon (`"mailto"` and `"mailto:"` are equivalent).
- Only literal autolinks created by `remark-gfm`'s autolink-literal extension are affected (bare emails, bare `http(s)`/`www` URLs). Explicit markdown links (`[text](mailto:...)`) are left as links, since they're an intentional link, not an autolink.
- **Default behavior is completely unchanged** when the prop is omitted — no extra plugin is added to the remark pipeline in that case.

## How

`mdast-util-gfm-autolink-literal` doesn't tag the link nodes it creates, so a small remark plugin (`packages/streamdown/lib/remark/disable-autolink-protocols.ts`) identifies them structurally: a link with exactly one `text` child whose value reconstructs the node's `url` (accounting for the `mailto:` prefix GFM adds to bare emails). Matching nodes are unwrapped back to their text children. The plugin runs immediately after `remark-gfm` in the pipeline (before the CJK/math plugin slots), matching the existing "before/after gfm" plugin ordering convention.

It's exposed via the standard unified `[plugin, options]` tuple form rather than a plugin-factory closure — Streamdown's internal `Markdown` processor cache keys processors by plugin name + `JSON.stringify(options)`, and a factory returning a fresh anonymous closure per call would always serialize to the same cache key, causing different `disableAutolinkProtocols` configurations to silently reuse a stale cached processor (caught this via a failing test while developing).

## Testing

Added `packages/streamdown/__tests__/disable-autolink-protocols.test.tsx` covering:
- bare email not linked when `mailto` is disabled
- default behavior (prop omitted) unchanged
- explicit `[text](mailto:...)` links stay linked
- http/https autolinks still linked when only `mailto` is disabled
- case-insensitivity and the `"mailto:"` form
- disabling `https` leaves `mailto` autolinks untouched
- end-to-end wiring through the `<Streamdown disableAutolinkProtocols>` prop itself

`pnpm -F streamdown exec vitest run` passes except for 5 pre-existing failures on `main` unrelated to this change (image-placeholder / incomplete-image-sanitize tests, verified failing identically on a clean `upstream/main` checkout before my changes).

Also updated `apps/website/content/docs/configuration.mdx` with the new prop, and added a changeset.