### PR TITLE
fix: preserve streaming animations across text and code

### DIFF
--- a/.changeset/tidy-words-fade.md
+++ b/.changeset/tidy-words-fade.md
@@ -1,0 +1,9 @@
+---
+"streamdown": patch
+---
+
+Preserve pending and active word animations across streaming updates instead of setting their duration to zero before they finish. Apply the same timing to list markers, task checkboxes, images, and horizontal rules.
+
+Allow finite text animations to finish after streaming stops before removing their wrappers. Cleanup follows browser animation completion, including cancellation, rather than using a fixed timeout.
+
+Discard animation history for removed blocks and reset the timeline when content is cleared, so the first words of a replay animate again instead of appearing instantly.

--- a/.changeset/tidy-words-fade.md
+++ b/.changeset/tidy-words-fade.md
@@ -9,3 +9,5 @@ Allow finite text animations to finish after streaming stops before removing the
 Discard animation history for removed blocks and reset the timeline when content is cleared, so the first words of a replay animate again instead of appearing instantly.
 
 Exclude parser-generated layout whitespace from animation offsets so new words inside lists receive their fade and tight-to-loose list transitions preserve existing text history. Source whitespace remains counted.
+
+Animate fenced code as one unit on the shared timeline, preserving its fade while code and syntax highlighting update.

--- a/.changeset/tidy-words-fade.md
+++ b/.changeset/tidy-words-fade.md
@@ -7,3 +7,5 @@ Preserve pending and active word animations across streaming updates instead of 
 Allow finite text animations to finish after streaming stops before removing their wrappers. Cleanup follows browser animation completion, including cancellation, rather than using a fixed timeout.
 
 Discard animation history for removed blocks and reset the timeline when content is cleared, so the first words of a replay animate again instead of appearing instantly.
+
+Exclude parser-generated layout whitespace from animation offsets so new words inside lists receive their fade and tight-to-loose list transitions preserve existing text history. Source whitespace remains counted.

--- a/.changeset/tidy-words-fade.md
+++ b/.changeset/tidy-words-fade.md
@@ -11,3 +11,5 @@ Discard animation history for removed blocks and reset the timeline when content
 Exclude parser-generated layout whitespace from animation offsets so new words inside lists receive their fade and tight-to-loose list transitions preserve existing text history. Source whitespace remains counted.
 
 Animate fenced code as one unit on the shared timeline, preserving its fade while code and syntax highlighting update.
+
+Use one timestamp per render pass when scheduling blocks, so parsing time cannot let later blocks overtake earlier text.

--- a/packages/streamdown/__tests__/animate-issues.test.tsx
+++ b/packages/streamdown/__tests__/animate-issues.test.tsx
@@ -8,12 +8,14 @@
  */
 import { act, render } from "@testing-library/react";
 import { StrictMode, useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Streamdown } from "../index";
 import { MAX_ANIMATION_BACKLOG_MS } from "../lib/animate";
 
 const NEW_WORD_RE = /^(Next|section|arrives)$/;
 const SPAN_GAP_RE = /<\/span> <span/;
+
+afterEach(() => vi.restoreAllMocks());
 
 const parseDelay = (el: Element): number => {
   const raw = (el as HTMLElement).style.getPropertyValue("--sd-delay").trim();
@@ -257,7 +259,8 @@ describe("issue #570 — spans come off when isAnimating goes false", () => {
     expect(mounts).toBe(1);
   });
 
-  it("suppresses already-seen words under StrictMode double-invoke", async () => {
+  it("suppresses settled words under StrictMode double-invoke", async () => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(1000);
     const config = {
       animation: "fadeIn" as const,
       duration: 200,
@@ -276,6 +279,7 @@ describe("issue #570 — spans come off when isAnimating goes false", () => {
     await act(() => Promise.resolve());
     await act(() => Promise.resolve());
 
+    clock.mockReturnValue(1250);
     await act(() => {
       rerender(
         <StrictMode>
@@ -292,7 +296,7 @@ describe("issue #570 — spans come off when isAnimating goes false", () => {
       container.querySelectorAll("[data-sd-animate]")
     ) as HTMLElement[];
 
-    // "one"/"two"/"three" should have duration 0 (already seen); "four"/"five"
+    // "one"/"two"/"three" should have duration 0 (finished); "four"/"five"
     // keep the configured duration. Under the old get-and-reset path, StrictMode
     // would wipe prevContentLength and every span would be 200ms.
     const durations = spans.map((el) =>

--- a/packages/streamdown/__tests__/animate.test.ts
+++ b/packages/streamdown/__tests__/animate.test.ts
@@ -1,5 +1,7 @@
 import rehypeParse from "rehype-parse";
 import rehypeStringify from "rehype-stringify";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 import { describe, expect, it } from "vitest";
 import {
@@ -220,6 +222,17 @@ describe("animate plugin", () => {
   });
 
   describe("getLastRenderCharCount", () => {
+    it("counts source spaces without counting generated list padding", async () => {
+      const plugin = createAnimatePlugin();
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkRehype)
+        .use(plugin.rehypePlugin)
+        .use(rehypeStringify);
+      await processor.process("1. *One* **two**");
+      expect(plugin.getLastRenderCharCount()).toBe("One two".length);
+    });
+
     it("should return 0 before any render", () => {
       const plugin = createAnimatePlugin();
       expect(plugin.getLastRenderCharCount()).toBe(0);

--- a/packages/streamdown/__tests__/animate.test.ts
+++ b/packages/streamdown/__tests__/animate.test.ts
@@ -840,3 +840,15 @@ describe("code fence animation", () => {
     expect(settled.match(/--sd-duration:0ms/g)).toHaveLength(3);
   });
 });
+
+it("schedules blocks against one clock even when rendering takes time", async () => {
+  let now = 1000;
+  const timeline = createAnimateTimeline({ now: () => now });
+  const heading = createAnimatePlugin({ stagger: 10, timeline });
+  const code = createAnimatePlugin({ stagger: 10, timeline });
+  timeline.beginPass(now);
+  await processHtml("<h3>Code example</h3>", heading);
+  now += 15;
+  const result = await processHtml("<pre><code>const x = 1</code></pre>", code);
+  expect(delaysOf(result)).toEqual([20]);
+});

--- a/packages/streamdown/__tests__/animate.test.ts
+++ b/packages/streamdown/__tests__/animate.test.ts
@@ -261,7 +261,7 @@ describe("animate plugin", () => {
       const plugin = createAnimatePlugin();
       // First render: "Hello"
       await processHtml("<p>Hello</p>", plugin);
-      plugin.commit();
+      plugin.setPrevContentLength(plugin.getLastRenderCharCount());
 
       // Second render: "Hello world" — committed count drives the skip window
       const result = await processHtml("<p>Hello world</p>", plugin);
@@ -269,12 +269,52 @@ describe("animate plugin", () => {
       // "Hello" (chars 0-4) should have duration:0ms — already visible
       // " world" should have normal duration
       const spans = result.match(/--sd-duration:[^;"]*/g) ?? [];
-      expect(spans.some((s) => s.includes("0ms"))).toBe(true);
-      expect(spans.some((s) => s.includes("150ms"))).toBe(true);
+      expect(spans).toEqual(["--sd-duration:0ms", "--sd-duration:150ms"]);
     });
   });
 
   describe("stagger delay", () => {
+    it.each([
+      ["list marker", "<ul><li>Alpha beta", "</li></ul>", "li"],
+      [
+        "task checkbox",
+        '<ul><li><input type="checkbox">Alpha beta',
+        "</li></ul>",
+        "input",
+      ],
+      ["image", '<p><img src="/test.png">Alpha beta', "</p>", "img"],
+      ["rule", "<hr><p>Alpha beta", "</p>", "hr"],
+    ])("preserves a pending %s animation across updates", async (_name, prefix, suffix, selector) => {
+      let now = 1000;
+      const timeline = createAnimateTimeline({ now: () => now });
+      const plugin = createAnimatePlugin({ duration: 250, timeline });
+      timeline.beginPass(now);
+      const before = document.createElement("div");
+      before.innerHTML = await processHtml(prefix + suffix, plugin);
+      const style = before.querySelector(selector)?.getAttribute("style");
+      expect(style).toContain("250ms");
+      plugin.commit();
+      timeline.commitPass();
+
+      now += 50;
+      timeline.beginPass(now);
+      const after = document.createElement("div");
+      after.innerHTML = await processHtml(`${prefix} gamma${suffix}`, plugin);
+      expect(after.querySelector(selector)?.getAttribute("style")).toBe(style);
+      plugin.commit();
+      timeline.commitPass();
+
+      now += 500;
+      timeline.beginPass(now);
+      after.innerHTML = await processHtml(
+        `${prefix} gamma delta${suffix}`,
+        plugin
+      );
+      expect(after.querySelector(selector)?.getAttribute("style")).toContain(
+        "duration:0ms"
+      );
+    });
+
     it("should apply incremental delay to each word", async () => {
       const plugin = createAnimatePlugin({ stagger: 50 });
       const result = await processHtml("<p>Hello world foo</p>", plugin);
@@ -413,7 +453,7 @@ describe("animate plugin", () => {
       const result = await processHtml("<p>Hello world foo</p>", plugin);
       timeline.commitPass();
 
-      expect(delaysOf(result)).toEqual([70]);
+      expect(delaysOf(result)).toEqual([50, 70]);
     });
 
     it("per-plugin mark/rewind makes StrictMode double-rehype idempotent", async () => {

--- a/packages/streamdown/__tests__/animate.test.ts
+++ b/packages/streamdown/__tests__/animate.test.ts
@@ -19,7 +19,7 @@ const WORLD_SPAN_RE = />world<\/span>/;
 const I_SPACE_SPAN_RE = />i <\/span>/;
 const INLINE_CODE_ANIMATE_RE =
   /<code[^>]*>[\s\S]*data-sd-animate[\s\S]*world[\s\S]*<\/code>/;
-const FENCED_PRE_BARE_RE = /<pre><code>block<\/code><\/pre>/;
+const FENCED_PRE_BARE_RE = /<pre[^>]*><code>block<\/code><\/pre>/;
 const PRE_ANIMATE_RE = /<pre>[\s\S]*data-sd-animate/;
 
 const INPUT_TAG_RE = /<input[^>]*>/;
@@ -132,12 +132,14 @@ describe("animate plugin", () => {
 
     it("should not animate text inside pre elements", async () => {
       const result = await processHtml("<pre>some code</pre>");
-      expect(result).not.toContain("data-sd-animate");
+      expect(result).toContain("data-sd-animate");
+      expect(result).not.toContain("<span");
     });
 
     it("should not animate text inside pre > code (fenced blocks)", async () => {
       const result = await processHtml("<pre><code>const x = 1</code></pre>");
-      expect(result).not.toContain("data-sd-animate");
+      expect(result).toContain("data-sd-animate");
+      expect(result).not.toContain("<span");
       expect(result).toContain("const x = 1");
     });
 
@@ -787,5 +789,54 @@ describe("animate plugin", () => {
       const hr = result.match(HR_TAG_RE)?.[0] ?? "";
       expect(hr).toContain("--sd-duration:0ms");
     });
+  });
+});
+
+describe("code fence animation", () => {
+  it("reserves one timeline slot without changing highlighted code", async () => {
+    const plugin = createAnimatePlugin({ duration: 250, stagger: 10 });
+    const code = '<code><span class="token">const x = 1</span>\n</code>';
+    const result = await processHtml(
+      `<h3>Code example</h3><pre>${code}</pre><p>Following</p>`,
+      plugin
+    );
+    expect(delaysOf(result)).toEqual([10, 20, 30]);
+    expect(result).toContain(code);
+    expect(result.match(/data-sd-animate(?: |>|=)/g)).toHaveLength(4);
+  });
+
+  it("keeps code and following text timings when the fence grows", async () => {
+    let now = 1000;
+    const timeline = createAnimateTimeline({ now: () => now });
+    const plugin = createAnimatePlugin({
+      duration: 250,
+      stagger: 10,
+      timeline,
+    });
+    timeline.beginPass(now);
+    const initial = await processHtml(
+      "<pre><code>one</code></pre><p>Following</p>",
+      plugin
+    );
+    plugin.commit();
+    timeline.commitPass();
+    now += 50;
+    timeline.beginPass(now);
+    const growing = await processHtml(
+      "<pre><code>one two three four</code></pre><p>Following new</p>",
+      plugin
+    );
+    expect(delaysOf(initial)).toEqual([0, 10]);
+    expect(delaysOf(growing)).toEqual([0, 10]);
+    expect(growing.match(/--sd-duration:250ms/g)).toHaveLength(3);
+    plugin.commit();
+    timeline.commitPass();
+    now += 500;
+    timeline.beginPass(now);
+    const settled = await processHtml(
+      "<pre><code>one two three four five</code></pre><p>Following new</p>",
+      plugin
+    );
+    expect(settled.match(/--sd-duration:0ms/g)).toHaveLength(3);
   });
 });

--- a/packages/streamdown/__tests__/animation-drain.test.tsx
+++ b/packages/streamdown/__tests__/animation-drain.test.tsx
@@ -1,0 +1,101 @@
+import { act, render } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it } from "vitest";
+import { Streamdown } from "../index";
+
+function pendingAnimation() {
+  let finish: () => void = () => undefined;
+  const finished = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  return {
+    animation: {
+      animationName: "sd-fadeIn",
+      playState: "running",
+      effect: { getComputedTiming: () => ({ endTime: 500 }) },
+      finished,
+    },
+    finish,
+  };
+}
+
+function message(text: string, streaming: boolean) {
+  return (
+    <StrictMode>
+      <Streamdown animated={{ duration: 250 }} isAnimating={streaming}>
+        {text}
+      </Streamdown>
+    </StrictMode>
+  );
+}
+
+describe("animation drain", () => {
+  it("retains pending words after streaming ends and cleans up after every animation finishes", async () => {
+    const first = pendingAnimation();
+    const last = pendingAnimation();
+    const { container, rerender } = render(message("Alpha beta", true));
+    Object.defineProperty(container.firstElementChild, "getAnimations", {
+      value: () => [first.animation, last.animation],
+    });
+    const word = container.querySelector("[data-sd-animate]");
+    await act(() => rerender(message("Alpha beta gamma", false)));
+    expect(container.querySelector("[data-sd-animate]")).toBe(word);
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(3);
+
+    await act(async () => first.finish());
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(3);
+    await act(async () => last.finish());
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(0);
+    expect(container.textContent).toBe("Alpha beta gamma");
+  });
+
+  it("does not let completion of an earlier drain tear down a resumed stream", async () => {
+    const previous = pendingAnimation();
+    const current = pendingAnimation();
+    let animations = [previous.animation];
+    const { container, rerender } = render(message("Alpha", true));
+    Object.defineProperty(container.firstElementChild, "getAnimations", {
+      value: () => animations,
+    });
+    await act(() => rerender(message("Alpha", false)));
+    await act(() => rerender(message("Alpha beta", true)));
+    await act(async () => previous.finish());
+    animations = [current.animation];
+    await act(() => rerender(message("Alpha beta gamma", false)));
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(3);
+    await act(async () => current.finish());
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(0);
+  });
+
+  it("resamples animations when the final content changes during a drain", async () => {
+    const previous = pendingAnimation();
+    const current = pendingAnimation();
+    let animations = [previous.animation];
+    const { container, rerender } = render(message("Alpha", true));
+    Object.defineProperty(container.firstElementChild, "getAnimations", {
+      value: () => animations,
+    });
+    await act(() => rerender(message("Alpha", false)));
+    animations = [previous.animation, current.animation];
+    await act(() => rerender(message("Alpha beta", false)));
+    await act(async () => previous.finish());
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(2);
+    await act(async () => current.finish());
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(0);
+  });
+
+  it("does not wait for unrelated or infinite animations", async () => {
+    const unrelated = pendingAnimation();
+    unrelated.animation.animationName = "spinner";
+    const infinite = pendingAnimation();
+    infinite.animation.effect.getComputedTiming = () => ({
+      endTime: Number.POSITIVE_INFINITY,
+    });
+    const { container, rerender } = render(message("Alpha", true));
+    Object.defineProperty(container.firstElementChild, "getAnimations", {
+      value: () => [unrelated.animation, infinite.animation],
+    });
+    await act(() => rerender(message("Alpha", false)));
+    expect(container.querySelectorAll("[data-sd-animate]")).toHaveLength(0);
+  });
+});

--- a/packages/streamdown/__tests__/animation-layout-whitespace.test.tsx
+++ b/packages/streamdown/__tests__/animation-layout-whitespace.test.tsx
@@ -1,0 +1,79 @@
+import { act, render } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Streamdown } from "../index";
+
+afterEach(() => vi.restoreAllMocks());
+
+const prefixes = [
+  ["paragraph", "But in ourselves, that we"],
+  ["tight list", "1. First\n2. But in ourselves, that we"],
+  ["loose ordered list", "1. First\n\n2. But in ourselves, that we"],
+  ["loose unordered list", "- First\n\n- But in ourselves, that we"],
+  ["italic list item", "1. First\n\n2. *But in ourselves, that we"],
+  ["nested list", "- First\n\n  - But in ourselves, that we"],
+  ["quoted list", "> 1. First\n>\n> 2. But in ourselves, that we"],
+];
+
+describe.each(["word", "char"] as const)("layout whitespace (%s)", (sep) => {
+  it.each(prefixes)("fades every arriving unit in a %s", async (_, prefix) => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(1000);
+    const config = { duration: 250, stagger: 10, sep };
+    const message = (text: string) => (
+      <StrictMode>
+        <Streamdown animated={config} isAnimating>
+          {text}
+        </Streamdown>
+      </StrictMode>
+    );
+    const { container, rerender } = render(message(prefix));
+    const read = () => [
+      ...container.querySelectorAll<HTMLElement>("[data-sd-animate]"),
+    ];
+    const previous = read();
+    const styles = previous.map((word) => word.getAttribute("style"));
+    clock.mockReturnValue(1050);
+    await act(() => rerender(message(`${prefix} are underlings.`)));
+    const updated = read();
+    for (const [index, word] of previous.entries()) {
+      expect(updated[index]).toBe(word);
+      expect(word.getAttribute("style")).toBe(styles[index]);
+    }
+    const arrived = updated.slice(previous.length);
+    expect(arrived.map((word) => word.textContent).join("")).toBe(
+      "are underlings."
+    );
+    for (const word of arrived) {
+      expect(word.style.getPropertyValue("--sd-duration")).toBe("250ms");
+    }
+    const delays = arrived.map((word) =>
+      Number.parseFloat(word.style.getPropertyValue("--sd-delay") || "0")
+    );
+    for (let index = 1; index < delays.length; index++) {
+      expect(delays[index]).toBeGreaterThan(delays[index - 1]);
+    }
+  });
+});
+
+it("preserves source whitespace between inline elements in the animation offsets", async () => {
+  const clock = vi.spyOn(performance, "now").mockReturnValue(1000);
+  const config = { duration: 250, stagger: 10 };
+  const message = (text: string) => (
+    <Streamdown animated={config} isAnimating>
+      {text}
+    </Streamdown>
+  );
+  const { container, rerender } = render(message("1. First\n\n2. *One* "));
+  clock.mockReturnValue(1050);
+  await act(() => rerender(message("1. First\n\n2. *One* **two** three")));
+  const words = [
+    ...container.querySelectorAll<HTMLElement>("[data-sd-animate]"),
+  ];
+  expect(words.slice(-2).map((word) => word.textContent)).toEqual([
+    "two",
+    "three",
+  ]);
+  for (const word of words.slice(-2)) {
+    expect(word.style.getPropertyValue("--sd-duration")).toBe("250ms");
+  }
+});

--- a/packages/streamdown/__tests__/animation-lifetime.test.tsx
+++ b/packages/streamdown/__tests__/animation-lifetime.test.tsx
@@ -1,0 +1,110 @@
+import { act, render } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Streamdown } from "../index";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("animation history after clearing content", () => {
+  it.each([
+    50, 1000,
+  ])("animates the first batch again after clearing at %i ms", async (elapsed) => {
+    let now = 1000;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    const message = (text: string) => (
+      <StrictMode>
+        <Streamdown animated={{ duration: 250, stagger: 40 }} isAnimating>
+          {text}
+        </Streamdown>
+      </StrictMode>
+    );
+    const batch = "Alpha beta gamma delta epsilon zeta eta theta";
+    const { container, rerender } = render(message(batch));
+    now += elapsed;
+    await act(() => rerender(message("")));
+    await act(() => rerender(message(batch)));
+    const words = [
+      ...container.querySelectorAll<HTMLElement>("[data-sd-animate]"),
+    ];
+    expect(words).toHaveLength(8);
+    for (const [index, word] of words.entries()) {
+      expect(word.style.getPropertyValue("--sd-duration")).toBe("250ms");
+      expect(word.style.getPropertyValue("--sd-delay") || "0ms").toBe(
+        `${index * 40}ms`
+      );
+    }
+  });
+});
+
+describe.each([
+  false,
+  true,
+])("animation lifetime (StrictMode: %s)", (strict) => {
+  it("preserves pending and active fades across fast updates, then settles them", async () => {
+    let now = 1000;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    const config = { duration: 250, stagger: 100 };
+    const message = (text: string) => {
+      const content = (
+        <Streamdown animated={config} isAnimating>
+          {text}
+        </Streamdown>
+      );
+      return strict ? <StrictMode>{content}</StrictMode> : content;
+    };
+    const { container, rerender } = render(message("One two three"));
+    const words = [
+      ...container.querySelectorAll<HTMLElement>("[data-sd-animate]"),
+    ];
+    const styles = words.map((word) => word.getAttribute("style"));
+    expect(words).toHaveLength(3);
+
+    now += 50;
+    await act(() => rerender(message("One two three four")));
+    const updated = [
+      ...container.querySelectorAll<HTMLElement>("[data-sd-animate]"),
+    ];
+    for (const [index, word] of words.entries()) {
+      expect(updated[index]).toBe(word);
+      expect(word.getAttribute("style")).toBe(styles[index]);
+    }
+
+    now += 50;
+    await act(() => rerender(message("One two three four five")));
+    for (const [index, word] of words.entries()) {
+      expect(word.getAttribute("style")).toBe(styles[index]);
+    }
+
+    now = 1600;
+    await act(() => rerender(message("One two three four five six")));
+    for (const word of words) {
+      expect(word.style.getPropertyValue("--sd-duration")).toBe("0ms");
+    }
+    const last = container.querySelector<HTMLElement>(
+      "[data-sd-animate]:last-child"
+    );
+    expect(last?.textContent?.trim()).toBe("six");
+    expect(last?.style.getPropertyValue("--sd-duration")).toBe("250ms");
+  });
+
+  it("keeps a partial word's fade while tokens extend that word", async () => {
+    let now = 1000;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    const message = (text: string) => {
+      const content = (
+        <Streamdown animated={{ duration: 250 }} isAnimating>
+          {text}
+        </Streamdown>
+      );
+      return strict ? <StrictMode>{content}</StrictMode> : content;
+    };
+    const { container, rerender } = render(message("Hel"));
+    const word = container.querySelector<HTMLElement>("[data-sd-animate]");
+    const style = word?.getAttribute("style");
+    now += 50;
+    await act(() => rerender(message("Hello")));
+    expect(container.querySelector("[data-sd-animate]")).toBe(word);
+    expect(word?.textContent).toBe("Hello");
+    expect(word?.getAttribute("style")).toBe(style);
+  });
+});

--- a/packages/streamdown/__tests__/list-animation-retrigger.test.tsx
+++ b/packages/streamdown/__tests__/list-animation-retrigger.test.tsx
@@ -8,7 +8,7 @@
  * re-run their CSS entry animation.
  *
  * Fix: the animate plugin tracks prevContentLength and sets --sd-duration:0ms for
- * text-node positions that were already rendered in the previous pass, so
+ * text-node positions whose previous animation has finished, so
  * already-visible characters do not re-run their entry animation even when the
  * spans around them are rebuilt.
  *
@@ -20,7 +20,7 @@
  */
 
 import { act, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Streamdown } from "../index";
 
 const animatedConfig = {
@@ -30,8 +30,11 @@ const animatedConfig = {
   sep: "char" as const,
 };
 
+afterEach(() => vi.restoreAllMocks());
+
 describe("list animation retrigger fix (#410)", () => {
-  it("does not remount spans for existing list items when a new item appears", async () => {
+  it("does not re-animate settled list items when a new item appears", async () => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(1000);
     const { rerender, container } = render(
       <Streamdown animated={animatedConfig} isAnimating={true}>
         {"1. Item 1\n2. Item 2\n"}
@@ -50,6 +53,7 @@ describe("list animation retrigger fix (#410)", () => {
     });
 
     // Simulate a new list group appearing (triggers tight→loose transition)
+    clock.mockReturnValue(3000);
     await act(() => {
       rerender(
         <Streamdown animated={animatedConfig} isAnimating={true}>
@@ -94,7 +98,8 @@ describe("list animation retrigger fix (#410)", () => {
     }
   });
 
-  it("sets --sd-duration:0ms on already-rendered content when item text grows", async () => {
+  it("sets --sd-duration:0ms on settled content when item text grows", async () => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(1000);
     // When a list item's text grows during streaming, its node position
     // changes (end column extends). This causes the memo'd MemoLi to
     // re-render, and the animate plugin applies 0ms to already-visible chars.
@@ -117,6 +122,7 @@ describe("list animation retrigger fix (#410)", () => {
 
     // Streaming update: item text grows from "AB" to "AB CD"
     // This changes the li node position → MemoLi re-renders
+    clock.mockReturnValue(3000);
     await act(() => {
       rerender(
         <Streamdown animated={animatedConfig} isAnimating={true}>

--- a/packages/streamdown/__tests__/list-animation-retrigger.test.tsx
+++ b/packages/streamdown/__tests__/list-animation-retrigger.test.tsx
@@ -75,13 +75,7 @@ describe("list animation retrigger fix (#410)", () => {
     // its entry animation: those characters carry --sd-duration:0ms.
     expect(container.querySelector("li > p")).toBeTruthy();
 
-    // One character at the transition boundary is not suppressed:
-    // prevContentLength counts inter-element whitespace, and the tight -> loose
-    // change alters how much of it the block contains, so the boundary lands one
-    // character early. That accounting lives in lib/animate.ts and is unchanged
-    // here; before this test was updated the transition was never rendered at
-    // all, so it could not be observed.
-    const previouslyVisible = afterSpans.slice(0, initialSpans.length - 1);
+    const previouslyVisible = afterSpans.slice(0, initialSpans.length);
     for (const span of previouslyVisible) {
       expect(
         (span as HTMLElement).style.getPropertyValue("--sd-duration")

--- a/packages/streamdown/__tests__/void-element-animation.test.tsx
+++ b/packages/streamdown/__tests__/void-element-animation.test.tsx
@@ -65,3 +65,25 @@ describe("void element animation (React render)", () => {
     expect(hr?.getAttribute("style") ?? "").toContain("--sd-animation");
   });
 });
+
+it("keeps the animated code wrapper when a streamed fence grows", async () => {
+  const prefix = "### Code example\n\n```js\nconst x = 1";
+  const { container, rerender } = await renderAnimated(prefix);
+  const code = container.querySelector('[data-streamdown="code-block"]');
+  const wrapper = code?.closest("[data-sd-animate]");
+  expect(wrapper).not.toBeNull();
+  const style = wrapper?.getAttribute("style");
+  expect(style).toContain("--sd-duration: 500ms");
+  expect(code?.querySelector("[data-sd-animate]")).toBeNull();
+
+  rerender(
+    <Streamdown animated={animated} isAnimating={true}>
+      {`${prefix}\nconst y = 2\n\`\`\``}
+    </Streamdown>
+  );
+  await act(() => Promise.resolve());
+  expect(container.querySelector('[data-streamdown="code-block"]')).toBe(code);
+  expect(code?.closest("[data-sd-animate]")).toBe(wrapper);
+  expect(wrapper?.getAttribute("style")).toBe(style);
+  expect(code?.textContent).toContain("const y = 2");
+});

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -50,6 +50,7 @@ import {
   type StreamdownTranslations,
   TranslationsContext,
 } from "./lib/translations-context";
+import { useAnimationDrain } from "./lib/use-animation-drain";
 import { createCn } from "./lib/utils";
 
 export type { AnimateOptions } from "./lib/animate";
@@ -393,8 +394,8 @@ export const Block = memo(
     animatePlugin: animatePluginProp,
     ...props
   }: BlockProps) => {
-    // After rehype paints, commit the new char count so the *next* render
-    // treats already-visible text as settled. Commit lives outside the render
+    // After rehype paints, commit the char count and pending animation timings
+    // so the next render preserves their schedule. Commit lives outside the render
     // body so StrictMode double-invoke cannot wipe and re-seed prevContentLength
     // (#570 secondary). The plugin seeds prevContentLength from its own
     // committedCharCount at the start of every rehype run.
@@ -646,6 +647,9 @@ export const Streamdown = memo(
       return "";
     }, [animated]);
 
+    const { containerRef: animationContainerRef, animateText } =
+      useAnimationDrain(isAnimating, animatedKey, mode, children);
+
     // Shared wall-clock timeline: serializes stagger delays across sibling
     // blocks AND across streaming ticks (memoized earlier blocks don't
     // re-render, so a pure render-order counter would miss them). Fixes #482.
@@ -676,7 +680,7 @@ export const Streamdown = memo(
       // Reset the per-pass cursor from the last *committed* horizon so a
       // StrictMode double-render recomputes the same delays instead of
       // stacking (#482 + StrictMode).
-      if (isAnimating && animateTimelineRef.current) {
+      if (animateText && animateTimelineRef.current) {
         animateTimelineRef.current.beginPass(animateTimelineRef.current.now());
       }
     } else {
@@ -690,7 +694,22 @@ export const Streamdown = memo(
     // renders that called beginPass never reach this effect, so they can't
     // poison nextStartAt.
     useLayoutEffect(() => {
-      if (isAnimating) {
+      // Removed blocks have no DOM animations to preserve. Keeping their
+      // history makes a replay's first words look already settled.
+      blockAnimatePluginsRef.current.length = Math.min(
+        blockAnimatePluginsRef.current.length,
+        blocksToRender.length
+      );
+      blockRehypePluginsRef.current.length = Math.min(
+        blockRehypePluginsRef.current.length,
+        blocksToRender.length
+      );
+      if (blocksToRender.length === 0) {
+        animateTimelineRef.current = null;
+        prevAnimatedKeyRef.current = "";
+        return;
+      }
+      if (animateText) {
         animateTimelineRef.current?.commitPass();
       }
     });
@@ -860,7 +879,7 @@ export const Streamdown = memo(
       blockRehypePlugins: Pluggable[];
     } => {
       let blockAnimatePlugin: AnimatePlugin | null = null;
-      if (animateTimelineRef.current && isAnimating) {
+      if (animateTimelineRef.current && animateText) {
         if (!blockAnimatePluginsRef.current[index]) {
           // maxBacklogMs is consumed by the timeline factory, not the plugin.
           const rawOpts =
@@ -945,6 +964,7 @@ export const Streamdown = memo(
                       : null,
                     className
                   )}
+                  ref={animationContainerRef}
                   style={style}
                 >
                   {blocksToRender.length === 0 && caret && isAnimating && (

--- a/packages/streamdown/lib/animate.ts
+++ b/packages/streamdown/lib/animate.ts
@@ -467,6 +467,12 @@ const animationTiming = (
   return { duration: config.duration, delay: timing.delay };
 };
 
+// remark-rehype pads block elements with positionless newlines. They are not
+// streamed content: trailing padding must not make the next word look old, and
+// adding <p> wrappers to a loose list must not shift existing animation offsets.
+const isLayoutWhitespace = (node: Text): boolean =>
+  !node.position && WHITESPACE_ONLY_RE.test(node.value);
+
 const isVoidAnimateElement = (node: Node): node is Element =>
   isElement(node) && VOID_ANIMATE_TAGS.has(node.tagName);
 
@@ -493,6 +499,9 @@ const countNewWords = (
           newWords += 1;
         }
         charPos += 1;
+        return;
+      }
+      if (isLayoutWhitespace(node as Text)) {
         return;
       }
       const text = (node as Text).value;
@@ -542,6 +551,9 @@ const processTextNode = (
     return;
   }
 
+  if (isLayoutWhitespace(node)) {
+    return;
+  }
   const text = node.value;
   if (!text.trim()) {
     charCounter.count += text.length;

--- a/packages/streamdown/lib/animate.ts
+++ b/packages/streamdown/lib/animate.ts
@@ -165,10 +165,9 @@ const WHITESPACE_ONLY_RE = /^\s+$/;
 // `pre` (CommonMark always emits `pre > code`); raw inline `code` is safe to
 // animate — word spans inherit styles the same way surrounding prose does (#594).
 const SKIP_TAGS = new Set(["pre", "svg", "math", "annotation"]);
-// Elements with no text node of their own that should still animate in. They
-// honor opacity/filter/transform, so they reuse the standard [data-sd-animate]
-// rule and work with every animation type.
-const VOID_ANIMATE_TAGS = new Set(["img", "hr"]);
+// Code fences reserve one slot without touching syntax-highlighting spans.
+// Like images and rules, the whole element follows the shared timeline.
+const ATOMIC_ANIMATE_TAGS = new Set(["img", "hr", "pre"]);
 
 const isElement = (node: unknown): node is Element =>
   typeof node === "object" &&
@@ -267,12 +266,9 @@ const stampCheckbox = (
   }
 };
 
-// Images and rules have no text node, so they're tagged directly. Their
-// "already shown" state is judged by document position (charCounter.count)
-// rather than character length, since they contribute no characters.
-// Advance count by 1 so a trailing void at the prevLen boundary is treated as
-// already-shown on the next tick (avoids one-frame re-animate).
-const processVoidElement = (
+// Atomic elements occupy one position regardless of their contents, so growing
+// a code fence cannot restart its fade or move the following text's offset.
+const processAtomicElement = (
   element: Element,
   ancestors: Node[],
   config: AnimateConfig,
@@ -473,11 +469,11 @@ const animationTiming = (
 const isLayoutWhitespace = (node: Text): boolean =>
   !node.position && WHITESPACE_ONLY_RE.test(node.value);
 
-const isVoidAnimateElement = (node: Node): node is Element =>
-  isElement(node) && VOID_ANIMATE_TAGS.has(node.tagName);
+const isAtomicAnimateElement = (node: Node): node is Element =>
+  isElement(node) && ATOMIC_ANIMATE_TAGS.has(node.tagName);
 
 /**
- * Count newly-animated units (mirrors processTextNode / processVoidElement
+ * Count newly-animated units (mirrors processTextNode / processAtomicElement
  * skip logic) so timeline.take reserves the right number of slots.
  */
 const countNewWords = (
@@ -489,12 +485,12 @@ const countNewWords = (
   let charPos = 0;
   visitParents(
     tree,
-    (node: Node) => node.type === "text" || isVoidAnimateElement(node),
+    (node: Node) => node.type === "text" || isAtomicAnimateElement(node),
     (node: Node, ancestors) => {
       if (hasSkipAncestor(ancestors)) {
         return SKIP;
       }
-      if (isVoidAnimateElement(node)) {
+      if (isAtomicAnimateElement(node)) {
         if (isNewAnimateUnit(prevLen, charPos)) {
           newWords += 1;
         }
@@ -667,7 +663,7 @@ export function createAnimatePlugin(
 
     visitParents(
       tree,
-      (node: Node) => node.type === "text" || isVoidAnimateElement(node),
+      (node: Node) => node.type === "text" || isAtomicAnimateElement(node),
       (node: Node, ancestors) => {
         if (node.type === "text") {
           return processTextNode(
@@ -679,7 +675,7 @@ export function createAnimatePlugin(
             schedule
           );
         }
-        processVoidElement(
+        processAtomicElement(
           node as Element,
           ancestors,
           config,

--- a/packages/streamdown/lib/animate.ts
+++ b/packages/streamdown/lib/animate.ts
@@ -129,7 +129,7 @@ export function createAnimateTimeline(
 export interface AnimatePlugin {
   /**
    * Commit the last rehype char count so the *next* rehype run treats that
-   * many characters as already-visible. Also clears the StrictMode rewind
+   * many characters as already-scheduled. Also clears the StrictMode rewind
    * mark so the next commit starts clean. Called from Block's useLayoutEffect.
    */
   commit: () => void;
@@ -283,14 +283,16 @@ const processVoidElement = (
   if (hasSkipAncestor(ancestors)) {
     return;
   }
-  const prevLen = renderState.prevContentLength;
   const partStart = charCounter.count;
   charCounter.count += 1;
-  const skipAnimation = prevLen > 0 && partStart < prevLen;
-  const delay = skipAnimation
-    ? 0
-    : schedule.baseDelay + charCounter.newIndex++ * schedule.step;
-  stampAnimation(element, config, skipAnimation ? 0 : config.duration, delay);
+  const timing = animationTiming(
+    partStart,
+    config,
+    renderState,
+    charCounter,
+    schedule
+  );
+  stampAnimation(element, config, timing.duration, timing.delay);
 };
 
 /**
@@ -387,10 +389,9 @@ const makeSpan = (
   animation: string,
   duration: number,
   easing: string,
-  skipAnimation?: boolean,
   delay?: number
 ): Element => {
-  let style = `--sd-animation:sd-${animation};--sd-duration:${skipAnimation ? 0 : duration}ms;--sd-easing:${easing}`;
+  let style = `--sd-animation:sd-${animation};--sd-duration:${duration}ms;--sd-easing:${easing}`;
   if (delay) {
     style += `;--sd-delay:${Math.round(delay)}ms`;
   }
@@ -414,9 +415,17 @@ interface AnimateConfig {
   timeline?: AnimateTimeline;
 }
 
+interface AnimationTiming {
+  delay: number;
+  endsAt: number;
+}
+
 interface AnimateRenderState {
+  committedAnimations: Map<number, AnimationTiming>;
   committedCharCount: number;
   lastRenderCharCount: number;
+  now: number;
+  pendingAnimations: Map<number, AnimationTiming>;
   /**
    * Timeline cursor snapshot from the first rehype run of the current commit.
    * null → not yet run this commit; number → rewind here on re-entry
@@ -433,6 +442,30 @@ interface Schedule {
 
 const isNewAnimateUnit = (prevLen: number, partStart: number): boolean =>
   !(prevLen > 0 && partStart < prevLen);
+
+const animationTiming = (
+  partStart: number,
+  config: AnimateConfig,
+  state: AnimateRenderState,
+  counter: { newIndex: number },
+  schedule: Schedule
+): { duration: number; delay: number } => {
+  let timing = state.committedAnimations.get(partStart);
+  if (isNewAnimateUnit(state.prevContentLength, partStart)) {
+    const delay = Math.round(
+      schedule.baseDelay + counter.newIndex++ * schedule.step
+    );
+    timing = { delay, endsAt: state.now + delay + config.duration };
+  }
+  if (!timing || timing.endsAt <= state.now) {
+    return { duration: 0, delay: 0 };
+  }
+  // Keep the original CSS timing on retained DOM nodes. Replacing it with
+  // duration:0 before the fade ends jumps to its final keyframe; subtracting
+  // elapsed time from the delay would advance an already-running animation.
+  state.pendingAnimations.set(partStart, timing);
+  return { duration: config.duration, delay: timing.delay };
+};
 
 const isVoidAnimateElement = (node: Node): node is Element =>
   isElement(node) && VOID_ANIMATE_TAGS.has(node.tagName);
@@ -516,7 +549,6 @@ const processTextNode = (
   }
 
   const parts = config.sep === "char" ? splitByChar(text) : splitByWord(text);
-  const prevLen = renderState.prevContentLength;
   let didAnimate = false;
 
   // Fade the list marker in with this item's first animated word. Only the
@@ -533,24 +565,25 @@ const processTextNode = (
     if (WHITESPACE_ONLY_RE.test(part)) {
       return { type: "text", value: part } as Text;
     }
-    const skipAnimation = prevLen > 0 && partStart < prevLen;
-    const delay = skipAnimation
-      ? 0
-      : schedule.baseDelay + charCounter.newIndex++ * schedule.step;
+    const timing = animationTiming(
+      partStart,
+      config,
+      renderState,
+      charCounter,
+      schedule
+    );
     didAnimate = true;
     if (liAncestor && needsMarker && !markerStamped) {
-      const itemDuration = skipAnimation ? 0 : config.duration;
-      stampMarker(liAncestor, itemDuration, delay, config.easing);
-      stampCheckbox(liAncestor, config, itemDuration, delay);
+      stampMarker(liAncestor, timing.duration, timing.delay, config.easing);
+      stampCheckbox(liAncestor, config, timing.duration, timing.delay);
       markerStamped = true;
     }
     return makeSpan(
       part,
       config.animation,
-      config.duration,
+      timing.duration,
       config.easing,
-      skipAnimation,
-      delay
+      timing.delay
     );
   });
 
@@ -581,21 +614,26 @@ export function createAnimatePlugin(
   };
 
   const renderState: AnimateRenderState = {
+    committedAnimations: new Map(),
     committedCharCount: 0,
     prevContentLength: 0,
     lastRenderCharCount: 0,
     pendingMark: null,
+    now: 0,
+    pendingAnimations: new Map(),
   };
 
   const id = instanceId++;
   const rehypeAnimate = () => (tree: Root) => {
     const charCounter = { count: 0, newIndex: 0 };
 
-    // Seed skip-window from the last committed paint (#570 secondary).
+    // Seed the scheduled prefix from the last committed paint (#570 secondary).
     renderState.prevContentLength = renderState.committedCharCount;
+    renderState.pendingAnimations = new Map();
 
     const timeline = config.timeline;
     const now = timeline?.now() ?? defaultNow();
+    renderState.now = now;
 
     // StrictMode / discarded render: first run marks the cursor; a re-run
     // rewinds so take() doesn't stack on itself. commit() clears the mark.
@@ -654,12 +692,14 @@ export function createAnimatePlugin(
     setPrevContentLength(length: number) {
       renderState.committedCharCount = length;
       renderState.prevContentLength = length;
+      renderState.committedAnimations.clear();
     },
     getLastRenderCharCount() {
       return renderState.lastRenderCharCount;
     },
     commit() {
       renderState.committedCharCount = renderState.lastRenderCharCount;
+      renderState.committedAnimations = renderState.pendingAnimations;
       renderState.pendingMark = null;
     },
   };

--- a/packages/streamdown/lib/animate.ts
+++ b/packages/streamdown/lib/animate.ts
@@ -46,6 +46,7 @@ export interface AnimateTimeline {
   /** Snapshot of the working cursor (passNextStartAt). */
   mark: () => number;
   now: () => number;
+  passNow: () => number;
   /** Restore the working cursor to a prior mark. */
   rewind: (mark: number) => void;
   take: (wordCount: number, stagger: number, now: number) => ScheduleSlot;
@@ -69,10 +70,13 @@ export function createAnimateTimeline(
   let committedNextStartAt = 0;
   /** Working absolute time for the in-flight pass. */
   let passNextStartAt = 0;
+  let passStartedAt = nowFn();
 
   return {
     now: nowFn,
+    passNow: () => passStartedAt,
     beginPass(now: number) {
+      passStartedAt = now;
       // Resume from the last commit, but never more than maxBacklog ahead of
       // wall-clock — drops debt from a previous pass that overshot via the
       // min-step floor so a fast stream stays caught up on the next tick.
@@ -640,7 +644,8 @@ export function createAnimatePlugin(
     renderState.pendingAnimations = new Map();
 
     const timeline = config.timeline;
-    const now = timeline?.now() ?? defaultNow();
+    // All blocks paint in the same commit, so their CSS delays share an origin.
+    const now = timeline?.passNow() ?? defaultNow();
     renderState.now = now;
 
     // StrictMode / discarded render: first run marks the cursor; a re-run

--- a/packages/streamdown/lib/components.tsx
+++ b/packages/streamdown/lib/components.tsx
@@ -1112,12 +1112,13 @@ export const components: Options["components"] = {
   blockquote: MemoBlockquote,
   code: MemoCode,
   img: MemoImg,
-  pre: ({ children }) => {
-    if (isValidElement(children)) {
-      return cloneElement(children, { "data-block": "true" });
-    }
-    return children;
-  },
+  pre: ({ children, node: _node, ...props }) => (
+    <div {...props}>
+      {isValidElement(children)
+        ? cloneElement(children, { "data-block": "true" })
+        : children}
+    </div>
+  ),
   sup: MemoSup,
   sub: MemoSub,
   p: MemoParagraph,

--- a/packages/streamdown/lib/use-animation-drain.ts
+++ b/packages/streamdown/lib/use-animation-drain.ts
@@ -1,0 +1,51 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+export function useAnimationDrain(
+  isAnimating: boolean,
+  animatedKey: string,
+  mode: "streaming" | "static",
+  content: unknown
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [retained, setRetained] = useState(false);
+  const enabled = Boolean(animatedKey) && mode !== "static";
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: New content or animation settings can replace the DOM animations being drained.
+  useLayoutEffect(() => {
+    if (!enabled || isAnimating) {
+      setRetained(enabled && isAnimating);
+      return;
+    }
+
+    // Read the browser's actual animations after the final chunk commits:
+    // a fixed grace period can truncate staggered words or delay reduced motion.
+    const pending = (
+      containerRef.current?.getAnimations?.({ subtree: true }) ?? []
+    ).filter(
+      (animation) =>
+        "animationName" in animation &&
+        String(animation.animationName).startsWith("sd-") &&
+        animation.playState !== "finished" &&
+        animation.playState !== "idle" &&
+        Number.isFinite(animation.effect?.getComputedTiming().endTime)
+    );
+    if (pending.length === 0) {
+      setRetained(false);
+      return;
+    }
+
+    let cancelled = false;
+    Promise.allSettled(pending.map((animation) => animation.finished)).then(
+      () => {
+        if (!cancelled) {
+          setRetained(false);
+        }
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [isAnimating, enabled, animatedKey, content]);
+
+  return { containerRef, animateText: enabled && (isAnimating || retained) };
+}


### PR DESCRIPTION
## Description

Streaming updates can truncate active fades, completion can reveal pending text instantly, replay can skip opening animations, generated list whitespace can make new words appear already displayed, and code blocks can appear ahead of the text before them. Preserve animation history and use the shared animation timeline for text and code.

## Type of Change

- [x] Bug fix

## Changes Made

- Preserve each pending or active fade's original timing across updates, including list markers, checkboxes, images and rules.
- Let finite Streamdown CSS animations finish after streaming stops, then remove animation attributes/wrappers. Cleanup uses `Animation.finished`, handles cancellation, and is invalidated when streaming resumes or the final content changes.
- Discard removed blocks' history and reset the timeline when content is cleared, so replay animates its opening words.
- Exclude positionless parser-generated layout whitespace from both animation counting passes. Source whitespace still counts; loose-list and tight-to-loose transitions preserve offsets.
- Animate fenced code as one unit on the shared timeline. Its entry fade follows preceding words without inserting spans into syntax-highlighted content. A stable wrapper preserves the fade while code and highlighting update and while final animations drain. All blocks share one render-pass clock, so parsing time cannot let a later block overtake earlier text.

Animation defaults and the public API are unchanged. Code uses the configured duration and timeline; it does not get per-token syntax animations. Existing callbacks retain their streaming-state semantics.

## Testing

- Streamdown: **1,206 passing tests**, including plugin-level code scheduling and a React regression for the persistent code wrapper.
- `pnpm check` passes.
- The patched 2.6.0 distribution builds successfully and passes **111 consumer Markdown/message-bubble tests**.
- **14 consumer browser checks** pass across Chromium and WebKit: pending/active fades, completion/replay, list offsets, asynchronous plugin updates, and code entry ordering, growth and completion. The browser fixture uses real CSS animations and the actual installed component.
- Full-response playback also verified in both engines, with cold and cached maths loading.

The existing package/website build and six-package test validation from the earlier commits remains described in the linked history. The optional `apps/test` production build requires an AI Gateway credential; it was not used as a gate.

## Screenshots/Demos

[Original before/after animation recording](https://github.com/rogersnm/streamdown/blob/demo/animation-lifetime/comparison.mp4) · [Quarter-speed recording](https://github.com/rogersnm/streamdown/blob/demo/animation-lifetime/comparison-slow.mp4)

The original recording covers the update/completion/replay fixes; it predates the list-offset and code-entry additions. Its 50 ms updates, 250 ms fades and 10 ms stagger are comparison settings, not changed defaults.

List reproduction: render `1. First\n\n2. *But in ourselves, that we`, then append ` are underlings.`. Previously “are” could receive a zero-duration fade while adjacent words remained mid-animation.

Code reproduction: deliver a heading and fenced code in the same update with staggered animation enabled. Previously the code bypassed the timeline; now its wrapper receives one slot after the heading and keeps the same fade when the fence grows.

The consumer's separate fix for changing its React key when its maths plugin loads is application-side and is not included here.

## Checklist

- [x] Followed project code style.
- [x] Added and updated regression tests.
- [x] Updated the patch changeset.
