### PR TITLE
fix: preserve literal data in multiline custom tags

### DIFF
--- a/.changeset/literal-data-containers.md
+++ b/.changeset/literal-data-containers.md
@@ -1,0 +1,5 @@
+---
+"streamdown": patch
+---
+
+Keep literal data tags out of multiline Markdown-container preprocessing so encoded punctuation next to URLs remains literal text.

--- a/packages/streamdown/__tests__/custom-tags-markdown.test.tsx
+++ b/packages/streamdown/__tests__/custom-tags-markdown.test.tsx
@@ -13,6 +13,25 @@ const LITERAL_BOLD_RE = /\*{2}bold\*{2}|\\?\*{1,2}bold\\?\*{1,2}/;
 const STRONG_SELECTOR = '[data-streamdown="strong"]';
 
 describe("Issue #478 - Markdown inside custom tags (multiline content)", () => {
+  it("preserves encoded JSON punctuation next to URLs in literal data tags", () => {
+    const LiteralData = (props: CustomComponentProps) => (
+      <div data-testid="literal-data">{props.children as React.ReactNode}</div>
+    );
+    const { container } = render(
+      <Streamdown
+        allowedTags={{ "literal-data": [] }}
+        components={{ "literal-data": LiteralData }}
+        literalTagContent={["literal-data"]}
+        mode="static"
+      >
+        {'<literal-data>\n{"websites":&#91;"https://example.com"&#93;}\n</literal-data>'}
+      </Streamdown>
+    );
+    expect(
+      container.querySelector('[data-testid="literal-data"]')?.textContent?.trim()
+    ).toBe('{"websites":["https://example.com"]}');
+  });
+
   it("should render bold markdown inside custom tag with newline prefix", () => {
     const AiThinking = (props: CustomComponentProps) => (
       <div data-testid="ai-thinking">{props.children as React.ReactNode}</div>

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -585,7 +585,10 @@ export const Streamdown = memo(
       // parses, plus <!----> placeholders for internal blank lines. Runs after
       // literal escaping so those markers are not corrupted.
       if (allowedTagNames.length > 0) {
-        result = preprocessCustomTags(result, allowedTagNames);
+        result = preprocessCustomTags(
+          result,
+          allowedTagNames.filter((tag) => !literalTagContent?.includes(tag))
+        );
       }
 
       return result;


### PR DESCRIPTION
## Problem
Multiline custom-tag preprocessing also processes literalTagContent tags. Its blank-line sandwich makes entity-encoded punctuation following a bare URL enter Markdown/GFM parsing. For example, a literal JSON body containing {"websites":&#91;"https://example.com"&#93;} arrives with the closing &#93; still encoded and is no longer valid JSON.

## Fix
Exclude explicitly literal tags from Markdown-container preprocessing. Keep existing literal escaping/restoration and normal Markdown custom-tag processing unchanged.

## Validation
Added a renderer regression that fails on current main and passes with this change. 47 tests pass across custom-tag Markdown, preprocessing, and literal-content suites. Downstream reproduction: https://github.com/comp-work/monorepo/pull/1896 (private repository), where URL-bearing suggested tasks disappear while URL-free tasks survive. This source change corresponds to the downstream maintained patch; no sanitizer rules are relaxed.