### PR TITLE
fix(remend): guard incomplete HTML tag handler against math blocks

### DIFF
--- a/.changeset/html-tag-math-guard.md
+++ b/.changeset/html-tag-math-guard.md
@@ -1,0 +1,16 @@
+---
+"remend": patch
+---
+
+Stop the incomplete-HTML-tag handler from truncating math expressions.
+
+`handleIncompleteHtmlTag` guarded against code blocks but not math, so an ordinary
+comparison inside math — `$$ I = \sum_{j<k} p_j $$` — matched the incomplete-tag
+pattern and deleted everything from the `<` to the end of the string. The trailing
+`$$` was then auto-closed by the katex handler, so KaTeX rendered a parse error and
+the rest of the message never reached the DOM.
+
+The handler now skips candidates inside math blocks (`$`, `$$`, `\(`, `\[`), matching
+the guard the emphasis handlers already had. Because the pattern is leftmost-matching,
+it also walks forward to later candidates instead of bailing out, so a genuine
+incomplete tag after a math expression is still stripped.

--- a/packages/remend/__tests__/html-tags.test.ts
+++ b/packages/remend/__tests__/html-tags.test.ts
@@ -74,6 +74,29 @@ describe("incomplete HTML tag stripping", () => {
     );
   });
 
+  it("should not strip < inside block math", () => {
+    const text = "Intro\n\n$$\nI = \\sum_{j<k} p_j\n$$\n\nTAIL";
+    expect(remend(text)).toBe(text);
+  });
+
+  it("should not strip < inside inline dollar math", () => {
+    const text = "inline $A_{j<k}$ more";
+    expect(remend(text)).toBe(text);
+  });
+
+  it("should not strip < inside LaTeX delimiters", () => {
+    const inline = "value \\(a<b\\) end";
+    expect(remend(inline)).toBe(inline);
+
+    const block = "value \\[a<b\\] end";
+    expect(remend(block)).toBe(block);
+  });
+
+  it("should still strip incomplete tags outside math blocks", () => {
+    expect(remend("$x<y$ then <div")).toBe("$x<y$ then");
+    expect(remend("$$a<b$$ done <span")).toBe("$$a<b$$ done");
+  });
+
   it("should be disabled when htmlTags option is false", () => {
     expect(remend("Hello <div", { htmlTags: false })).toBe("Hello <div");
   });

--- a/packages/remend/src/html-tag-handler.ts
+++ b/packages/remend/src/html-tag-handler.ts
@@ -1,9 +1,20 @@
 import { isInsideCodeBlock } from "./code-block-utils";
+import { isWithinMathBlock } from "./utils";
 
 // Matches an incomplete HTML tag at the end of the string.
 // Must start with < followed by a letter (opening tag) or / (closing tag),
 // and must NOT contain a > (which would close the tag).
 const incompleteHtmlTagPattern = /<[a-zA-Z/][^>]*$/;
+
+const tagNameStartPattern = /[a-zA-Z/]/;
+
+const hasMathDelimiters = (text: string): boolean =>
+  text.includes("$") || text.includes("\\(") || text.includes("\\[");
+
+const startsTag = (text: string, index: number): boolean => {
+  const nextChar = text[index + 1];
+  return nextChar !== undefined && tagNameStartPattern.test(nextChar);
+};
 
 export const handleIncompleteHtmlTag = (text: string): string => {
   const match = text.match(incompleteHtmlTagPattern);
@@ -12,11 +23,28 @@ export const handleIncompleteHtmlTag = (text: string): string => {
     return text;
   }
 
-  // Don't strip if the < is inside a code block or inline code
-  if (isInsideCodeBlock(text, match.index)) {
-    return text;
+  // The pattern is leftmost-matching and always runs to the end of the string,
+  // so every later < that starts a tag name is an equally valid candidate.
+  // Walk forward until we find one that is not inside code or math: a comparison
+  // operator such as \sum_{j<k} must not swallow the rest of the message.
+  const checkMath = hasMathDelimiters(text);
+
+  for (let index = match.index; index < text.length; index += 1) {
+    if (text[index] !== "<" || !startsTag(text, index)) {
+      continue;
+    }
+
+    if (isInsideCodeBlock(text, index)) {
+      continue;
+    }
+
+    if (checkMath && isWithinMathBlock(text, index)) {
+      continue;
+    }
+
+    // Strip the incomplete tag and any trailing whitespace before it
+    return text.substring(0, index).trimEnd();
   }
 
-  // Strip the incomplete tag and any trailing whitespace before it
-  return text.substring(0, match.index).trimEnd();
+  return text;
 };


### PR DESCRIPTION
## Description

`handleIncompleteHtmlTag` guarded against code blocks but never against math, so an ordinary
comparison inside a math expression matched the incomplete-tag pattern and deleted everything
from the `<` to the end of the string.

```js
remend('Intro\n\n$$\nI = \\sum_{j<k} p_j\n$$\n\nTAIL')
// before → 'Intro\n\n$$\nI = \\sum_{j\n$$'   ← TAIL gone, math truncated
// after  → unchanged
```

Because the `katex` handler (priority 70) runs after `htmlTags` (priority 10), the now-orphaned
`$$` was auto-closed, so KaTeX received unterminated input and rendered a `ParseError` in
`--color-muted-foreground`. The net effect for the reader is a message that silently ends
mid-formula in grey text, with no error surfaced anywhere.

`remend` already implements and exports `isWithinMathBlock`, and the emphasis handlers already
use it — `htmlTags` was simply never covered.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Related to #616

<sub>Deliberately not `Fixes` — this covers the math half of that issue. See **Additional Notes**.</sub>

## Changes Made

- Added an `isWithinMathBlock` guard to `handleIncompleteHtmlTag`, gated behind the same
  `hasMathDelimiters` fast path the emphasis handlers use, so the `O(n)` scan is skipped
  entirely for text with no math delimiters.
- **Changed the handler to walk forward through candidates instead of bailing out on the
  first guarded one.** This is the non-obvious half. `incompleteHtmlTagPattern` is
  leftmost-matching and its `[^>]*$` tail means the match always runs to the end of the
  string — so every later `<` that starts a tag name is an equally valid candidate. Simply
  returning `text` when the first match falls inside math would trade one bug for another:

  ```js
  remend('$x<y$ then <div')
  // guard-only → '$x<y$ then <div'   ← the genuine incomplete tag now survives. wrong.
  // this PR    → '$x<y$ then'        ← correct
  ```

  The same walk-forward now applies to code blocks, which fixes a smaller unreported case
  on its own: a `<` inside a fenced block no longer masks a real incomplete tag after it.
- Added 4 test cases to `packages/remend/__tests__/html-tags.test.ts`.
- Added a patch changeset for `remend`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

New cases cover block `$$`, inline `$`, both LaTeX delimiter forms (`\(…\)` and `\[…\]`), and
the walk-forward behaviour. I confirmed all four fail on `main` before the fix and pass after —
the walk-forward case in particular fails against a guard-only implementation too.

Manual verification against the exact reproductions from the issue:

| Input | Before | After |
| --- | --- | --- |
| `Intro\n\n$$\nI = \sum_{j<k} p_j\n$$\n\nTAIL` | truncated at `\sum_{j` | unchanged |
| `inline $$A_{j<k}$$ more\n\nTAIL` | `inline $$A_{j$$` | unchanged |
| `Hello <div` | `Hello` | `Hello` (unchanged behaviour) |

### Test Coverage

`remend`: 493 tests across 26 files, all passing.
Full monorepo suite: 1172 tests across 85 files, 6/6 turbo tasks green.
`biome check` reports no findings on both touched files.

<sub>Note: `tsc --noEmit` reports two `TS18048` errors in `packages/remend/src/strikethrough-handler.ts`.
I verified these are present on `main` and unrelated to this change.</sub>

## Screenshots/Demos

Not applicable — no visual surface changes. The before/after is shown as code above.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

<sub>Documentation left unchecked: this is a behavioural fix with no public API change, so there is
nothing in the docs to update. Happy to add a note to the termination docs if you'd like one.</sub>

## Changeset

- [x] I have created a changeset for these changes

`.changeset/html-tag-math-guard.md` — `patch` bump for `remend`.

## Additional Notes

**What this PR intentionally leaves out.** #616 raises a second, broader problem: the handler
also fires on text that is already complete, so ordinary prose like `the loop runs while i<n`
still loses its remainder. That one is not a missing guard — it needs an explicit signal,
because `remend(text)` currently cannot distinguish a streaming tail from settled text, and
every tail-oriented heuristic keeps firing after the stream ends.

The issue suggests an option or a `mode` argument mirroring `Streamdown`'s `mode="static"`.
That is a public API decision affecting more than this handler, so I did not want to make it
unilaterally in a first contribution. Happy to open a follow-up if you want to shape the API —
or to fold it into this PR if you already know which direction you'd prefer.
