### PR TITLE
feat: wire `onCopy`/`onError `on default code-block copy controls

### DIFF
--- a/.changeset/code-copy-callbacks.md
+++ b/.changeset/code-copy-callbacks.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Wire `onCopy` and `onError` through default code and Mermaid copy controls via `controls.code.copy` and `controls.mermaid.copy`.

--- a/apps/website/content/docs/code-blocks.mdx
+++ b/apps/website/content/docs/code-blocks.mdx
@@ -218,6 +218,25 @@ The copy button:
 - Provides visual feedback on successful copy
 - Is automatically disabled during streaming (when `isAnimating={true}`)
 
+### Copy Callbacks
+
+Pass `onCopy` and/or `onError` through `controls.code.copy` to run your own logic after the default copy button succeeds or fails. The button still renders — you do not need a custom component.
+
+```tsx title="app/page.tsx"
+<Streamdown
+  controls={{
+    code: {
+      copy: {
+        onCopy: () => toast.success("Copied to clipboard"),
+        onError: (error) => toast.error(error.message),
+      },
+    },
+  }}
+>
+  {markdown}
+</Streamdown>
+```
+
 ### Disable Controls
 
 Disable individual code block buttons using the `controls` prop:

--- a/apps/website/content/docs/configuration.mdx
+++ b/apps/website/content/docs/configuration.mdx
@@ -154,7 +154,7 @@ Math rendering and CJK support require installing separate plugins. See [Mathema
     },
     controls: {
       description:
-        "Control visibility of interactive buttons and custom download filenames for code, tables, and mermaid diagrams.",
+        "Control visibility of interactive buttons, custom download filenames, and copy callbacks (`onCopy` / `onError`) for code, tables, and mermaid diagrams.",
       type: "ControlsConfig",
       default: "true",
     },
@@ -361,7 +361,7 @@ import { Streamdown, defaultUrlTransform } from 'streamdown';
   }}
 />
 
-The `controls` prop can be configured granularly. Set a block type to `false` to hide all of its buttons, or pass an object to toggle individual actions. For downloads, pass `{ filename: "customName" }` to set a custom base filename — the file extension is added automatically.
+The `controls` prop can be configured granularly. Set a block type to `false` to hide all of its buttons, or pass an object to toggle individual actions. For downloads, pass `{ filename: "customName" }` to set a custom base filename — the file extension is added automatically. For code and Mermaid copy buttons, pass `{ onCopy, onError }` to hook into the default copy flow without replacing the button.
 
 ```tsx title="app/page.tsx"
 <Streamdown
@@ -373,12 +373,18 @@ The `controls` prop can be configured granularly. Set a block type to `false` to
       csvSeparator: ",", // "," | ";" | "\t" | "auto"
     },
     code: {
-      copy: true, // Show code copy button
+      copy: {
+        onCopy: () => console.log("copied"), // optional success callback
+        onError: (error) => console.error(error), // optional error callback
+      },
       download: { filename: "myScript" }, // Download as myScript.js, myScript.py, etc.
     },
     mermaid: {
       download: { filename: "flowchart" }, // Download as flowchart.svg / flowchart.png / flowchart.mmd
-      copy: true, // Show mermaid copy button
+      copy: {
+        onCopy: () => console.log("copied"),
+        onError: (error) => console.error(error),
+      },
       fullscreen: true, // Show mermaid fullscreen button
       panZoom: true, // Show mermaid pan/zoom controls
     },
@@ -388,7 +394,7 @@ The `controls` prop can be configured granularly. Set a block type to `false` to
 </Streamdown>
 ```
 
-You can still use `download: true` (or omit it) to keep the default filenames: `file.<ext>` for code, `table.csv` / `table.md` for tables, and `diagram.svg` / `diagram.png` / `diagram.mmd` for mermaid.
+You can still use `copy: true` / `copy: false` to show or hide the button, and `download: true` (or omit it) to keep the default filenames: `file.<ext>` for code, `table.csv` / `table.md` for tables, and `diagram.svg` / `diagram.png` / `diagram.mmd` for mermaid.
 
 ### Remend Options
 

--- a/apps/website/content/docs/interactivity.mdx
+++ b/apps/website/content/docs/interactivity.mdx
@@ -63,6 +63,25 @@ CSV copy and download use a comma by default. Customize the delimiter with `cont
 
 Every code block includes a copy button that appears on hover. The copy button will be shown for code blocks in the top-right corner on hover. The copy button will copy the raw code without syntax highlighting. It will also show a checkmark for 2 seconds after successful copy. It will be disabled during streaming to prevent copying incomplete code.
 
+Pass callbacks through `controls.code.copy` to react to copy success or failure without replacing the default button:
+
+```tsx
+<Streamdown
+  controls={{
+    code: {
+      copy: {
+        onCopy: () => toast.success("Code copied"),
+        onError: (error) => toast.error(error.message),
+      },
+    },
+  }}
+>
+  {markdown}
+</Streamdown>
+```
+
+You can still use `copy: true` / `copy: false` to show or hide the button without callbacks.
+
 ### Download Code
 
 Code blocks also include a download button that appears on hover. The download button will be shown for code blocks in the top-right corner on hover. The download button will download the code with the appropriate file extension based on language. It will also use "file.[extension]" as the filename by default. Customize the base name with `controls.code.download`:
@@ -80,6 +99,23 @@ A JavaScript block would download as `myScript.js`. It will preserve formatting 
 ### Copy Diagrams
 
 Mermaid diagrams include a copy button that allows users to copy the diagram source code. The copy button will be shown for Mermaid diagrams in the top-right corner on hover. The copy button will copy the raw Mermaid syntax for easy sharing and editing.
+
+Pass callbacks through `controls.mermaid.copy` the same way as code blocks:
+
+```tsx
+<Streamdown
+  controls={{
+    mermaid: {
+      copy: {
+        onCopy: () => toast.success("Diagram copied"),
+        onError: (error) => toast.error(error.message),
+      },
+    },
+  }}
+>
+  {markdown}
+</Streamdown>
+```
 
 ### Download Diagrams
 

--- a/apps/website/content/docs/plugins/mermaid.mdx
+++ b/apps/website/content/docs/plugins/mermaid.mdx
@@ -473,7 +473,23 @@ Download the diagram as SVG, PNG, or Mermaid source. By default files are named 
 
 ### Copy
 
-Copy the diagram to your clipboard for pasting into other applications.
+Copy the diagram source to your clipboard for pasting into other applications. Pass callbacks through `controls.mermaid.copy` to react to success or failure without replacing the default button:
+
+```tsx
+<Streamdown
+  plugins={{ mermaid }}
+  controls={{
+    mermaid: {
+      copy: {
+        onCopy: () => toast.success("Diagram copied"),
+        onError: (error) => toast.error(error.message),
+      },
+    },
+  }}
+>
+  {markdown}
+</Streamdown>
+```
 
 ### Customizing Controls
 
@@ -486,7 +502,7 @@ You can customize which controls are shown:
     mermaid: {
       fullscreen: true,
       download: { filename: "flowchart" }, // Download as flowchart.svg / flowchart.png / flowchart.mmd
-      copy: true,
+      copy: true, // or { onCopy, onError } for callbacks
       panZoom: true, // Enable pan and zoom controls
     },
   }}

--- a/packages/streamdown/__tests__/controls.test.ts
+++ b/packages/streamdown/__tests__/controls.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { getDownloadFilename } from "../lib/controls";
+import { describe, expect, it, vi } from "vitest";
+import { getCopyCallbacks, getDownloadFilename } from "../lib/controls";
 
 describe("getDownloadFilename", () => {
   it("returns the fallback when controls is a boolean", () => {
@@ -62,5 +62,55 @@ describe("getDownloadFilename", () => {
         "file"
       )
     ).toBe("file");
+  });
+});
+
+describe("getCopyCallbacks", () => {
+  it("returns empty callbacks when controls is a boolean", () => {
+    expect(getCopyCallbacks(true, "code")).toEqual({});
+    expect(getCopyCallbacks(false, "mermaid")).toEqual({});
+  });
+
+  it("returns empty callbacks when the block type is not configured", () => {
+    expect(getCopyCallbacks({}, "code")).toEqual({});
+    expect(getCopyCallbacks({ table: true }, "code")).toEqual({});
+  });
+
+  it("returns empty callbacks when the block type is a boolean", () => {
+    expect(getCopyCallbacks({ code: true }, "code")).toEqual({});
+    expect(getCopyCallbacks({ mermaid: false }, "mermaid")).toEqual({});
+  });
+
+  it("returns empty callbacks when copy is a boolean", () => {
+    expect(getCopyCallbacks({ code: { copy: true } }, "code")).toEqual({});
+    expect(getCopyCallbacks({ code: { copy: false } }, "code")).toEqual({});
+    expect(getCopyCallbacks({ mermaid: { copy: true } }, "mermaid")).toEqual(
+      {}
+    );
+  });
+
+  it("returns onCopy and onError from copy config", () => {
+    const onCopy = vi.fn();
+    const onError = vi.fn();
+
+    expect(
+      getCopyCallbacks({ code: { copy: { onCopy, onError } } }, "code")
+    ).toEqual({ onCopy, onError });
+    expect(
+      getCopyCallbacks({ mermaid: { copy: { onCopy, onError } } }, "mermaid")
+    ).toEqual({ onCopy, onError });
+  });
+
+  it("returns partial callbacks when only one is provided", () => {
+    const onCopy = vi.fn();
+    expect(getCopyCallbacks({ code: { copy: { onCopy } } }, "code")).toEqual({
+      onCopy,
+      onError: undefined,
+    });
+
+    const onError = vi.fn();
+    expect(
+      getCopyCallbacks({ mermaid: { copy: { onError } } }, "mermaid")
+    ).toEqual({ onCopy: undefined, onError });
   });
 });

--- a/packages/streamdown/__tests__/show-controls.test.tsx
+++ b/packages/streamdown/__tests__/show-controls.test.tsx
@@ -467,6 +467,100 @@ graph TD
         expect(downloadBtn).toBeTruthy();
       });
     });
+
+    it("should wire onCopy from code.copy config to the default copy button", async () => {
+      const onCopy = vi.fn();
+      const originalClipboard = navigator.clipboard;
+
+      Object.defineProperty(navigator, "clipboard", {
+        value: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const { container } = render(
+        <Streamdown controls={{ code: { copy: { onCopy } } }}>
+          {markdownWithCode}
+        </Streamdown>
+      );
+
+      const button = await waitFor(() => {
+        const copyBtn = container.querySelector(
+          '[data-streamdown="code-block-copy-button"]'
+        );
+        expect(copyBtn).toBeTruthy();
+        expect(copyBtn?.hasAttribute("disabled")).toBe(false);
+        return copyBtn as HTMLButtonElement;
+      });
+
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalled();
+        expect(onCopy).toHaveBeenCalled();
+      });
+
+      Object.defineProperty(navigator, "clipboard", {
+        value: originalClipboard,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("should wire onError from code.copy config when clipboard is unavailable", async () => {
+      const onError = vi.fn();
+      const originalClipboard = navigator.clipboard;
+
+      Object.defineProperty(navigator, "clipboard", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { container } = render(
+        <Streamdown controls={{ code: { copy: { onError } } }}>
+          {markdownWithCode}
+        </Streamdown>
+      );
+
+      const button = await waitFor(() => {
+        const copyBtn = container.querySelector(
+          '[data-streamdown="code-block-copy-button"]'
+        );
+        expect(copyBtn).toBeTruthy();
+        expect(copyBtn?.hasAttribute("disabled")).toBe(false);
+        return copyBtn as HTMLButtonElement;
+      });
+
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+      });
+
+      Object.defineProperty(navigator, "clipboard", {
+        value: originalClipboard,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("should still show the copy button when copy is an object config", async () => {
+      const { container } = render(
+        <Streamdown controls={{ code: { copy: { onCopy: () => undefined } } }}>
+          {markdownWithCode}
+        </Streamdown>
+      );
+
+      await waitFor(() => {
+        const copyBtn = container.querySelector(
+          '[data-streamdown="code-block-copy-button"]'
+        );
+        expect(copyBtn).toBeTruthy();
+      });
+    });
   });
 
   describe("image controls", () => {

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -139,6 +139,13 @@ export const normalizeHtmlIndentation = (content: string): string => {
 
 export type DownloadControlConfig = boolean | { filename: string };
 
+export type CopyControlConfig =
+  | boolean
+  | {
+      onCopy?: () => void;
+      onError?: (error: Error) => void;
+    };
+
 export type ControlsConfig =
   | boolean
   | {
@@ -153,14 +160,14 @@ export type ControlsConfig =
       code?:
         | boolean
         | {
-            copy?: boolean;
+            copy?: CopyControlConfig;
             download?: DownloadControlConfig;
           };
       mermaid?:
         | boolean
         | {
             download?: DownloadControlConfig;
-            copy?: boolean;
+            copy?: CopyControlConfig;
             fullscreen?: boolean;
             panZoom?: boolean;
           };

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -20,6 +20,7 @@ import { CodeBlock } from "./code-block";
 import { CodeBlockCopyButton } from "./code-block/copy-button";
 import { CodeBlockDownloadButton } from "./code-block/download-button";
 import { CodeBlockSkeleton } from "./code-block/skeleton";
+import { getCopyCallbacks } from "./controls";
 import { ImageComponent } from "./image";
 import { LinkSafetyModal } from "./link-modal";
 import type { ExtraProps, Options } from "./markdown";
@@ -947,7 +948,12 @@ const CodeComponent = ({
                     config={mermaidContext?.config}
                   />
                 ) : null}
-                {showCopy ? <CodeBlockCopyButton code={code} /> : null}
+                {showCopy ? (
+                  <CodeBlockCopyButton
+                    code={code}
+                    {...getCopyCallbacks(controlsConfig, "mermaid")}
+                  />
+                ) : null}
                 {showFullscreen ? (
                   <MermaidFullscreenButton
                     chart={code}
@@ -992,7 +998,11 @@ const CodeComponent = ({
           {showDownload ? (
             <CodeBlockDownloadButton code={code} language={language} />
           ) : null}
-          {showCopy ? <CodeBlockCopyButton /> : null}
+          {showCopy ? (
+            <CodeBlockCopyButton
+              {...getCopyCallbacks(controlsConfig, "code")}
+            />
+          ) : null}
         </>
       ) : null}
     </CodeBlock>

--- a/packages/streamdown/lib/controls.ts
+++ b/packages/streamdown/lib/controls.ts
@@ -21,3 +21,27 @@ export const getDownloadFilename = (
 
   return downloadConfig.filename || fallback;
 };
+
+export const getCopyCallbacks = (
+  config: ControlsConfig,
+  type: "code" | "mermaid"
+): { onCopy?: () => void; onError?: (error: Error) => void } => {
+  if (typeof config === "boolean") {
+    return {};
+  }
+
+  const typeConfig = config[type];
+  if (typeof typeConfig !== "object") {
+    return {};
+  }
+
+  const copyConfig = typeConfig.copy;
+  if (typeof copyConfig !== "object" || copyConfig === null) {
+    return {};
+  }
+
+  return {
+    onCopy: copyConfig.onCopy,
+    onError: copyConfig.onError,
+  };
+};


### PR DESCRIPTION
## Summary

- Extend `ControlsConfig` with `CopyControlConfig` so `controls.code.copy` / `controls.mermaid.copy` can be `{ onCopy, onError }` (still accepts `boolean`).
- Thread those callbacks into the default-rendered `CodeBlockCopyButton` via `getCopyCallbacks`.
- Add unit and integration coverage for callback extraction and default control wiring.

Hosts using default controls can now surface copy failures and hook success events without re-owning the full code composition:

```tsx
<Streamdown
  controls={{
    code: {
      copy: {
        onCopy: () => announce("Copied"),
        onError: (error) => toast.error(error.message),
      },
    },
  }}
>
  {markdown}
</Streamdown>
```

Closes #557

## Test plan

- [x] `vitest run controls.test.ts show-controls.test.tsx`
- [x] `vitest run code-block.test.tsx`
- [ ] Click default code copy button with `controls.code.copy.onCopy` and confirm callback fires
- [ ] Confirm clipboard-unavailable path calls `onError`
- [ ] Confirm `copy: false` still hides the button and object config still shows it